### PR TITLE
Fix NoSQL listing silently dropping entities at internal fetch boundaries

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
@@ -2819,13 +2819,13 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
     String prefix = "testPaginatedListTables";
     Namespace namespace = Namespace.of(prefix);
     restCatalog.createNamespace(namespace);
-    for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < 30; i++) {
       restCatalog.createTable(TableIdentifier.of(namespace, prefix + i), SCHEMA);
     }
 
     try {
-      assertThat(catalogApi.listTables(currentCatalogName, namespace)).hasSize(20);
-      for (var pageSize : List.of(1, 2, 3, 9, 10, 11, 19, 20, 21, 2000)) {
+      assertThat(catalogApi.listTables(currentCatalogName, namespace)).hasSize(30);
+      for (var pageSize : List.of(1, 2, 3, 9, 10, 11, 19, 20, 21, 25, 2000)) {
         int total = 0;
         String pageToken = null;
         do {
@@ -2836,10 +2836,10 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
           total += response.identifiers().size();
           pageToken = response.nextPageToken();
         } while (pageToken != null);
-        assertThat(total).as("Total paginated results for pageSize = " + pageSize).isEqualTo(20);
+        assertThat(total).as("Total paginated results for pageSize = " + pageSize).isEqualTo(30);
       }
     } finally {
-      for (int i = 0; i < 20; i++) {
+      for (int i = 0; i < 30; i++) {
         restCatalog.dropTable(TableIdentifier.of(namespace, prefix + i));
       }
       restCatalog.dropNamespace(namespace);

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
@@ -944,7 +944,7 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
             listEntitiesBuildPagePart(
                 access, fetchBuffer, mapper, filter, transformer, result, limit);
         fetchBuffer.clear();
-        if (nextToken != null || result.size() == limit) {
+        if (nextToken != null) {
           break;
         }
       }


### PR DESCRIPTION
On the `NoSQL` backend, listing entities stops iterating as soon as a page is full, but the continuation token is only produced once the next element is encountered — so when a page ends exactly on an internal fetch boundary no token is returned and the client stops early, leaving the remaining entities unreachable. With no filtering this happens whenever the requested page size is a multiple of the internal fetch size of 25, which covers the common page sizes 25, 50 and 100; listing 30 tables with a page size of 25 silently returns 25 and reports no further pages, with no error. This changes the loop to keep iterating until a token is produced, which is how the relational backend already behaves. testPaginatedListTables already asserts that the pages sum to the total number of tables, but used 20 tables so the internal fetch buffer never filled — it is raised to 30 and a page size of 25 is added so the boundary is covered.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
