### PR TITLE
Add makefile target for config-doc-verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,7 @@ jobs:
             -PnoIntegrationTests \
             --continue
       - name: Verify configuration reference is up to date
-        run: |
-          ./gradlew :polaris-config-docs-site:copyConfigSectionsToSite
-          if ! git diff --exit-code site/content/in-dev/unreleased/configuration/config-sections/ || \
-             [ -n "$(git ls-files --others --exclude-standard site/content/in-dev/unreleased/configuration/config-sections/)" ]; then
-            echo "ERROR: Configuration reference is out of date. Please run './gradlew :polaris-config-docs-site:copyConfigSectionsToSite' and commit the changes."
-            exit 1
-          fi
+        run: make config-doc-verify
       - name: Save partial Gradle build cache
         uses: ./.github/actions/ci-incr-build-cache-save
       - name: Archive test results

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,17 @@ config-doc-generate: check-dependencies ## Generate configuration reference docu
 	@./gradlew :polaris-config-docs-site:copyConfigSectionsToSite
 	@echo "--- Configuration reference documentation generated ---"
 
+config-doc-verify: DEPENDENCIES := java21 git
+.PHONY: config-doc-verify
+config-doc-verify: config-doc-generate ## Verify configuration reference documentation is up to date
+	@echo "--- Verifying configuration reference documentation is up to date ---"
+	@if ! git diff --exit-code site/content/in-dev/unreleased/configuration/config-sections/ || \
+		[ -n "$$(git ls-files --others --exclude-standard site/content/in-dev/unreleased/configuration/config-sections/)" ]; then \
+		echo "ERROR: Configuration reference is out of date. Please run 'make config-doc-generate' and commit the changes."; \
+		exit 1; \
+	fi
+	@echo "--- Configuration reference documentation is up to date ---"
+
 spotless-apply: DEPENDENCIES := java21
 .PHONY: spotless-apply
 spotless-apply: check-dependencies ## Apply code formatting using Spotless Gradle plugin.


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This is follow-up PR for https://github.com/apache/polaris/pull/5161. This new makefile target is equivalent of `helm-doc-verify` but for service configuration doc. Ci is also updated to use this new makefile target (matched to how we are doing with helm as well in this CI).

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
