### PR TITLE
[1/2] Enforce immutable Iceberg encryption key IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,11 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 - The NoSQL persistence commit log (`Commits.commitLog`) no longer stops early when a commit's recent-ancestor tail is shorter than the internal fetch page size. With a `polaris.persistence.reference-previous-head-count` smaller than the page size, the natural-order commit log previously truncated at the first short tail because trailing null entries in the fetch page were treated as end-of-history, which could also drop still-referenced objects during maintenance.
+- Iceberg tables now pin `encryption.key-id` in catalog state and reject adding, changing, or
+  removing it after table creation, preserving the table's encryption key identity. Tables created
+  before this pin was recorded continue to use legacy behavior and are not automatically enrolled
+  into the new invariant from metadata stored outside the catalog. Metadata with Iceberg encryption
+  table properties is rejected before entering protected state when its format version is below 3.
 - Python CLI REPL now shows a clear "Syntax error" message for malformed input instead of a generic "unexpected error" message.
 - Python CLI `setup export` now includes nested namespaces and policy definitions from those
   namespaces. Previously, only top-level namespaces and their policies were exported.

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -469,8 +469,15 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     }
 
     IcebergTableLikeEntity existingEntity = IcebergTableLikeEntity.of(rawEntity);
+    TableMetadataTransitionValidator.validate(
+        existingEntity.getInternalPropertiesAsMap(), metadata);
 
     Map<String, String> storedProperties = buildTableMetadataPropertiesMap(metadata);
+    if (existingEntity
+        .getInternalPropertiesAsMap()
+        .containsKey(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY)) {
+      TableMetadataTransitionValidator.pin(storedProperties, metadata);
+    }
     IcebergTableLikeEntity updatedEntity =
         new IcebergTableLikeEntity.Builder(existingEntity)
             .setInternalProperties(storedProperties)
@@ -1808,7 +1815,8 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         }
       }
 
-      String latestLocation = entity != null ? entity.getMetadataLocation() : null;
+      IcebergTableLikeEntity currentEntity = entity;
+      String latestLocation = currentEntity != null ? currentEntity.getMetadataLocation() : null;
       LOGGER.debug("Refreshing latestLocation: {}", latestLocation);
       if (latestLocation == null) {
         disableRefresh();
@@ -1839,7 +1847,10 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
                       resolvedEntities,
                       new HashMap<>(tableDefaultProperties),
                       Set.of(PolarisStorageActions.READ, PolarisStorageActions.LIST));
-              return TableMetadataParser.read(fileIO, metadataLocation);
+              TableMetadata metadata = TableMetadataParser.read(fileIO, metadataLocation);
+              TableMetadataTransitionValidator.validateLoaded(
+                  currentEntity.getInternalPropertiesAsMap(), metadata);
+              return metadata;
             });
         if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_REFRESH_TABLE)) {
           polarisEventDispatcher.dispatch(
@@ -1966,10 +1977,20 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
             throw alreadyExistsExceptionWithSameNameForTableLikeEntity(tableIdentifier, subType);
           }
         }
-        Map<String, String> storedProperties = buildTableMetadataPropertiesMap(metadata);
         IcebergTableLikeEntity entity =
             IcebergTableLikeEntity.of(
                 resolvedPath == null ? null : resolvedPath.getRawLeafEntity());
+        if (base != null) {
+          TableMetadataTransitionValidator.validate(
+              entity == null ? Map.of() : entity.getInternalPropertiesAsMap(), metadata);
+        }
+        Map<String, String> storedProperties = buildTableMetadataPropertiesMap(metadata);
+        if (entity == null
+            || entity
+                .getInternalPropertiesAsMap()
+                .containsKey(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY)) {
+          TableMetadataTransitionValidator.pin(storedProperties, metadata);
+        }
         String existingLocation;
         if (null == entity) {
           existingLocation = null;
@@ -3091,6 +3112,21 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
 
       // finally, validate that the metadata file is within the table directory
       validateMetadataFileInTableDir(tableIdentifier, tableMetadata);
+
+      if (existingLocation != null) {
+        TableMetadataTransitionValidator.validate(
+            entity.getInternalPropertiesAsMap(), tableMetadata);
+      }
+      Map<String, String> internalProperties = new HashMap<>(entity.getInternalPropertiesAsMap());
+      if (existingLocation == null
+          || internalProperties.containsKey(
+              TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY)) {
+        TableMetadataTransitionValidator.pin(internalProperties, tableMetadata);
+      }
+      entity =
+          new IcebergTableLikeEntity.Builder(entity)
+              .setInternalProperties(internalProperties)
+              .build();
 
       // TODO: These might fail due to concurrent update; we need to do a retry in those cases.
       if (null == existingLocation) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataTransitionValidator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataTransitionValidator.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import java.util.Map;
+import java.util.Objects;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.encryption.EncryptionUtil;
+import org.apache.iceberg.exceptions.ValidationException;
+
+final class TableMetadataTransitionValidator {
+  static final String KEY_ID_PINNED_PROPERTY = "polaris.encryption.key-id-pinned";
+  static final String KEY_ID_PROPERTY = "polaris.encryption.key-id";
+
+  private TableMetadataTransitionValidator() {}
+
+  static void validate(Map<String, String> trustedProperties, TableMetadata candidate) {
+    if (!trustedProperties.containsKey(KEY_ID_PINNED_PROPERTY)) {
+      // Legacy tables remain outside the invariant until an explicit trusted attestation
+      // mechanism enrolls them. Ordinary legacy operations must not establish trust from
+      // metadata that may have been read from unprotected storage.
+      return;
+    }
+    if (!keyIdMatches(trustedProperties, candidate)) {
+      throw new ValidationException(
+          "Cannot add, change, or remove encryption key ID after table creation");
+    }
+  }
+
+  /**
+   * Verifies metadata loaded from storage against the trusted catalog pin before it is used.
+   *
+   * <p>Legacy entities without a pin remain outside the invariant. For pinned entities, a missing
+   * key ID is a value in its own right and must continue to be missing.
+   */
+  static void validateLoaded(
+      Map<String, String> trustedProperties, TableMetadata metadataFromStorage) {
+    if (!trustedProperties.containsKey(KEY_ID_PINNED_PROPERTY)) {
+      return;
+    }
+    if (!keyIdMatches(trustedProperties, metadataFromStorage)) {
+      throw new IllegalStateException(
+          "Iceberg table metadata integrity check failed for "
+              + metadataFromStorage.metadataFileLocation()
+              + ": encryption key ID does not match trusted catalog state");
+    }
+  }
+
+  static void pin(Map<String, String> trustedProperties, TableMetadata metadata) {
+    EncryptionUtil.checkCompatibility(metadata.properties(), metadata.formatVersion());
+    trustedProperties.put(KEY_ID_PINNED_PROPERTY, Boolean.TRUE.toString());
+    String keyId = metadata.properties().get(TableProperties.ENCRYPTION_TABLE_KEY);
+    if (keyId == null) {
+      trustedProperties.remove(KEY_ID_PROPERTY);
+    } else {
+      trustedProperties.put(KEY_ID_PROPERTY, keyId);
+    }
+  }
+
+  private static boolean keyIdMatches(
+      Map<String, String> trustedProperties, TableMetadata candidate) {
+    String expectedKeyId = trustedProperties.get(KEY_ID_PROPERTY);
+    String candidateKeyId = candidate.properties().get(TableProperties.ENCRYPTION_TABLE_KEY);
+    return Objects.equals(expectedKeyId, candidateKeyId);
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -974,6 +974,85 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
   }
 
   @Test
+  public void testCommitRejectsEncryptionKeyIdChange() {
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("immutable_key_commit");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    Table table =
+        catalog
+            .buildTable(tableId, SCHEMA)
+            .withProperty(TableProperties.FORMAT_VERSION, "3")
+            .withProperty(TableProperties.ENCRYPTION_TABLE_KEY, "key-1")
+            .create();
+
+    EntityResult namespaceResult =
+        metaStoreManager.readEntityByName(
+            polarisContext,
+            List.of(catalogEntity),
+            PolarisEntityType.NAMESPACE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            namespace.toString());
+    EntityResult tableResult =
+        metaStoreManager.readEntityByName(
+            polarisContext,
+            List.of(catalogEntity, namespaceResult.getEntity()),
+            PolarisEntityType.TABLE_LIKE,
+            PolarisEntitySubType.ICEBERG_TABLE,
+            tableId.name());
+    IcebergTableLikeEntity entity = IcebergTableLikeEntity.of(tableResult.getEntity());
+    Assertions.assertThat(entity.getInternalPropertiesAsMap())
+        .containsEntry(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY, "true")
+        .containsEntry(TableMetadataTransitionValidator.KEY_ID_PROPERTY, "key-1");
+    Assertions.assertThat(entity.getPropertiesAsMap())
+        .doesNotContainKeys(
+            TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY,
+            TableMetadataTransitionValidator.KEY_ID_PROPERTY);
+
+    Assertions.assertThatThrownBy(
+            () ->
+                table
+                    .updateProperties()
+                    .set(TableProperties.ENCRYPTION_TABLE_KEY, "key-2")
+                    .commit())
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Cannot add, change, or remove encryption key ID after table creation");
+    Assertions.assertThat(catalog.loadTable(tableId).properties())
+        .containsEntry(TableProperties.ENCRYPTION_TABLE_KEY, "key-1");
+  }
+
+  @Test
+  public void testLoadRejectsEncryptionKeyIdAddedToPinnedPlaintextMetadata() {
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("immutable_key_load");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    Table table =
+        catalog
+            .buildTable(tableId, SCHEMA)
+            .withProperty(TableProperties.FORMAT_VERSION, "3")
+            .create();
+    TableMetadata current = ((BaseTable) table).operations().current();
+    TableMetadata modified =
+        TableMetadata.buildFrom(current)
+            .setProperties(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, "key-1"))
+            .build();
+    fileIO.addFile(
+        current.metadataFileLocation(), TableMetadataParser.toJson(modified).getBytes(UTF_8));
+
+    Assertions.assertThatThrownBy(() -> catalog.loadTable(tableId))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Iceberg table metadata integrity check failed for")
+        .hasMessageContaining(": encryption key ID does not match trusted catalog state");
+  }
+
+  @Test
   public void testValidateNotificationWhenTableAndNamespacesDontExist() {
     Assumptions.assumeTrue(
         requiresNamespaceCreate(),
@@ -1650,6 +1729,49 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     Assertions.assertThat(catalog.tableExists(table))
         .as("Table should be created on receiving notification")
         .isTrue();
+  }
+
+  @Test
+  public void testUpdateNotificationRejectsEncryptionKeyIdChange() {
+    Assumptions.assumeTrue(
+        supportsNotifications(), "Only applicable if notifications are supported");
+
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("immutable_key_notification");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    Table table =
+        catalog
+            .buildTable(tableId, SCHEMA)
+            .withProperty(TableProperties.FORMAT_VERSION, "3")
+            .withProperty(TableProperties.ENCRYPTION_TABLE_KEY, "key-1")
+            .create();
+    TableMetadata current = ((BaseTable) table).operations().current();
+    String metadataLocation =
+        current.location() + "/metadata/notification-key-change.metadata.json";
+    TableMetadata candidate =
+        TableMetadata.buildFrom(current)
+            .setProperties(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, "key-2"))
+            .build();
+    TableMetadataParser.write(candidate, fileIO.newOutputFile(metadataLocation));
+
+    NotificationRequest request = new NotificationRequest();
+    request.setNotificationType(NotificationType.UPDATE);
+    TableUpdateNotification update = new TableUpdateNotification();
+    update.setMetadataLocation(metadataLocation);
+    update.setTableName(tableId.name());
+    update.setTableUuid(current.uuid());
+    update.setTimestamp(230950845L);
+    request.setPayload(update);
+
+    Assertions.assertThatThrownBy(() -> catalog.sendNotification(tableId, request))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Cannot add, change, or remove encryption key ID after table creation");
+    Assertions.assertThat(catalog.loadTable(tableId).properties())
+        .containsEntry(TableProperties.ENCRYPTION_TABLE_KEY, "key-1");
   }
 
   @Test
@@ -2440,6 +2562,61 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
             () -> catalog.registerTable(TABLE, "metadata_location_without_slashes"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid metadata file location");
+  }
+
+  @Test
+  public void testRegisterTableOverwriteRejectsEncryptionKeyIdChange() {
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("immutable_key_register");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    Table table =
+        catalog
+            .buildTable(tableId, SCHEMA)
+            .withProperty(TableProperties.FORMAT_VERSION, "3")
+            .withProperty(TableProperties.ENCRYPTION_TABLE_KEY, "key-1")
+            .create();
+    TableMetadata current = ((BaseTable) table).operations().current();
+    String metadataLocation = current.location() + "/metadata/register-key-change.metadata.json";
+    TableMetadata candidate =
+        TableMetadata.buildFrom(current)
+            .setProperties(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, "key-2"))
+            .build();
+    TableMetadataParser.write(candidate, fileIO.newOutputFile(metadataLocation));
+
+    Assertions.assertThatThrownBy(() -> catalog.registerTable(tableId, metadataLocation, true))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Cannot add, change, or remove encryption key ID after table creation");
+    Assertions.assertThat(catalog.loadTable(tableId).properties())
+        .containsEntry(TableProperties.ENCRYPTION_TABLE_KEY, "key-1");
+  }
+
+  @Test
+  public void testRegisterTableRejectsEncryptionPropertiesInFormatV2Metadata() {
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("incompatible_encryption_register");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    String tableLocation = STORAGE_LOCATION + "/incompatible-encryption-register/table";
+    String metadataLocation = tableLocation + "/metadata/v1.metadata.json";
+    TableMetadata incompatibleMetadata =
+        TableMetadata.buildFrom(createSampleTableMetadata(tableLocation))
+            .setProperties(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, "key-1"))
+            .build();
+    Assertions.assertThat(incompatibleMetadata.formatVersion()).isEqualTo(2);
+    TableMetadataParser.write(incompatibleMetadata, fileIO.newOutputFile(metadataLocation));
+
+    Assertions.assertThatThrownBy(() -> catalog.registerTable(tableId, metadataLocation))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid properties for v2")
+        .hasMessageContaining(TableProperties.ENCRYPTION_TABLE_KEY);
+    Assertions.assertThat(catalog.tableExists(tableId)).isFalse();
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/TableMetadataTransitionValidatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/TableMetadataTransitionValidatorTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TableMetadataTransitionValidatorTest {
+  private static final String KEY_ID = TableProperties.ENCRYPTION_TABLE_KEY;
+
+  @Test
+  void allowsLegacyTableWithKeyIdToRemainOutsideInvariant() {
+    assertThatCode(
+            () ->
+                TableMetadataTransitionValidator.validate(
+                    Map.of(), metadata(Map.of(KEY_ID, "key-1"))))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void allowsLegacyTableWithoutKeyIdToRemainOutsideInvariant() {
+    assertThatCode(() -> TableMetadataTransitionValidator.validate(Map.of(), metadata(Map.of())))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void allowsUnchangedPinnedKeyId() {
+    assertThatCode(
+            () ->
+                TableMetadataTransitionValidator.validate(
+                    pinned("key-1"), metadata(Map.of(KEY_ID, "key-1"))))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void allowsUnchangedPinnedMissingKeyId() {
+    assertThatCode(
+            () -> TableMetadataTransitionValidator.validate(pinned(null), metadata(Map.of())))
+        .doesNotThrowAnyException();
+  }
+
+  @ParameterizedTest
+  @MethodSource("changedKeyIds")
+  void rejectsChangedPinnedKeyId(String pinnedKeyId, Map<String, String> newProperties) {
+    assertThatThrownBy(
+            () ->
+                TableMetadataTransitionValidator.validate(
+                    pinned(pinnedKeyId), metadata(newProperties)))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Cannot add, change, or remove encryption key ID after table creation");
+  }
+
+  @ParameterizedTest
+  @MethodSource("changedKeyIds")
+  void rejectsLoadedMetadataWithChangedPinnedKeyId(
+      String pinnedKeyId, Map<String, String> loadedProperties) {
+    assertThatThrownBy(
+            () ->
+                TableMetadataTransitionValidator.validateLoaded(
+                    pinned(pinnedKeyId), metadata(loadedProperties)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Iceberg table metadata integrity check failed for test.metadata.json: encryption key "
+                + "ID does not match trusted catalog state");
+  }
+
+  @Test
+  void allowsLoadedMetadataWithPinnedMissingKeyId() {
+    assertThatCode(
+            () -> TableMetadataTransitionValidator.validateLoaded(pinned(null), metadata(Map.of())))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void leavesLoadedLegacyMetadataOutsideInvariant() {
+    assertThatCode(
+            () ->
+                TableMetadataTransitionValidator.validateLoaded(
+                    Map.of(), metadata(Map.of(KEY_ID, "key-1"))))
+        .doesNotThrowAnyException();
+  }
+
+  private static Stream<Arguments> changedKeyIds() {
+    return Stream.of(
+        Arguments.of(null, Map.of(KEY_ID, "key-1")),
+        Arguments.of("key-1", Map.of(KEY_ID, "key-2")),
+        Arguments.of("key-1", Map.of()));
+  }
+
+  @Test
+  void pinsPresentKeyId() {
+    Map<String, String> trustedProperties = new HashMap<>();
+
+    TableMetadataTransitionValidator.pin(trustedProperties, metadata(Map.of(KEY_ID, "key-1")));
+
+    assertThat(trustedProperties)
+        .containsEntry(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY, "true")
+        .containsEntry(TableMetadataTransitionValidator.KEY_ID_PROPERTY, "key-1")
+        .doesNotContainKey(KEY_ID);
+  }
+
+  @Test
+  void pinsMissingKeyId() {
+    Map<String, String> trustedProperties =
+        new HashMap<>(Map.of(TableMetadataTransitionValidator.KEY_ID_PROPERTY, "old-key"));
+
+    TableMetadataTransitionValidator.pin(trustedProperties, metadata(Map.of()));
+
+    assertThat(trustedProperties)
+        .containsEntry(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY, "true")
+        .doesNotContainKey(TableMetadataTransitionValidator.KEY_ID_PROPERTY);
+  }
+
+  @Test
+  void rejectsIncompatibleEncryptionPropertiesBeforePinning() {
+    Map<String, String> trustedProperties = new HashMap<>();
+
+    assertThatThrownBy(
+            () ->
+                TableMetadataTransitionValidator.pin(
+                    trustedProperties, metadata(2, Map.of(KEY_ID, "key-1"))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid properties for v2")
+        .hasMessageContaining(KEY_ID);
+    assertThat(trustedProperties).isEmpty();
+  }
+
+  private static Map<String, String> pinned(String keyId) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY, "true");
+    if (keyId != null) {
+      properties.put(TableMetadataTransitionValidator.KEY_ID_PROPERTY, keyId);
+    }
+    return properties;
+  }
+
+  private static TableMetadata metadata(Map<String, String> properties) {
+    return metadata(3, properties);
+  }
+
+  private static TableMetadata metadata(int formatVersion, Map<String, String> properties) {
+    TableMetadata metadata = mock(TableMetadata.class);
+    when(metadata.formatVersion()).thenReturn(formatVersion);
+    when(metadata.metadataFileLocation()).thenReturn("test.metadata.json");
+    when(metadata.properties()).thenReturn(properties);
+    return metadata;
+  }
+}


### PR DESCRIPTION
## Summary

- Pin `encryption.key-id`, including its absence, in trusted Polaris internal entity state.
- Reject adding, changing, or removing the key ID on commit, register overwrite, notification update, and metadata load.
- Reject Iceberg encryption properties in metadata whose format version is below 3 before protected state is established.
- Keep unpinned legacy tables fully operational without implicitly deriving trusted state from object storage.

This implements the first catalog responsibility in Iceberg's [catalog security requirements](https://iceberg.apache.org/docs/nightly/encryption/#catalog-security-requirements). Polaris already accepts Iceberg table encryption metadata, including when encryption is performed entirely by REST catalog clients. The key-ID invariant is therefore a catalog requirement rather than a server-side purge feature.

## Stack

This is **1/2** of a stacked change. The metadata-integrity follow-up is https://github.com/apache/polaris/pull/5186 and depends on this PR.

Both PRs target `main` because their head branches are in an external fork. The follow-up PR links the incremental second-layer diff and documents the Git update required after this PR is merged.

## Compatibility

New plaintext tables pin the absence of `encryption.key-id`; new encrypted tables pin its exact value. Existing unpinned tables remain in legacy mode and are not enrolled automatically.

## Verification

- `./gradlew format compileAll`
- `:polaris-runtime-service:test` for `TableMetadataTransitionValidatorTest`, `LocalIcebergCatalogNoSqlInMemTest`, and `LocalIcebergCatalogRelationalTest`
- The stacked branch passed all 22,103 runtime-service unit tests (0 failures, 0 errors, 43 skipped).
- Runtime-service integration tests fail before test execution in the common Quarkus `TestHTTPResourceManager` initialization path; all 28 suites report the same `ParameterResolutionException` caused by the NPE at `TestHTTPResourceManager.java:190`.

## Checklist

- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: related to #2829
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed): not needed for internal catalog invariants
