### PR TITLE
Route table-like authorization through authorize(state, request)

### DIFF
--- a/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
+++ b/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.polaris.core.auth.AuthorizationDecision;
+import org.apache.polaris.core.auth.AuthorizationIntent;
+import org.apache.polaris.core.auth.AuthorizationIntentResolver;
 import org.apache.polaris.core.auth.AuthorizationPreConditions;
 import org.apache.polaris.core.auth.AuthorizationRequest;
 import org.apache.polaris.core.auth.AuthorizationState;
@@ -34,6 +36,7 @@ import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
+import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
 import org.apache.polaris.extension.auth.ranger.utils.RangerUtils;
 import org.apache.ranger.authz.api.RangerAuthzException;
 import org.apache.ranger.authz.embedded.RangerEmbeddedAuthorizer;
@@ -90,7 +93,32 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
   @Override
   public @NonNull AuthorizationDecision authorize(
       @NonNull AuthorizationState authzState, @NonNull AuthorizationRequest request) {
-    throw new UnsupportedOperationException("authorize is not implemented yet");
+    PolarisResolutionManifest resolutionManifest = authzState.getResolutionManifest();
+    Set<PolarisBaseEntity> activatedEntities =
+        resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles();
+    for (AuthorizationIntent intent : request.intents()) {
+      AuthorizationIntentResolver.ResolvedIntent resolvedIntent =
+          AuthorizationIntentResolver.resolve(resolutionManifest, intent);
+      try {
+        // Reuse the existing resolved-path authorization logic (Ranger policy evaluation,
+        // credential-rotation precondition, semantics lookup) by driving it with the targets
+        // resolved from the request intent, then translate its ForbiddenException into a decision.
+        authorizeOrThrow(
+            request.principal(),
+            activatedEntities,
+            intent.getOperation(),
+            resolvedIntent.targets(),
+            resolvedIntent.secondaries());
+      } catch (ForbiddenException e) {
+        LOG.debug(
+            "Authorization denied for principal {} intent {}",
+            request.principal().getName(),
+            intent,
+            e);
+        return AuthorizationDecision.deny(e.getMessage());
+      }
+    }
+    return AuthorizationDecision.allow();
   }
 
   @Override

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthorizationIntentResolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthorizationIntentResolver.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.auth;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import org.apache.polaris.core.auth.RbacOperationSemantics.ResolvedPathRooting;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
+import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
+import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Resolves an {@link AuthorizationIntent}'s securable references into the {@link
+ * PolarisResolvedPathWrapper} targets and secondaries required by the resolved-path authorization
+ * APIs.
+ *
+ * <p>This lives in the {@code org.apache.polaris.core.auth} package so it can consult the
+ * package-private {@link RbacOperationSemantics} to decide whether a given operation roots its
+ * target path at the root container. It is shared by {@link PolarisAuthorizerImpl} and by pluggable
+ * authorizer extensions (such as the Apache Ranger authorizer) so that every authorizer resolves
+ * the securables of the decision-native {@code authorize(state, request)} path identically.
+ */
+public final class AuthorizationIntentResolver {
+
+  private AuthorizationIntentResolver() {}
+
+  /**
+   * The resolved target and secondary paths for a single {@link AuthorizationIntent}. Either list
+   * may be {@code null} when the intent has no target/secondary to resolve.
+   */
+  public record ResolvedIntent(
+      @Nullable List<PolarisResolvedPathWrapper> targets,
+      @Nullable List<PolarisResolvedPathWrapper> secondaries) {}
+
+  /**
+   * Resolves the securable references carried by {@code intent} against {@code resolutionManifest}
+   * into the target and secondary resolved paths expected by the resolved-path authorization APIs.
+   *
+   * @param resolutionManifest the populated resolution manifest for the current authorization flow
+   * @param intent the authorization intent whose securables should be resolved
+   * @return the resolved targets and secondaries for the intent
+   */
+  public static ResolvedIntent resolve(
+      PolarisResolutionManifest resolutionManifest, AuthorizationIntent intent) {
+    RbacOperationSemantics semantics = RbacOperationSemantics.forOperation(intent.getOperation());
+    boolean prependRootContainer = semantics.rooting() == ResolvedPathRooting.ROOT;
+
+    List<PolarisResolvedPathWrapper> resolvedTargets;
+    List<PolarisResolvedPathWrapper> resolvedSecondaries;
+    if (intent instanceof TargetlessAuthorizationIntent) {
+      resolvedTargets =
+          prependRootContainer
+              ? List.of(resolutionManifest.getResolvedRootContainerEntityAsPath())
+              : null;
+      resolvedSecondaries = null;
+    } else if (intent instanceof SingleTargetAuthorizationIntent singleTargetIntent) {
+      resolvedTargets =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, singleTargetIntent.target(), prependRootContainer));
+      resolvedSecondaries = null;
+    } else if (intent instanceof RenameAuthorizationIntent renameIntent) {
+      resolvedTargets =
+          List.of(
+              getResolvedSecurable(resolutionManifest, renameIntent.from(), prependRootContainer));
+      resolvedSecondaries =
+          List.of(
+              getResolvedSecurable(resolutionManifest, renameIntent.to(), prependRootContainer));
+    } else if (intent instanceof PolicyAttachmentAuthorizationIntent policyAttachmentIntent) {
+      resolvedTargets =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, policyAttachmentIntent.policy(), prependRootContainer));
+      resolvedSecondaries =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, policyAttachmentIntent.attachedTo(), prependRootContainer));
+    } else if (intent instanceof RoleAssignmentAuthorizationIntent roleAssignmentIntent) {
+      resolvedTargets =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, roleAssignmentIntent.role(), prependRootContainer));
+      resolvedSecondaries =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, roleAssignmentIntent.assignee(), prependRootContainer));
+    } else if (intent instanceof PrivilegeGrantAuthorizationIntent privilegeGrantIntent) {
+      resolvedTargets =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, privilegeGrantIntent.grantTarget(), prependRootContainer));
+      resolvedSecondaries =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, privilegeGrantIntent.grantee(), prependRootContainer));
+    } else if (intent instanceof RootPrivilegeGrantAuthorizationIntent rootPrivilegeGrantIntent) {
+      resolvedTargets = List.of(resolutionManifest.getResolvedRootContainerEntityAsPath());
+      resolvedSecondaries =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, rootPrivilegeGrantIntent.grantee(), prependRootContainer));
+    } else {
+      throw new IllegalStateException("Unsupported authorization intent: " + intent.getClass());
+    }
+    return new ResolvedIntent(resolvedTargets, resolvedSecondaries);
+  }
+
+  private static PolarisResolvedPathWrapper getResolvedSecurable(
+      PolarisResolutionManifest resolutionManifest,
+      PolarisSecurable securable,
+      boolean prependRootContainer) {
+    PolarisResolvedPathWrapper resolvedSecurable =
+        securable.getLeaf().entityType().isTopLevel()
+            ? resolutionManifest.getResolvedTopLevelEntity(
+                securable.getLeaf().name(), securable.getLeaf().entityType())
+            : resolutionManifest.getResolvedPath(
+                ResolvedPathKey.of(
+                    getPathNamesWithinCatalog(securable), securable.getLeaf().entityType()),
+                prependRootContainer);
+    Preconditions.checkState(
+        resolvedSecurable != null,
+        "Resolved path for securable is null for entityType=%s leaf=%s parents=%s",
+        securable.getLeaf().entityType(),
+        securable.getLeaf(),
+        securable.getParents());
+    return resolvedSecurable;
+  }
+
+  private static List<String> getPathNamesWithinCatalog(PolarisSecurable securable) {
+    // Resolver path keys are scoped within the reference catalog, so the explicit catalog
+    // path segment is omitted from the PolarisSecurable path before lookup.
+    return securable.getPathSegments().stream()
+        .filter(segment -> segment.entityType() != PolarisEntityType.CATALOG)
+        .map(PathSegment::name)
+        .toList();
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
@@ -133,7 +133,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.polaris.core.StructuredLogKeys;
-import org.apache.polaris.core.auth.RbacOperationSemantics.ResolvedPathRooting;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityCore;
@@ -142,7 +141,6 @@ import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
-import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -773,73 +771,15 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
       PolarisPrincipal polarisPrincipal,
       PolarisResolutionManifest resolutionManifest,
       AuthorizationIntent intent) {
-    RbacOperationSemantics semantics = RbacOperationSemantics.forOperation(intent.getOperation());
-    boolean prependRootContainer = semantics.rooting() == ResolvedPathRooting.ROOT;
     try {
-      List<PolarisResolvedPathWrapper> resolvedTargets;
-      List<PolarisResolvedPathWrapper> resolvedSecondaries;
-      if (intent instanceof TargetlessAuthorizationIntent) {
-        resolvedTargets =
-            prependRootContainer
-                ? List.of(resolutionManifest.getResolvedRootContainerEntityAsPath())
-                : null;
-        resolvedSecondaries = null;
-      } else if (intent instanceof SingleTargetAuthorizationIntent singleTargetIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, singleTargetIntent.target(), prependRootContainer));
-        resolvedSecondaries = null;
-      } else if (intent instanceof RenameAuthorizationIntent renameIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, renameIntent.from(), prependRootContainer));
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(resolutionManifest, renameIntent.to(), prependRootContainer));
-      } else if (intent instanceof PolicyAttachmentAuthorizationIntent policyAttachmentIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, policyAttachmentIntent.policy(), prependRootContainer));
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, policyAttachmentIntent.attachedTo(), prependRootContainer));
-      } else if (intent instanceof RoleAssignmentAuthorizationIntent roleAssignmentIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, roleAssignmentIntent.role(), prependRootContainer));
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, roleAssignmentIntent.assignee(), prependRootContainer));
-      } else if (intent instanceof PrivilegeGrantAuthorizationIntent privilegeGrantIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, privilegeGrantIntent.grantTarget(), prependRootContainer));
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, privilegeGrantIntent.grantee(), prependRootContainer));
-      } else if (intent instanceof RootPrivilegeGrantAuthorizationIntent rootPrivilegeGrantIntent) {
-        resolvedTargets = List.of(resolutionManifest.getResolvedRootContainerEntityAsPath());
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, rootPrivilegeGrantIntent.grantee(), prependRootContainer));
-      } else {
-        throw new IllegalStateException("Unsupported authorization intent: " + intent.getClass());
-      }
+      AuthorizationIntentResolver.ResolvedIntent resolvedIntent =
+          AuthorizationIntentResolver.resolve(resolutionManifest, intent);
       authorizeOrThrow(
           polarisPrincipal,
           resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
           intent.getOperation(),
-          resolvedTargets,
-          resolvedSecondaries);
+          resolvedIntent.targets(),
+          resolvedIntent.secondaries());
       return AuthorizationDecision.allow();
     } catch (ForbiddenException e) {
       LOGGER.debug(
@@ -849,38 +789,6 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
           e);
       return AuthorizationDecision.deny(e.getMessage());
     }
-  }
-
-  private PolarisResolvedPathWrapper getResolvedSecurable(
-      PolarisResolutionManifest resolutionManifest,
-      PolarisSecurable securable,
-      boolean prependRootContainer) {
-    PolarisResolvedPathWrapper resolvedSecurable =
-        securable.getLeaf().entityType().isTopLevel()
-            ? resolutionManifest.getResolvedTopLevelEntity(
-                securable.getLeaf().name(), securable.getLeaf().entityType())
-            : resolutionManifest.getResolvedPath(
-                ResolvedPathKey.of(
-                    getPathNamesWithinCatalog(securable), securable.getLeaf().entityType()),
-                prependRootContainer);
-    Preconditions.checkState(
-        resolvedSecurable != null,
-        "Resolved path for securable is null for entityType=%s leaf=%s parents=%s",
-        securable.getLeaf().entityType(),
-        securable.getLeaf(),
-        securable.getParents());
-    return resolvedSecurable;
-  }
-
-  private List<String> getPathNamesWithinCatalog(PolarisSecurable securable) {
-    // Resolver path keys are scoped within the reference catalog, so the explicit catalog
-    // path segment is omitted from the PolarisSecurable path before lookup.
-    return securable.getPathSegments().stream()
-        .filter(
-            segment ->
-                segment.entityType() != org.apache.polaris.core.entity.PolarisEntityType.CATALOG)
-        .map(PathSegment::name)
-        .toList();
   }
 
   /**

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/common/CatalogHandler.java
@@ -385,13 +385,20 @@ public abstract class CatalogHandler {
       throw notFoundExceptionForTableLikeEntity(identifier, subType);
     }
 
-    authorizer()
-        .authorizeOrThrow(
+    // Route through the decision-native authorize(state, request) path (via the throwing
+    // convenience wrapper) instead of the legacy resolved-path authorizeOrThrow overload. The
+    // resolution manifest was already populated by resolveBasicTableLikeTargetOrThrow, so the
+    // authorizer re-resolves the same table-like securable from the request intent. The null-check
+    // above is retained so a missing entity still surfaces as a not-found (404) response rather
+    // than a server error from the authorizer's re-resolution.
+    AuthorizationState authorizationState = new AuthorizationState(resolutionManifest);
+    AuthorizationRequest request =
+        new AuthorizationRequest(
             polarisPrincipal(),
-            resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
-            op,
-            target,
-            null /* secondary */);
+            List.of(
+                new SingleTargetAuthorizationIntent(
+                    op, PolarisSecurableMapper.tableLike(catalogName(), identifier))));
+    authorizer().authorizeOrThrow(authorizationState, request);
 
     initializeCatalog();
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doThrow;
@@ -219,6 +220,18 @@ class IcebergCatalogHandlerTest {
     assertThat(actionsCaptor.getValue()).containsExactlyInAnyOrder(actions);
   }
 
+  /**
+   * Matches an {@link AuthorizationRequest} whose first intent targets the given operation. Used to
+   * stub/verify the decision-native {@code authorizeOrThrow(state, request)} path per operation.
+   */
+  private static AuthorizationRequest requestWithOperation(PolarisAuthorizableOperation op) {
+    return argThat(
+        request ->
+            request != null
+                && !request.intents().isEmpty()
+                && request.intents().getFirst().getOperation() == op);
+  }
+
   @Test
   void registerTableWithVendedCredentialsVendsReadWriteActionsWhenWriteDelegationAuthorized() {
     Catalog catalog = mockRegisterTableCatalog(false);
@@ -323,39 +336,37 @@ class IcebergCatalogHandlerTest {
     when(catalog.loadTable(TABLE2)).thenReturn(table);
     when(accessDelegationModeResolver.resolve(any(), any()))
         .thenReturn(Optional.of(VENDED_CREDENTIALS));
+    // The write-delegation probe now routes through the decision-native
+    // authorizeOrThrow(state, request) path rather than the legacy resolved-path overload, so deny
+    // it by matching the request whose intent is the write-delegation operation.
     doThrow(new ForbiddenException("write delegation denied"))
         .when(authorizer)
         .authorizeOrThrow(
-            any(),
-            any(),
-            eq(PolarisAuthorizableOperation.LOAD_TABLE_WITH_WRITE_DELEGATION),
-            nullable(PolarisResolvedPathWrapper.class),
-            nullable(PolarisResolvedPathWrapper.class));
-    @SuppressWarnings("unchecked")
-    ArgumentCaptor<AuthorizationRequest> requestCaptor =
+            any(AuthorizationState.class),
+            requestWithOperation(PolarisAuthorizableOperation.LOAD_TABLE_WITH_WRITE_DELEGATION));
+    ArgumentCaptor<AuthorizationRequest> resolveRequestCaptor =
         ArgumentCaptor.forClass(AuthorizationRequest.class);
     ArgumentCaptor<AuthorizationState> stateCaptor =
         ArgumentCaptor.forClass(AuthorizationState.class);
-    ArgumentCaptor<PolarisAuthorizableOperation> operationCaptor =
-        ArgumentCaptor.forClass(PolarisAuthorizableOperation.class);
+    ArgumentCaptor<AuthorizationRequest> authorizeRequestCaptor =
+        ArgumentCaptor.forClass(AuthorizationRequest.class);
 
     @SuppressWarnings("resource")
     IcebergCatalogHandler handler = newHandler();
 
     handler.loadCredentials(TABLE2, Optional.empty());
 
-    verify(authorizer).resolveAuthorizationInputs(stateCaptor.capture(), requestCaptor.capture());
+    verify(authorizer)
+        .resolveAuthorizationInputs(stateCaptor.capture(), resolveRequestCaptor.capture());
     assertThat(stateCaptor.getValue().getResolutionManifest()).isSameAs(resolutionManifest);
-    assertThat(requestCaptor.getValue().intents().getFirst().getOperation())
+    assertThat(resolveRequestCaptor.getValue().intents().getFirst().getOperation())
         .isEqualTo(PolarisAuthorizableOperation.LOAD_TABLE_WITH_WRITE_DELEGATION);
     verify(authorizer, org.mockito.Mockito.times(2))
-        .authorizeOrThrow(
-            any(),
-            any(),
-            operationCaptor.capture(),
-            nullable(PolarisResolvedPathWrapper.class),
-            nullable(PolarisResolvedPathWrapper.class));
-    assertThat(operationCaptor.getAllValues())
+        .authorizeOrThrow(any(AuthorizationState.class), authorizeRequestCaptor.capture());
+    assertThat(
+            authorizeRequestCaptor.getAllValues().stream()
+                .map(request -> request.intents().getFirst().getOperation())
+                .toList())
         .containsExactly(
             PolarisAuthorizableOperation.LOAD_TABLE_WITH_WRITE_DELEGATION,
             PolarisAuthorizableOperation.LOAD_TABLE_WITH_READ_DELEGATION);


### PR DESCRIPTION
## Summary

This is the first preparatory PR to migrate `authorizeOrThrow` to `authorize`. It migrates `CatalogHandler.authorizeResolvedBasicTableLikeOperationOrThrow` to obtain its authorization decision from the decision-native `PolarisAuthorizer.authorize(AuthorizationState, AuthorizationRequest)` path (via the throwing `authorizeOrThrow(state, request)` convenience wrapper) instead of the legacy resolved-path `authorizeOrThrow(principal, activatedEntities, op, target, secondary)` overload.

## Why this method first

`authorizeResolvedBasicTableLikeOperationOrThrow` is the most widely used table-like authorization method — `loadTable`, `loadCredentials`, `loadView`, `dropTable`, `commitView`, and others all flow through it (directly or via `resolveAndAuthorizeBasicTableLikeOperationOrThrow`). The resolution manifest is already populated by `resolveBasicTableLikeTargetOrThrow` before this method runs, so the authorizer re-resolves the same table-like securable from the request intent with no manifest changes required. This makes it the safest, highest-leverage starting point.

## Changes

* **`CatalogHandler.java`** — `authorizeResolvedBasicTableLikeOperationOrThrow` now builds an `AuthorizationRequest` (single `SingleTargetAuthorizationIntent`) and calls `authorizer().authorizeOrThrow(state, request)`. The existing null-check guard is retained so a missing entity still surfaces as a not-found (404) response rather than a server error from the authorizer's re-resolution.
* **`AuthorizationIntentResolver.java` (new)** — extracts the `AuthorizationIntent` → resolved target/secondary path resolution out of `PolarisAuthorizerImpl` into a shared helper in the `org.apache.polaris.core.auth` package. It lives in that package so it can consult the package-private `RbacOperationSemantics` for root-container rooting, giving every authorizer (built-in and pluggable) one source of truth for resolving an `AuthorizationRequest`'s securables against the resolution manifest.
* **`PolarisAuthorizerImpl.java`** — `authorizeIntent` now delegates securable resolution to `AuthorizationIntentResolver` (behavior-preserving; the moved private helpers are removed).
* **`RangerPolarisAuthorizer.java`** — implements `authorize(state, request)`, which previously threw `UnsupportedOperationException`. It resolves each intent via `AuthorizationIntentResolver` and drives the existing resolved-path Ranger authorization logic, translating a `ForbiddenException` into an `AuthorizationDecision`. Without this, routing `dropTable` (and other table-like ops) through `authorize(state, request)` failed under the Ranger authorizer.
* **`IcebergCatalogHandlerTest.java`** — updated `loadCredentialsFallbackResolvesOnceThenAuthorizesReadDelegation` to stub/verify the decision-native `authorizeOrThrow(state, request)` path (matched by the request intent's operation) instead of the legacy overload; added a small `requestWithOperation(.)` argument-matcher helper.

## Behavior

No behavioral change. Every table-like operation that flows through this method still throws `ForbiddenException` on denial (the wrapper delegates to `authorize(.)` and throws when not allowed), and `loadTable`/`loadCredentials` keep their existing write-delegation-probe → read-delegation-fallback control flow.

## Testing

* `IcebergCatalogHandlerTest` (mock-based) passes.
* Real-`PolarisAuthorizerImpl` authz suites pass unchanged: `IcebergCatalogHandlerAuthzTest` (6921), `IcebergCatalogHandlerFineGrainedDisabledTest` (107), `PolarisGenericTableCatalogHandlerAuthzTest` (538), `PolicyCatalogHandlerAuthzTest` (1518), `IcebergCatalogHandlerTest` (12) — 0 failures.
* Ranger extension integration tests pass: `RangerIcebergCatalogHandlerIT` and `RangerGenericTableHandlerIT` (`:polaris-extensions-auth-ranger:intTest`) — 0 failures.

## Checklist

* 🛡️ Not a security issue
* 🔗 Resolves the existing TODO in `IcebergCatalogHandler`
* 🧪 Updated existing tests to cover the new `authorize()` path
* 💡 Added Javadoc for the new helper
* 🧾 No CHANGELOG update required (internal refactoring)
* 📚 No documentation update required
