### PR TITLE
[2/2] Enforce encrypted Iceberg metadata integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,11 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 - The NoSQL persistence commit log (`Commits.commitLog`) no longer stops early when a commit's recent-ancestor tail is shorter than the internal fetch page size. With a `polaris.persistence.reference-previous-head-count` smaller than the page size, the natural-order commit log previously truncated at the first short tail because trailing null entries in the fetch page were treated as end-of-history, which could also drop still-referenced objects during maintenance.
+- Iceberg tables now pin `encryption.key-id` in catalog state and reject adding, changing, or
+  removing it after table creation, preserving the table's encryption key identity. Tables created
+  before this pin was recorded continue to use legacy behavior and are not automatically enrolled
+  into the new invariant from metadata stored outside the catalog. Metadata with Iceberg encryption
+  table properties is rejected before entering protected state when its format version is below 3.
 - Python CLI REPL now shows a clear "Syntax error" message for malformed input instead of a generic "unexpected error" message.
 - Python CLI `setup export` now includes nested namespaces and policy definitions from those
   namespaces. Previously, only top-level namespaces and their policies were exported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   before this pin was recorded continue to use legacy behavior and are not automatically enrolled
   into the new invariant from metadata stored outside the catalog. Metadata with Iceberg encryption
   table properties is rejected before entering protected state when its format version is below 3.
+- Encrypted Iceberg tables now pin a canonical metadata SHA-256 in catalog state. Table loads and
+  asynchronous purge verify the digest before using metadata read from storage.
 - Python CLI REPL now shows a clear "Syntax error" message for malformed input instead of a generic "unexpected error" message.
 - Python CLI `setup export` now includes nested namespaces and policy definitions from those
   namespaces. Previously, only top-level namespaces and their policies were exported.

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -81,6 +81,7 @@ import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.iceberg.exceptions.UnprocessableEntityException;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
@@ -478,6 +479,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         .containsKey(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY)) {
       TableMetadataTransitionValidator.pin(storedProperties, metadata);
     }
+    TableMetadataIntegrity.pin(storedProperties, metadata);
     IcebergTableLikeEntity updatedEntity =
         new IcebergTableLikeEntity.Builder(existingEntity)
             .setInternalProperties(storedProperties)
@@ -1848,8 +1850,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
                       new HashMap<>(tableDefaultProperties),
                       Set.of(PolarisStorageActions.READ, PolarisStorageActions.LIST));
               TableMetadata metadata = TableMetadataParser.read(fileIO, metadataLocation);
-              TableMetadataTransitionValidator.validateLoaded(
-                  currentEntity.getInternalPropertiesAsMap(), metadata);
+              TableMetadataIntegrity.validate(currentEntity, metadata);
               return metadata;
             });
         if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_REFRESH_TABLE)) {
@@ -1991,6 +1992,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
                 .containsKey(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY)) {
           TableMetadataTransitionValidator.pin(storedProperties, metadata);
         }
+        TableMetadataIntegrity.pin(storedProperties, metadata);
         String existingLocation;
         if (null == entity) {
           existingLocation = null;
@@ -3116,13 +3118,19 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       if (existingLocation != null) {
         TableMetadataTransitionValidator.validate(
             entity.getInternalPropertiesAsMap(), tableMetadata);
+        if (entity
+            .getInternalPropertiesAsMap()
+            .containsKey(TableMetadataTransitionValidator.KEY_ID_PROPERTY)) {
+          throw new ValidationException(
+              "Cannot update a protected table by notification without an authenticated expected "
+                  + "metadata digest");
+        }
       }
       Map<String, String> internalProperties = new HashMap<>(entity.getInternalPropertiesAsMap());
-      if (existingLocation == null
-          || internalProperties.containsKey(
-              TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY)) {
+      if (existingLocation == null) {
         TableMetadataTransitionValidator.pin(internalProperties, tableMetadata);
       }
+      TableMetadataIntegrity.pin(internalProperties, tableMetadata);
       entity =
           new IcebergTableLikeEntity.Builder(entity)
               .setInternalProperties(internalProperties)

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -469,8 +469,15 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     }
 
     IcebergTableLikeEntity existingEntity = IcebergTableLikeEntity.of(rawEntity);
+    TableMetadataTransitionValidator.validate(
+        existingEntity.getInternalPropertiesAsMap(), metadata);
 
     Map<String, String> storedProperties = buildTableMetadataPropertiesMap(metadata);
+    if (existingEntity
+        .getInternalPropertiesAsMap()
+        .containsKey(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY)) {
+      TableMetadataTransitionValidator.pin(storedProperties, metadata);
+    }
     IcebergTableLikeEntity updatedEntity =
         new IcebergTableLikeEntity.Builder(existingEntity)
             .setInternalProperties(storedProperties)
@@ -1808,7 +1815,8 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         }
       }
 
-      String latestLocation = entity != null ? entity.getMetadataLocation() : null;
+      IcebergTableLikeEntity currentEntity = entity;
+      String latestLocation = currentEntity != null ? currentEntity.getMetadataLocation() : null;
       LOGGER.debug("Refreshing latestLocation: {}", latestLocation);
       if (latestLocation == null) {
         disableRefresh();
@@ -1839,7 +1847,10 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
                       resolvedEntities,
                       new HashMap<>(tableDefaultProperties),
                       Set.of(PolarisStorageActions.READ, PolarisStorageActions.LIST));
-              return TableMetadataParser.read(fileIO, metadataLocation);
+              TableMetadata metadata = TableMetadataParser.read(fileIO, metadataLocation);
+              TableMetadataTransitionValidator.validateLoaded(
+                  currentEntity.getInternalPropertiesAsMap(), metadata);
+              return metadata;
             });
         if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_REFRESH_TABLE)) {
           polarisEventDispatcher.dispatch(
@@ -1966,10 +1977,20 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
             throw alreadyExistsExceptionWithSameNameForTableLikeEntity(tableIdentifier, subType);
           }
         }
-        Map<String, String> storedProperties = buildTableMetadataPropertiesMap(metadata);
         IcebergTableLikeEntity entity =
             IcebergTableLikeEntity.of(
                 resolvedPath == null ? null : resolvedPath.getRawLeafEntity());
+        if (base != null) {
+          TableMetadataTransitionValidator.validate(
+              entity == null ? Map.of() : entity.getInternalPropertiesAsMap(), metadata);
+        }
+        Map<String, String> storedProperties = buildTableMetadataPropertiesMap(metadata);
+        if (entity == null
+            || entity
+                .getInternalPropertiesAsMap()
+                .containsKey(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY)) {
+          TableMetadataTransitionValidator.pin(storedProperties, metadata);
+        }
         String existingLocation;
         if (null == entity) {
           existingLocation = null;
@@ -3091,6 +3112,21 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
 
       // finally, validate that the metadata file is within the table directory
       validateMetadataFileInTableDir(tableIdentifier, tableMetadata);
+
+      if (existingLocation != null) {
+        TableMetadataTransitionValidator.validate(
+            entity.getInternalPropertiesAsMap(), tableMetadata);
+      }
+      Map<String, String> internalProperties = new HashMap<>(entity.getInternalPropertiesAsMap());
+      if (existingLocation == null
+          || internalProperties.containsKey(
+              TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY)) {
+        TableMetadataTransitionValidator.pin(internalProperties, tableMetadata);
+      }
+      entity =
+          new IcebergTableLikeEntity.Builder(entity)
+              .setInternalProperties(internalProperties)
+              .build();
 
       // TODO: These might fail due to concurrent update; we need to do a retry in those cases.
       if (null == existingLocation) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataIntegrity.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataIntegrity.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Map;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.util.HashWriter;
+import org.apache.iceberg.util.JsonUtil;
+import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
+
+/** Maintains the trusted metadata digest for encrypted Iceberg tables. */
+public final class TableMetadataIntegrity {
+  static final String METADATA_HASH_PROPERTY = "polaris.encryption.metadata-hash";
+  static final String METADATA_HASH_VERSION_PROPERTY = "polaris.encryption.metadata-hash-version";
+  static final String METADATA_HASH_VERSION = "iceberg-canonical-json-sha256-v1";
+
+  private TableMetadataIntegrity() {}
+
+  /**
+   * Records the candidate metadata digest in trusted catalog properties.
+   *
+   * <p>The hash uses Iceberg's canonical JSON representation, matching {@code HiveCatalog}. The
+   * digest is only required for encrypted tables.
+   */
+  static void pin(Map<String, String> trustedProperties, TableMetadata metadata) {
+    if (!trustedProperties.containsKey(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY)) {
+      return;
+    }
+
+    if (metadata.properties().containsKey(TableProperties.ENCRYPTION_TABLE_KEY)) {
+      trustedProperties.put(METADATA_HASH_PROPERTY, metadataHash(metadata));
+      trustedProperties.put(METADATA_HASH_VERSION_PROPERTY, METADATA_HASH_VERSION);
+    } else {
+      trustedProperties.remove(METADATA_HASH_PROPERTY);
+      trustedProperties.remove(METADATA_HASH_VERSION_PROPERTY);
+    }
+  }
+
+  /**
+   * Verifies encrypted metadata loaded from storage before it is used.
+   *
+   * <p>Legacy entities without a key-id pin are outside this invariant. Once an entity has been
+   * pinned, an encrypted table must also have a matching digest.
+   */
+  public static void validate(IcebergTableLikeEntity entity, TableMetadata metadata) {
+    Map<String, String> trustedProperties = entity.getInternalPropertiesAsMap();
+    if (!trustedProperties.containsKey(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY)) {
+      return;
+    }
+
+    TableMetadataTransitionValidator.validateLoaded(trustedProperties, metadata);
+
+    String trustedKeyId = trustedProperties.get(TableMetadataTransitionValidator.KEY_ID_PROPERTY);
+    String expectedHash = trustedProperties.get(METADATA_HASH_PROPERTY);
+    String hashVersion = trustedProperties.get(METADATA_HASH_VERSION_PROPERTY);
+    if (trustedKeyId == null) {
+      if (expectedHash != null || hashVersion != null) {
+        throw integrityFailure(metadata, "trusted catalog state is inconsistent");
+      }
+      return;
+    }
+    if (expectedHash == null) {
+      throw integrityFailure(metadata, "trusted catalog state has no metadata digest");
+    }
+    if (!METADATA_HASH_VERSION.equals(hashVersion)) {
+      throw integrityFailure(
+          metadata, "trusted catalog state has an unsupported metadata digest version");
+    }
+
+    byte[] expected;
+    try {
+      expected = Base64.getDecoder().decode(expectedHash);
+    } catch (IllegalArgumentException e) {
+      throw integrityFailure(metadata, "trusted catalog state has an invalid metadata digest", e);
+    }
+
+    if (!MessageDigest.isEqual(expected, metadataHashBytes(metadata))) {
+      throw integrityFailure(metadata, "metadata does not match the trusted catalog digest");
+    }
+  }
+
+  static String metadataHash(TableMetadata metadata) {
+    return Base64.getEncoder().encodeToString(metadataHashBytes(metadata));
+  }
+
+  private static byte[] metadataHashBytes(TableMetadata metadata) {
+    try (HashWriter hashWriter = new HashWriter("SHA-256", StandardCharsets.UTF_8)) {
+      JsonGenerator generator = JsonUtil.factory().createGenerator(hashWriter);
+      TableMetadataParser.toJson(metadata, generator);
+      generator.flush();
+      return hashWriter.getHash();
+    } catch (NoSuchAlgorithmException | IOException e) {
+      throw new IllegalStateException("Unable to hash Iceberg table metadata", e);
+    }
+  }
+
+  private static TableMetadataIntegrityException integrityFailure(
+      TableMetadata metadata, String reason) {
+    return integrityFailure(metadata, reason, null);
+  }
+
+  private static TableMetadataIntegrityException integrityFailure(
+      TableMetadata metadata, String reason, Exception cause) {
+    String message =
+        "Iceberg table metadata integrity check failed for "
+            + metadata.metadataFileLocation()
+            + ": "
+            + reason;
+    return cause == null
+        ? new TableMetadataIntegrityException(message)
+        : new TableMetadataIntegrityException(message, cause);
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataIntegrityException.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataIntegrityException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+/** Indicates that Iceberg table metadata does not match trusted Polaris catalog state. */
+public final class TableMetadataIntegrityException extends IllegalStateException {
+
+  public TableMetadataIntegrityException(String message) {
+    super(message);
+  }
+
+  public TableMetadataIntegrityException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataTransitionValidator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataTransitionValidator.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import java.util.Map;
+import java.util.Objects;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.encryption.EncryptionUtil;
+import org.apache.iceberg.exceptions.ValidationException;
+
+final class TableMetadataTransitionValidator {
+  static final String KEY_ID_PINNED_PROPERTY = "polaris.encryption.key-id-pinned";
+  static final String KEY_ID_PROPERTY = "polaris.encryption.key-id";
+
+  private TableMetadataTransitionValidator() {}
+
+  static void validate(Map<String, String> trustedProperties, TableMetadata candidate) {
+    if (!trustedProperties.containsKey(KEY_ID_PINNED_PROPERTY)) {
+      // Legacy tables remain outside the invariant until an explicit trusted attestation
+      // mechanism enrolls them. Ordinary legacy operations must not establish trust from
+      // metadata that may have been read from unprotected storage.
+      return;
+    }
+    if (!keyIdMatches(trustedProperties, candidate)) {
+      throw new ValidationException(
+          "Cannot add, change, or remove encryption key ID after table creation");
+    }
+  }
+
+  /**
+   * Verifies metadata loaded from storage against the trusted catalog pin before it is used.
+   *
+   * <p>Legacy entities without a pin remain outside the invariant. For pinned entities, a missing
+   * key ID is a value in its own right and must continue to be missing.
+   */
+  static void validateLoaded(
+      Map<String, String> trustedProperties, TableMetadata metadataFromStorage) {
+    if (!trustedProperties.containsKey(KEY_ID_PINNED_PROPERTY)) {
+      return;
+    }
+    if (!keyIdMatches(trustedProperties, metadataFromStorage)) {
+      throw new IllegalStateException(
+          "Iceberg table metadata integrity check failed for "
+              + metadataFromStorage.metadataFileLocation()
+              + ": encryption key ID does not match trusted catalog state");
+    }
+  }
+
+  static void pin(Map<String, String> trustedProperties, TableMetadata metadata) {
+    EncryptionUtil.checkCompatibility(metadata.properties(), metadata.formatVersion());
+    trustedProperties.put(KEY_ID_PINNED_PROPERTY, Boolean.TRUE.toString());
+    String keyId = metadata.properties().get(TableProperties.ENCRYPTION_TABLE_KEY);
+    if (keyId == null) {
+      trustedProperties.remove(KEY_ID_PROPERTY);
+    } else {
+      trustedProperties.put(KEY_ID_PROPERTY, keyId);
+    }
+  }
+
+  private static boolean keyIdMatches(
+      Map<String, String> trustedProperties, TableMetadata candidate) {
+    String expectedKeyId = trustedProperties.get(KEY_ID_PROPERTY);
+    String candidateKeyId = candidate.properties().get(TableProperties.ENCRYPTION_TABLE_KEY);
+    return Objects.equals(expectedKeyId, candidateKeyId);
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataTransitionValidator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataTransitionValidator.java
@@ -56,7 +56,7 @@ final class TableMetadataTransitionValidator {
       return;
     }
     if (!keyIdMatches(trustedProperties, metadataFromStorage)) {
-      throw new IllegalStateException(
+      throw new TableMetadataIntegrityException(
           "Iceberg table metadata integrity check failed for "
               + metadataFromStorage.metadataFileLocation()
               + ": encryption key ID does not match trusted catalog state");

--- a/runtime/service/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
@@ -57,6 +57,7 @@ import org.apache.iceberg.exceptions.UnprocessableEntityException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.polaris.core.exceptions.FileIOUnknownHostException;
+import org.apache.polaris.service.catalog.iceberg.TableMetadataIntegrityException;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -175,6 +176,7 @@ public class IcebergExceptionMapper implements ExceptionMapper<RuntimeException>
       case FileIOUnknownHostException e -> Status.NOT_FOUND.getStatusCode();
       case AlreadyExistsException e -> Status.CONFLICT.getStatusCode();
       case CommitFailedException e -> Status.CONFLICT.getStatusCode();
+      case TableMetadataIntegrityException e -> 422;
       case UnprocessableEntityException e -> 422;
       case CherrypickAncestorCommitException e -> Status.BAD_REQUEST.getStatusCode();
       case CommitStateUnknownException e -> Status.BAD_REQUEST.getStatusCode();

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/NonRetryableTaskException.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/NonRetryableTaskException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.task;
+
+/** Indicates that retrying a task cannot change its failure verdict. */
+final class NonRetryableTaskException extends RuntimeException {
+
+  NonRetryableTaskException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TableCleanupTaskHandler.java
@@ -45,6 +45,8 @@ import org.apache.polaris.core.entity.TaskEntity;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.service.catalog.iceberg.TableMetadataIntegrity;
+import org.apache.polaris.service.catalog.iceberg.TableMetadataIntegrityException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,6 +119,12 @@ public class TableCleanupTaskHandler implements TaskHandler {
 
       TableMetadata tableMetadata =
           TableMetadataParser.read(fileIO, tableEntity.getMetadataLocation());
+      try {
+        TableMetadataIntegrity.validate(tableEntity, tableMetadata);
+      } catch (TableMetadataIntegrityException e) {
+        throw new NonRetryableTaskException(
+            "Table cleanup stopped because metadata failed integrity validation", e);
+      }
 
       PolarisMetaStoreManager metaStoreManager =
           metaStoreManagerFactory.getOrCreateMetaStoreManager(callContext.getRealmContext());

--- a/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/task/TaskExecutorImpl.java
@@ -69,6 +69,7 @@ import org.slf4j.LoggerFactory;
 public class TaskExecutorImpl implements TaskExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(TaskExecutorImpl.class);
   private static final long TASK_RETRY_DELAY = 1000;
+  private static final int MAX_TASK_ATTEMPTS = 3;
 
   private final Executor executor;
   private final Clock clock;
@@ -159,7 +160,16 @@ public class TaskExecutorImpl implements TaskExecutor {
 
     // Capture the metadata now in order to capture the principal and request ID, if any.
     PolarisEventMetadata eventMetadata = eventMetadataFactory.create();
-    tryHandleTask(taskEntityId, clone, eventMetadata, null, 1);
+    tryHandleTask(taskEntityId, clone, eventMetadata, null, 1)
+        .exceptionally(
+            t -> {
+              LOGGER
+                  .atError()
+                  .addKeyValue("taskEntityId", taskEntityId)
+                  .setCause(t)
+                  .log("Task execution reached a terminal failure");
+              return null;
+            });
   }
 
   private @NonNull CompletableFuture<Void> tryHandleTask(
@@ -168,9 +178,6 @@ public class TaskExecutorImpl implements TaskExecutor {
       PolarisEventMetadata eventMetadata,
       Throwable previousError,
       int attempt) {
-    if (attempt > 3) {
-      return CompletableFuture.failedFuture(previousError);
-    }
     String realmId = callContext.getRealmContext().getRealmIdentifier();
 
     PolarisPrincipal principalClone =
@@ -183,17 +190,33 @@ public class TaskExecutorImpl implements TaskExecutor {
               errorHandler.ifPresent(h -> h.accept(taskEntityId, false, null));
             },
             executor)
-        .exceptionallyComposeAsync(
+        .exceptionallyCompose(
             (t) -> {
               if (previousError != null) {
                 t.addSuppressed(previousError);
               }
               LOGGER.warn("Failed to handle task entity id {}", taskEntityId, t);
               errorHandler.ifPresent(h -> h.accept(taskEntityId, false, t));
-              return tryHandleTask(taskEntityId, callContext, eventMetadata, t, attempt + 1);
-            },
-            CompletableFuture.delayedExecutor(
-                TASK_RETRY_DELAY * (long) attempt, TimeUnit.MILLISECONDS, executor));
+              if (isNonRetryable(t) || attempt >= MAX_TASK_ATTEMPTS) {
+                return CompletableFuture.failedFuture(t);
+              }
+              return CompletableFuture.runAsync(
+                      () -> {},
+                      CompletableFuture.delayedExecutor(
+                          TASK_RETRY_DELAY * (long) attempt, TimeUnit.MILLISECONDS, executor))
+                  .thenCompose(
+                      ignored ->
+                          tryHandleTask(taskEntityId, callContext, eventMetadata, t, attempt + 1));
+            });
+  }
+
+  private static boolean isNonRetryable(Throwable failure) {
+    for (Throwable current = failure; current != null; current = current.getCause()) {
+      if (current instanceof NonRetryableTaskException) {
+        return true;
+      }
+    }
+    return false;
   }
 
   protected void handleTask(

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -974,6 +974,85 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
   }
 
   @Test
+  public void testCommitRejectsEncryptionKeyIdChange() {
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("immutable_key_commit");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    Table table =
+        catalog
+            .buildTable(tableId, SCHEMA)
+            .withProperty(TableProperties.FORMAT_VERSION, "3")
+            .withProperty(TableProperties.ENCRYPTION_TABLE_KEY, "key-1")
+            .create();
+
+    EntityResult namespaceResult =
+        metaStoreManager.readEntityByName(
+            polarisContext,
+            List.of(catalogEntity),
+            PolarisEntityType.NAMESPACE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            namespace.toString());
+    EntityResult tableResult =
+        metaStoreManager.readEntityByName(
+            polarisContext,
+            List.of(catalogEntity, namespaceResult.getEntity()),
+            PolarisEntityType.TABLE_LIKE,
+            PolarisEntitySubType.ICEBERG_TABLE,
+            tableId.name());
+    IcebergTableLikeEntity entity = IcebergTableLikeEntity.of(tableResult.getEntity());
+    Assertions.assertThat(entity.getInternalPropertiesAsMap())
+        .containsEntry(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY, "true")
+        .containsEntry(TableMetadataTransitionValidator.KEY_ID_PROPERTY, "key-1");
+    Assertions.assertThat(entity.getPropertiesAsMap())
+        .doesNotContainKeys(
+            TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY,
+            TableMetadataTransitionValidator.KEY_ID_PROPERTY);
+
+    Assertions.assertThatThrownBy(
+            () ->
+                table
+                    .updateProperties()
+                    .set(TableProperties.ENCRYPTION_TABLE_KEY, "key-2")
+                    .commit())
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Cannot add, change, or remove encryption key ID after table creation");
+    Assertions.assertThat(catalog.loadTable(tableId).properties())
+        .containsEntry(TableProperties.ENCRYPTION_TABLE_KEY, "key-1");
+  }
+
+  @Test
+  public void testLoadRejectsEncryptionKeyIdAddedToPinnedPlaintextMetadata() {
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("immutable_key_load");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    Table table =
+        catalog
+            .buildTable(tableId, SCHEMA)
+            .withProperty(TableProperties.FORMAT_VERSION, "3")
+            .create();
+    TableMetadata current = ((BaseTable) table).operations().current();
+    TableMetadata modified =
+        TableMetadata.buildFrom(current)
+            .setProperties(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, "key-1"))
+            .build();
+    fileIO.addFile(
+        current.metadataFileLocation(), TableMetadataParser.toJson(modified).getBytes(UTF_8));
+
+    Assertions.assertThatThrownBy(() -> catalog.loadTable(tableId))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Iceberg table metadata integrity check failed for")
+        .hasMessageContaining(": encryption key ID does not match trusted catalog state");
+  }
+
+  @Test
   public void testValidateNotificationWhenTableAndNamespacesDontExist() {
     Assumptions.assumeTrue(
         requiresNamespaceCreate(),
@@ -1650,6 +1729,49 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     Assertions.assertThat(catalog.tableExists(table))
         .as("Table should be created on receiving notification")
         .isTrue();
+  }
+
+  @Test
+  public void testUpdateNotificationRejectsEncryptionKeyIdChange() {
+    Assumptions.assumeTrue(
+        supportsNotifications(), "Only applicable if notifications are supported");
+
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("immutable_key_notification");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    Table table =
+        catalog
+            .buildTable(tableId, SCHEMA)
+            .withProperty(TableProperties.FORMAT_VERSION, "3")
+            .withProperty(TableProperties.ENCRYPTION_TABLE_KEY, "key-1")
+            .create();
+    TableMetadata current = ((BaseTable) table).operations().current();
+    String metadataLocation =
+        current.location() + "/metadata/notification-key-change.metadata.json";
+    TableMetadata candidate =
+        TableMetadata.buildFrom(current)
+            .setProperties(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, "key-2"))
+            .build();
+    TableMetadataParser.write(candidate, fileIO.newOutputFile(metadataLocation));
+
+    NotificationRequest request = new NotificationRequest();
+    request.setNotificationType(NotificationType.UPDATE);
+    TableUpdateNotification update = new TableUpdateNotification();
+    update.setMetadataLocation(metadataLocation);
+    update.setTableName(tableId.name());
+    update.setTableUuid(current.uuid());
+    update.setTimestamp(230950845L);
+    request.setPayload(update);
+
+    Assertions.assertThatThrownBy(() -> catalog.sendNotification(tableId, request))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Cannot add, change, or remove encryption key ID after table creation");
+    Assertions.assertThat(catalog.loadTable(tableId).properties())
+        .containsEntry(TableProperties.ENCRYPTION_TABLE_KEY, "key-1");
   }
 
   @Test
@@ -2440,6 +2562,61 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
             () -> catalog.registerTable(TABLE, "metadata_location_without_slashes"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid metadata file location");
+  }
+
+  @Test
+  public void testRegisterTableOverwriteRejectsEncryptionKeyIdChange() {
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("immutable_key_register");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    Table table =
+        catalog
+            .buildTable(tableId, SCHEMA)
+            .withProperty(TableProperties.FORMAT_VERSION, "3")
+            .withProperty(TableProperties.ENCRYPTION_TABLE_KEY, "key-1")
+            .create();
+    TableMetadata current = ((BaseTable) table).operations().current();
+    String metadataLocation = current.location() + "/metadata/register-key-change.metadata.json";
+    TableMetadata candidate =
+        TableMetadata.buildFrom(current)
+            .setProperties(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, "key-2"))
+            .build();
+    TableMetadataParser.write(candidate, fileIO.newOutputFile(metadataLocation));
+
+    Assertions.assertThatThrownBy(() -> catalog.registerTable(tableId, metadataLocation, true))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Cannot add, change, or remove encryption key ID after table creation");
+    Assertions.assertThat(catalog.loadTable(tableId).properties())
+        .containsEntry(TableProperties.ENCRYPTION_TABLE_KEY, "key-1");
+  }
+
+  @Test
+  public void testRegisterTableRejectsEncryptionPropertiesInFormatV2Metadata() {
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("incompatible_encryption_register");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    String tableLocation = STORAGE_LOCATION + "/incompatible-encryption-register/table";
+    String metadataLocation = tableLocation + "/metadata/v1.metadata.json";
+    TableMetadata incompatibleMetadata =
+        TableMetadata.buildFrom(createSampleTableMetadata(tableLocation))
+            .setProperties(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, "key-1"))
+            .build();
+    Assertions.assertThat(incompatibleMetadata.formatVersion()).isEqualTo(2);
+    TableMetadataParser.write(incompatibleMetadata, fileIO.newOutputFile(metadataLocation));
+
+    Assertions.assertThatThrownBy(() -> catalog.registerTable(tableId, metadataLocation))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid properties for v2")
+        .hasMessageContaining(TableProperties.ENCRYPTION_TABLE_KEY);
+    Assertions.assertThat(catalog.tableExists(tableId)).isFalse();
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -1047,9 +1047,42 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
         current.metadataFileLocation(), TableMetadataParser.toJson(modified).getBytes(UTF_8));
 
     Assertions.assertThatThrownBy(() -> catalog.loadTable(tableId))
-        .isInstanceOf(IllegalStateException.class)
+        .isInstanceOf(TableMetadataIntegrityException.class)
         .hasMessageContaining("Iceberg table metadata integrity check failed for")
         .hasMessageContaining(": encryption key ID does not match trusted catalog state");
+  }
+
+  @Test
+  public void testLoadRejectsModifiedEncryptedMetadata() {
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("encrypted_metadata_integrity");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    Table table =
+        catalog
+            .buildTable(tableId, SCHEMA)
+            .withProperty(TableProperties.FORMAT_VERSION, "3")
+            .withProperty(TableProperties.ENCRYPTION_TABLE_KEY, "key-1")
+            .create();
+    TableMetadata current = ((BaseTable) table).operations().current();
+    TableMetadata modified =
+        TableMetadata.buildFrom(current)
+            .setProperties(
+                Map.of(
+                    TableProperties.ENCRYPTION_TABLE_KEY,
+                    "key-1",
+                    TableProperties.COMMIT_NUM_RETRIES,
+                    "1"))
+            .build();
+    fileIO.addFile(
+        current.metadataFileLocation(), TableMetadataParser.toJson(modified).getBytes(UTF_8));
+
+    Assertions.assertThatThrownBy(() -> catalog.loadTable(tableId))
+        .isInstanceOf(TableMetadataIntegrityException.class)
+        .hasMessageContaining("metadata does not match the trusted catalog digest");
   }
 
   @Test
@@ -1775,6 +1808,100 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
   }
 
   @Test
+  public void testUpdateNotificationPinsAdmittedMetadataForMissingTable() {
+    Assumptions.assumeTrue(
+        supportsNotifications(), "Only applicable if notifications are supported");
+
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("metadata_integrity_notification_create");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    String tableLocation = STORAGE_LOCATION + "/metadata_integrity_notification_create/table/";
+    String metadataLocation = tableLocation + "metadata/v1.metadata.json";
+    TableMetadata admitted = createEncryptedSampleTableMetadata(tableLocation);
+    TableMetadataParser.write(admitted, fileIO.newOutputFile(metadataLocation));
+
+    NotificationRequest request = new NotificationRequest();
+    request.setNotificationType(NotificationType.UPDATE);
+    TableUpdateNotification update = new TableUpdateNotification();
+    update.setMetadataLocation(metadataLocation);
+    update.setTableName(tableId.name());
+    update.setTableUuid(admitted.uuid());
+    update.setTimestamp(230950845L);
+    request.setPayload(update);
+
+    Assertions.assertThat(catalog.sendNotification(tableId, request)).isTrue();
+
+    TableMetadata modified =
+        TableMetadata.buildFrom(admitted)
+            .setProperties(
+                Map.of(
+                    TableProperties.ENCRYPTION_TABLE_KEY,
+                    "key-1",
+                    TableProperties.COMMIT_NUM_RETRIES,
+                    "1"))
+            .build();
+    TableMetadataParser.overwrite(modified, fileIO.newOutputFile(metadataLocation));
+
+    Assertions.assertThatThrownBy(() -> catalog.loadTable(tableId))
+        .isInstanceOf(TableMetadataIntegrityException.class)
+        .hasMessageContaining("metadata does not match the trusted catalog digest");
+  }
+
+  @Test
+  public void testUpdateNotificationRejectsProtectedMetadataWithoutExpectedDigest() {
+    Assumptions.assumeTrue(
+        supportsNotifications(), "Only applicable if notifications are supported");
+
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("metadata_integrity_notification");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    Table table =
+        catalog
+            .buildTable(tableId, SCHEMA)
+            .withProperty(TableProperties.FORMAT_VERSION, "3")
+            .withProperty(TableProperties.ENCRYPTION_TABLE_KEY, "key-1")
+            .create();
+    TableMetadata current = ((BaseTable) table).operations().current();
+    String metadataLocation =
+        current.location() + "/metadata/notification-readmission.metadata.json";
+    TableMetadata admitted =
+        TableMetadata.buildFrom(current)
+            .setProperties(
+                Map.of(
+                    TableProperties.ENCRYPTION_TABLE_KEY,
+                    "key-1",
+                    TableProperties.COMMIT_NUM_RETRIES,
+                    "1"))
+            .build();
+    TableMetadataParser.write(admitted, fileIO.newOutputFile(metadataLocation));
+
+    NotificationRequest request = new NotificationRequest();
+    request.setNotificationType(NotificationType.UPDATE);
+    TableUpdateNotification update = new TableUpdateNotification();
+    update.setMetadataLocation(metadataLocation);
+    update.setTableName(tableId.name());
+    update.setTableUuid(current.uuid());
+    update.setTimestamp(230950845L);
+    request.setPayload(update);
+
+    Assertions.assertThatThrownBy(() -> catalog.sendNotification(tableId, request))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage(
+            "Cannot update a protected table by notification without an authenticated expected "
+                + "metadata digest");
+    Assertions.assertThat(catalog.loadTable(tableId).properties())
+        .doesNotContainKey(TableProperties.COMMIT_NUM_RETRIES);
+  }
+
+  @Test
   public void testUpdateNotificationWhenTableExistsInDisallowedLocation() {
     Assumptions.assumeTrue(
         requiresNamespaceCreate(),
@@ -2419,6 +2546,15 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     return TableMetadata.newTableMetadata(schema, partitionSpec, tableLocation, ImmutableMap.of());
   }
 
+  private TableMetadata createEncryptedSampleTableMetadata(String tableLocation) {
+    TableMetadata metadata = createSampleTableMetadata(tableLocation);
+    return TableMetadata.newTableMetadata(
+        metadata.schema(),
+        metadata.spec(),
+        tableLocation,
+        Map.of(TableProperties.FORMAT_VERSION, "3", TableProperties.ENCRYPTION_TABLE_KEY, "key-1"));
+  }
+
   private ViewMetadata createSampleViewMetadata(String viewLocation) {
     return ViewMetadata.builder()
         .setLocation(viewLocation)
@@ -2617,6 +2753,86 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
         .hasMessageContaining("Invalid properties for v2")
         .hasMessageContaining(TableProperties.ENCRYPTION_TABLE_KEY);
     Assertions.assertThat(catalog.tableExists(tableId)).isFalse();
+  }
+
+  @Test
+  public void testRegisterTablePinsAdmittedMetadata() {
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("metadata_integrity_register");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    String tableLocation = STORAGE_LOCATION + "/metadata_integrity_register/table/";
+    String metadataLocation = tableLocation + "metadata/v1.metadata.json";
+    TableMetadata admitted = createEncryptedSampleTableMetadata(tableLocation);
+    TableMetadataParser.write(admitted, fileIO.newOutputFile(metadataLocation));
+
+    Assertions.assertThat(catalog.registerTable(tableId, metadataLocation)).isNotNull();
+
+    TableMetadata modified =
+        TableMetadata.buildFrom(admitted)
+            .setProperties(
+                Map.of(
+                    TableProperties.ENCRYPTION_TABLE_KEY,
+                    "key-1",
+                    TableProperties.COMMIT_NUM_RETRIES,
+                    "1"))
+            .build();
+    TableMetadataParser.overwrite(modified, fileIO.newOutputFile(metadataLocation));
+
+    Assertions.assertThatThrownBy(() -> catalog.loadTable(tableId))
+        .isInstanceOf(TableMetadataIntegrityException.class)
+        .hasMessageContaining("metadata does not match the trusted catalog digest");
+  }
+
+  @Test
+  public void testRegisterTableOverwriteReadmitsProtectedMetadataRevision() {
+    LocalIcebergCatalog catalog = catalog();
+    Namespace namespace = Namespace.of("metadata_integrity_register_overwrite");
+    TableIdentifier tableId = TableIdentifier.of(namespace, "table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(namespace);
+    }
+
+    Table table =
+        catalog
+            .buildTable(tableId, SCHEMA)
+            .withProperty(TableProperties.FORMAT_VERSION, "3")
+            .withProperty(TableProperties.ENCRYPTION_TABLE_KEY, "key-1")
+            .create();
+    TableMetadata current = ((BaseTable) table).operations().current();
+    String metadataLocation = current.location() + "/metadata/register-readmission.metadata.json";
+    TableMetadata admitted =
+        TableMetadata.buildFrom(current)
+            .setProperties(
+                Map.of(
+                    TableProperties.ENCRYPTION_TABLE_KEY,
+                    "key-1",
+                    TableProperties.COMMIT_NUM_RETRIES,
+                    "1"))
+            .build();
+    TableMetadataParser.write(admitted, fileIO.newOutputFile(metadataLocation));
+
+    Assertions.assertThat(catalog.registerTable(tableId, metadataLocation, true)).isNotNull();
+    Assertions.assertThat(catalog.loadTable(tableId).properties())
+        .containsEntry(TableProperties.COMMIT_NUM_RETRIES, "1");
+
+    TableMetadata modified =
+        TableMetadata.buildFrom(admitted)
+            .setProperties(
+                Map.of(
+                    TableProperties.ENCRYPTION_TABLE_KEY,
+                    "key-1",
+                    TableProperties.COMMIT_NUM_RETRIES,
+                    "2"))
+            .build();
+    TableMetadataParser.overwrite(modified, fileIO.newOutputFile(metadataLocation));
+
+    Assertions.assertThatThrownBy(() -> catalog.loadTable(tableId))
+        .isInstanceOf(TableMetadataIntegrityException.class)
+        .hasMessageContaining("metadata does not match the trusted catalog digest");
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/TableMetadataIntegrityTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/TableMetadataIntegrityTest.java
@@ -1,0 +1,358 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.GenericStatisticsFile;
+import org.apache.iceberg.ImmutableGenericPartitionStatisticsFile;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotParser;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.encryption.BaseEncryptedKey;
+import org.apache.iceberg.inmemory.InMemoryFileIO;
+import org.apache.iceberg.types.Types;
+import org.apache.polaris.core.entity.PolarisEntitySubType;
+import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
+import org.junit.jupiter.api.Test;
+
+class TableMetadataIntegrityTest {
+  private static final String KEY_ID = "test-key";
+
+  @Test
+  void pinsAndValidatesEncryptedMetadata() {
+    TableMetadata metadata = metadata(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, KEY_ID));
+    Map<String, String> trustedProperties = pinnedProperties(KEY_ID);
+
+    TableMetadataIntegrity.pin(trustedProperties, metadata);
+
+    assertThat(trustedProperties)
+        .containsEntry(
+            TableMetadataIntegrity.METADATA_HASH_PROPERTY,
+            TableMetadataIntegrity.metadataHash(metadata))
+        .containsEntry(
+            TableMetadataIntegrity.METADATA_HASH_VERSION_PROPERTY,
+            TableMetadataIntegrity.METADATA_HASH_VERSION);
+    assertThatCode(() -> TableMetadataIntegrity.validate(entity(trustedProperties), metadata))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void doesNotPinPlaintextMetadata() {
+    Map<String, String> trustedProperties = pinnedProperties(null);
+    trustedProperties.put(TableMetadataIntegrity.METADATA_HASH_PROPERTY, "obsolete");
+
+    TableMetadataIntegrity.pin(trustedProperties, metadata(Map.of()));
+
+    assertThat(trustedProperties).doesNotContainKey(TableMetadataIntegrity.METADATA_HASH_PROPERTY);
+    assertThat(trustedProperties)
+        .doesNotContainKey(TableMetadataIntegrity.METADATA_HASH_VERSION_PROPERTY);
+    assertThatCode(
+            () -> TableMetadataIntegrity.validate(entity(trustedProperties), metadata(Map.of())))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void doesNotEnrollLegacyEncryptedMetadata() {
+    Map<String, String> trustedProperties = new HashMap<>();
+
+    TableMetadataIntegrity.pin(
+        trustedProperties, metadata(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, KEY_ID)));
+
+    assertThat(trustedProperties)
+        .doesNotContainKey(TableMetadataIntegrity.METADATA_HASH_PROPERTY)
+        .doesNotContainKey(TableMetadataIntegrity.METADATA_HASH_VERSION_PROPERTY)
+        .doesNotContainKey(TableMetadataTransitionValidator.KEY_ID_PROPERTY);
+  }
+
+  @Test
+  void rejectsKeyIdAddedToPinnedPlaintextMetadata() {
+    Map<String, String> trustedProperties = pinnedProperties(null);
+    TableMetadata modified = metadata(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, "added-key"));
+
+    assertThatThrownBy(() -> TableMetadataIntegrity.validate(entity(trustedProperties), modified))
+        .isInstanceOf(TableMetadataIntegrityException.class)
+        .hasMessageContaining("Iceberg table metadata integrity check failed for")
+        .hasMessageContaining(": encryption key ID does not match trusted catalog state");
+  }
+
+  @Test
+  void rejectsModifiedEncryptedMetadata() {
+    TableMetadata metadata = metadata(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, KEY_ID));
+    Map<String, String> trustedProperties = pinnedProperties(KEY_ID);
+    TableMetadataIntegrity.pin(trustedProperties, metadata);
+    TableMetadata modified =
+        metadata(
+            Map.of(
+                TableProperties.ENCRYPTION_TABLE_KEY,
+                KEY_ID,
+                TableProperties.COMMIT_NUM_RETRIES,
+                "1"));
+
+    assertThatThrownBy(() -> TableMetadataIntegrity.validate(entity(trustedProperties), modified))
+        .isInstanceOf(TableMetadataIntegrityException.class)
+        .hasMessageContaining("metadata does not match the trusted catalog digest");
+  }
+
+  @Test
+  void rejectsMissingOrInvalidDigestForPinnedEncryptedTable() {
+    Map<String, String> missingDigest = pinnedProperties(KEY_ID);
+
+    assertThatThrownBy(
+            () ->
+                TableMetadataIntegrity.validate(
+                    entity(missingDigest),
+                    metadata(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, KEY_ID))))
+        .isInstanceOf(TableMetadataIntegrityException.class)
+        .hasMessageContaining("trusted catalog state has no metadata digest");
+
+    Map<String, String> invalidDigest = pinnedProperties(KEY_ID);
+    invalidDigest.put(TableMetadataIntegrity.METADATA_HASH_PROPERTY, "not-base64!");
+    invalidDigest.put(
+        TableMetadataIntegrity.METADATA_HASH_VERSION_PROPERTY,
+        TableMetadataIntegrity.METADATA_HASH_VERSION);
+    assertThatThrownBy(
+            () ->
+                TableMetadataIntegrity.validate(
+                    entity(invalidDigest),
+                    metadata(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, KEY_ID))))
+        .isInstanceOf(TableMetadataIntegrityException.class)
+        .hasMessageContaining("trusted catalog state has an invalid metadata digest");
+  }
+
+  @Test
+  void rejectsUnsupportedDigestVersion() {
+    TableMetadata metadata = metadata(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, KEY_ID));
+    Map<String, String> trustedProperties = pinnedProperties(KEY_ID);
+    trustedProperties.put(
+        TableMetadataIntegrity.METADATA_HASH_PROPERTY,
+        TableMetadataIntegrity.metadataHash(metadata));
+    trustedProperties.put(TableMetadataIntegrity.METADATA_HASH_VERSION_PROPERTY, "future-version");
+
+    assertThatThrownBy(() -> TableMetadataIntegrity.validate(entity(trustedProperties), metadata))
+        .isInstanceOf(TableMetadataIntegrityException.class)
+        .hasMessageContaining("trusted catalog state has an unsupported metadata digest version");
+  }
+
+  @Test
+  void leavesLegacyUnpinnedEntityOutsideInvariant() {
+    assertThatCode(
+            () ->
+                TableMetadataIntegrity.validate(
+                    entity(Map.of()),
+                    metadata(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, KEY_ID))))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void canonicalHashIsStableAcrossRealisticMetadataFileRoundTrip() {
+    TableMetadata metadata = realisticEncryptedMetadata();
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    String location = "file:/tmp/table/metadata/v1.metadata.json";
+
+    assertThat(metadata.snapshots()).hasSize(2);
+    assertThat(metadata.snapshotLog()).hasSize(2);
+    assertThat(metadata.previousFiles()).hasSize(2);
+    assertThat(metadata.statisticsFiles()).hasSize(1);
+    assertThat(metadata.partitionStatisticsFiles()).hasSize(1);
+    assertThat(metadata.encryptionKeys()).hasSize(2);
+    assertThat(metadata.nextRowId()).isEqualTo(15L);
+
+    TableMetadataParser.write(metadata, fileIO.newOutputFile(location));
+    TableMetadata parsed = TableMetadataParser.read(fileIO, location);
+
+    assertThat(TableMetadataIntegrity.metadataHash(parsed))
+        .isEqualTo(TableMetadataIntegrity.metadataHash(metadata));
+  }
+
+  @Test
+  void rejectsModifiedEncryptionKeys() {
+    TableMetadata metadata = realisticEncryptedMetadata();
+    Map<String, String> trustedProperties = pinnedProperties(KEY_ID);
+    TableMetadataIntegrity.pin(trustedProperties, metadata);
+
+    TableMetadata modified =
+        TableMetadata.buildFrom(metadata)
+            .addEncryptionKey(
+                new BaseEncryptedKey(
+                    "data-key-3",
+                    ByteBuffer.wrap(new byte[] {7, 8, 9}),
+                    KEY_ID,
+                    Map.of("algorithm", "AES-GCM")))
+            .build();
+
+    assertThatThrownBy(() -> TableMetadataIntegrity.validate(entity(trustedProperties), modified))
+        .isInstanceOf(TableMetadataIntegrityException.class)
+        .hasMessageContaining("metadata does not match the trusted catalog digest");
+  }
+
+  @Test
+  void canonicalHashV1MatchesGoldenMetadata() throws IOException {
+    String resource = "/table-metadata-integrity-v1.json";
+    String json;
+    try (InputStream input = TableMetadataIntegrityTest.class.getResourceAsStream(resource)) {
+      assertThat(input).as(resource).isNotNull();
+      json = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    TableMetadata metadata = TableMetadataParser.fromJson(json);
+
+    assertThat(metadata.schemas()).hasSize(2);
+    assertThat(metadata.specs()).hasSize(1);
+    assertThat(metadata.sortOrders()).hasSize(1);
+    assertThat(metadata.refs()).containsKeys("main", "audit");
+    assertThat(metadata.statisticsFiles().getFirst().blobMetadata()).hasSize(1);
+    assertThat(metadata.encryptionKeys()).hasSize(2);
+    // This pins the v1 contract across Iceberg upgrades. Do not regenerate it mechanically.
+    assertThat(TableMetadataIntegrity.metadataHash(metadata))
+        .isEqualTo("C0vt/i/y4k0B6anvnLNc+vHQSqgO4qcAxP1tCssbyAg=");
+  }
+
+  private static TableMetadata realisticEncryptedMetadata() {
+    TableMetadata base =
+        metadata(
+            Map.of(
+                TableProperties.ENCRYPTION_TABLE_KEY,
+                KEY_ID,
+                TableProperties.METADATA_PREVIOUS_VERSIONS_MAX,
+                "10"));
+
+    TableMetadata withFirstMetadataLogEntry =
+        TableMetadata.buildFrom(base)
+            .setPreviousFileLocation("file:/tmp/table/metadata/v0.metadata.json")
+            .setProperties(Map.of("test.revision", "1"))
+            .build();
+
+    Snapshot firstSnapshot =
+        SnapshotParser.fromJson(
+            """
+            {
+              "sequence-number": 1,
+              "snapshot-id": 101,
+              "timestamp-ms": 1000,
+              "summary": {
+                "operation": "append",
+                "added-data-files": "1"
+              },
+              "manifest-list": "file:/tmp/table/metadata/snap-101.avro",
+              "schema-id": 0,
+              "first-row-id": 0,
+              "added-rows": 10,
+              "key-id": "data-key-1"
+            }
+            """);
+
+    Snapshot secondSnapshot =
+        SnapshotParser.fromJson(
+            """
+            {
+              "sequence-number": 2,
+              "snapshot-id": 102,
+              "parent-snapshot-id": 101,
+              "timestamp-ms": 2000,
+              "summary": {
+                "operation": "append",
+                "added-data-files": "1"
+              },
+              "manifest-list": "file:/tmp/table/metadata/snap-102.avro",
+              "schema-id": 0,
+              "first-row-id": 10,
+              "added-rows": 5,
+              "key-id": "data-key-2"
+            }
+            """);
+
+    TableMetadata withFirstSnapshot =
+        TableMetadataParser.fromJson(
+            TableMetadataParser.toJson(
+                TableMetadata.buildFrom(withFirstMetadataLogEntry)
+                    .setBranchSnapshot(firstSnapshot, SnapshotRef.MAIN_BRANCH)
+                    .build()));
+
+    return TableMetadata.buildFrom(withFirstSnapshot)
+        .setPreviousFileLocation("file:/tmp/table/metadata/v1.metadata.json")
+        .setBranchSnapshot(secondSnapshot, SnapshotRef.MAIN_BRANCH)
+        .setStatistics(
+            new GenericStatisticsFile(
+                102L, "file:/tmp/table/metadata/stats-102.puffin", 128L, 1L, List.of()))
+        .setPartitionStatistics(
+            ImmutableGenericPartitionStatisticsFile.builder()
+                .snapshotId(102L)
+                .path("file:/tmp/table/metadata/partition-stats-102.parquet")
+                .fileSizeInBytes(256L)
+                .build())
+        .addEncryptionKey(
+            new BaseEncryptedKey(
+                "data-key-1",
+                ByteBuffer.wrap(new byte[] {1, 2, 3}),
+                KEY_ID,
+                Map.of("algorithm", "AES-GCM")))
+        .addEncryptionKey(
+            new BaseEncryptedKey(
+                "data-key-2",
+                ByteBuffer.wrap(new byte[] {4, 5, 6}),
+                KEY_ID,
+                Map.of("algorithm", "AES-GCM")))
+        .build();
+  }
+
+  private static Map<String, String> pinnedProperties(String keyId) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY, "true");
+    if (keyId != null) {
+      properties.put(TableMetadataTransitionValidator.KEY_ID_PROPERTY, keyId);
+    }
+    return properties;
+  }
+
+  private static TableMetadata metadata(Map<String, String> properties) {
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+    Map<String, String> tableProperties = new HashMap<>(properties);
+    if (tableProperties.containsKey(TableProperties.ENCRYPTION_TABLE_KEY)) {
+      tableProperties.put(TableProperties.FORMAT_VERSION, "3");
+    }
+    return TableMetadata.newTableMetadata(
+        schema, PartitionSpec.unpartitioned(), "file:/tmp/table", tableProperties);
+  }
+
+  private static IcebergTableLikeEntity entity(Map<String, String> properties) {
+    return new IcebergTableLikeEntity.Builder(
+            PolarisEntitySubType.ICEBERG_TABLE,
+            TableIdentifier.of("namespace", "table"),
+            Map.of(),
+            properties,
+            "file:/tmp/table/metadata/v1.metadata.json")
+        .build();
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/TableMetadataTransitionValidatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/TableMetadataTransitionValidatorTest.java
@@ -88,7 +88,7 @@ class TableMetadataTransitionValidatorTest {
             () ->
                 TableMetadataTransitionValidator.validateLoaded(
                     pinned(pinnedKeyId), metadata(loadedProperties)))
-        .isInstanceOf(IllegalStateException.class)
+        .isInstanceOf(TableMetadataIntegrityException.class)
         .hasMessage(
             "Iceberg table metadata integrity check failed for test.metadata.json: encryption key "
                 + "ID does not match trusted catalog state");

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/TableMetadataTransitionValidatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/TableMetadataTransitionValidatorTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TableMetadataTransitionValidatorTest {
+  private static final String KEY_ID = TableProperties.ENCRYPTION_TABLE_KEY;
+
+  @Test
+  void allowsLegacyTableWithKeyIdToRemainOutsideInvariant() {
+    assertThatCode(
+            () ->
+                TableMetadataTransitionValidator.validate(
+                    Map.of(), metadata(Map.of(KEY_ID, "key-1"))))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void allowsLegacyTableWithoutKeyIdToRemainOutsideInvariant() {
+    assertThatCode(() -> TableMetadataTransitionValidator.validate(Map.of(), metadata(Map.of())))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void allowsUnchangedPinnedKeyId() {
+    assertThatCode(
+            () ->
+                TableMetadataTransitionValidator.validate(
+                    pinned("key-1"), metadata(Map.of(KEY_ID, "key-1"))))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void allowsUnchangedPinnedMissingKeyId() {
+    assertThatCode(
+            () -> TableMetadataTransitionValidator.validate(pinned(null), metadata(Map.of())))
+        .doesNotThrowAnyException();
+  }
+
+  @ParameterizedTest
+  @MethodSource("changedKeyIds")
+  void rejectsChangedPinnedKeyId(String pinnedKeyId, Map<String, String> newProperties) {
+    assertThatThrownBy(
+            () ->
+                TableMetadataTransitionValidator.validate(
+                    pinned(pinnedKeyId), metadata(newProperties)))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Cannot add, change, or remove encryption key ID after table creation");
+  }
+
+  @ParameterizedTest
+  @MethodSource("changedKeyIds")
+  void rejectsLoadedMetadataWithChangedPinnedKeyId(
+      String pinnedKeyId, Map<String, String> loadedProperties) {
+    assertThatThrownBy(
+            () ->
+                TableMetadataTransitionValidator.validateLoaded(
+                    pinned(pinnedKeyId), metadata(loadedProperties)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Iceberg table metadata integrity check failed for test.metadata.json: encryption key "
+                + "ID does not match trusted catalog state");
+  }
+
+  @Test
+  void allowsLoadedMetadataWithPinnedMissingKeyId() {
+    assertThatCode(
+            () -> TableMetadataTransitionValidator.validateLoaded(pinned(null), metadata(Map.of())))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void leavesLoadedLegacyMetadataOutsideInvariant() {
+    assertThatCode(
+            () ->
+                TableMetadataTransitionValidator.validateLoaded(
+                    Map.of(), metadata(Map.of(KEY_ID, "key-1"))))
+        .doesNotThrowAnyException();
+  }
+
+  private static Stream<Arguments> changedKeyIds() {
+    return Stream.of(
+        Arguments.of(null, Map.of(KEY_ID, "key-1")),
+        Arguments.of("key-1", Map.of(KEY_ID, "key-2")),
+        Arguments.of("key-1", Map.of()));
+  }
+
+  @Test
+  void pinsPresentKeyId() {
+    Map<String, String> trustedProperties = new HashMap<>();
+
+    TableMetadataTransitionValidator.pin(trustedProperties, metadata(Map.of(KEY_ID, "key-1")));
+
+    assertThat(trustedProperties)
+        .containsEntry(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY, "true")
+        .containsEntry(TableMetadataTransitionValidator.KEY_ID_PROPERTY, "key-1")
+        .doesNotContainKey(KEY_ID);
+  }
+
+  @Test
+  void pinsMissingKeyId() {
+    Map<String, String> trustedProperties =
+        new HashMap<>(Map.of(TableMetadataTransitionValidator.KEY_ID_PROPERTY, "old-key"));
+
+    TableMetadataTransitionValidator.pin(trustedProperties, metadata(Map.of()));
+
+    assertThat(trustedProperties)
+        .containsEntry(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY, "true")
+        .doesNotContainKey(TableMetadataTransitionValidator.KEY_ID_PROPERTY);
+  }
+
+  @Test
+  void rejectsIncompatibleEncryptionPropertiesBeforePinning() {
+    Map<String, String> trustedProperties = new HashMap<>();
+
+    assertThatThrownBy(
+            () ->
+                TableMetadataTransitionValidator.pin(
+                    trustedProperties, metadata(2, Map.of(KEY_ID, "key-1"))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid properties for v2")
+        .hasMessageContaining(KEY_ID);
+    assertThat(trustedProperties).isEmpty();
+  }
+
+  private static Map<String, String> pinned(String keyId) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(TableMetadataTransitionValidator.KEY_ID_PINNED_PROPERTY, "true");
+    if (keyId != null) {
+      properties.put(TableMetadataTransitionValidator.KEY_ID_PROPERTY, keyId);
+    }
+    return properties;
+  }
+
+  private static TableMetadata metadata(Map<String, String> properties) {
+    return metadata(3, properties);
+  }
+
+  private static TableMetadata metadata(int formatVersion, Map<String, String> properties) {
+    TableMetadata metadata = mock(TableMetadata.class);
+    when(metadata.formatVersion()).thenReturn(formatVersion);
+    when(metadata.metadataFileLocation()).thenReturn("test.metadata.json");
+    when(metadata.properties()).thenReturn(properties);
+    return metadata;
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.polaris.core.exceptions.FileIOUnknownHostException;
+import org.apache.polaris.service.catalog.iceberg.TableMetadataIntegrityException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -70,6 +71,7 @@ public class IcebergExceptionMapperTest {
                     "mybucket.blob.core.windows.net: Name or service not known",
                     new RuntimeException(new UnknownHostException())),
                 404),
+            Arguments.of(new TableMetadataIntegrityException("metadata digest mismatch"), 422),
             Arguments.of(new RuntimeException("Error persisting entity"), 500)),
         cloudCodeMappings.entrySet().stream()
             .flatMap(

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TableCleanupTaskHandlerTest.java
@@ -27,13 +27,17 @@ import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import java.io.IOException;
 import java.time.Clock;
+import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
@@ -51,6 +55,7 @@ import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.pagination.PageToken;
+import org.apache.polaris.service.catalog.iceberg.TableMetadataIntegrityException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -146,6 +151,109 @@ class TableCleanupTaskHandlerTest {
                         entity ->
                             entity.readData(
                                 BatchFileCleanupTaskHandler.BatchFileCleanupTask.class)));
+  }
+
+  @Test
+  public void testTableCleanupRejectsModifiedMetadata() throws IOException {
+    FileIO fileIO =
+        new InMemoryFileIO() {
+          @Override
+          public void close() {
+            // Keep the in-memory store open so the assertion can verify that purge did not delete
+            // it.
+          }
+        };
+    TableIdentifier tableIdentifier = TableIdentifier.of("db1", "table1");
+    TableCleanupTaskHandler handler = newTableCleanupTaskHandler(fileIO);
+    String metadataFile = "v1-invalid-digest.metadata.json";
+    TableMetadata plaintextMetadata = TaskTestUtils.writeTableMetadata(fileIO, metadataFile);
+    TableMetadata encryptedMetadata =
+        TableMetadata.buildFrom(plaintextMetadata)
+            .setProperties(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, "test-key"))
+            .build();
+    TableMetadataParser.overwrite(encryptedMetadata, fileIO.newOutputFile(metadataFile));
+    Map<String, String> trustedProperties =
+        Map.of(
+            "polaris.encryption.key-id-pinned",
+            "true",
+            "polaris.encryption.key-id",
+            "test-key",
+            "polaris.encryption.metadata-hash",
+            Base64.getEncoder().encodeToString(new byte[32]),
+            "polaris.encryption.metadata-hash-version",
+            "iceberg-canonical-json-sha256-v1");
+
+    TaskEntity task =
+        new TaskEntity.Builder()
+            .setName("cleanup_" + tableIdentifier)
+            .withTaskType(AsyncTaskType.ENTITY_CLEANUP_SCHEDULER)
+            .withData(
+                new IcebergTableLikeEntity.Builder(
+                        PolarisEntitySubType.ICEBERG_TABLE,
+                        tableIdentifier,
+                        Map.of(),
+                        trustedProperties,
+                        metadataFile)
+                    .setName("table1")
+                    .setCatalogId(1)
+                    .setCreateTimestamp(100)
+                    .build())
+            .build();
+
+    Assertions.assertThatThrownBy(() -> handler.handleTask(addTaskLocation(task), callContext))
+        .isInstanceOf(NonRetryableTaskException.class)
+        .hasMessage("Table cleanup stopped because metadata failed integrity validation")
+        .cause()
+        .isInstanceOf(TableMetadataIntegrityException.class)
+        .hasMessageContaining("metadata does not match the trusted catalog digest");
+    assertThat(fileIO.newInputFile(metadataFile).exists()).isTrue();
+  }
+
+  @Test
+  public void testTableCleanupRejectsKeyIdAddedToPinnedPlaintextMetadata() throws IOException {
+    FileIO fileIO =
+        new InMemoryFileIO() {
+          @Override
+          public void close() {
+            // Keep the in-memory store open so the assertion can verify that purge did not delete
+            // it.
+          }
+        };
+    TableIdentifier tableIdentifier = TableIdentifier.of("db1", "table1");
+    TableCleanupTaskHandler handler = newTableCleanupTaskHandler(fileIO);
+    String metadataFile = "v1-added-key-id.metadata.json";
+    TableMetadata plaintextMetadata = TaskTestUtils.writeTableMetadata(fileIO, metadataFile);
+    TableMetadata modifiedMetadata =
+        TableMetadata.buildFrom(plaintextMetadata)
+            .setProperties(Map.of(TableProperties.ENCRYPTION_TABLE_KEY, "added-key"))
+            .build();
+    TableMetadataParser.overwrite(modifiedMetadata, fileIO.newOutputFile(metadataFile));
+
+    TaskEntity task =
+        new TaskEntity.Builder()
+            .setName("cleanup_" + tableIdentifier)
+            .withTaskType(AsyncTaskType.ENTITY_CLEANUP_SCHEDULER)
+            .withData(
+                new IcebergTableLikeEntity.Builder(
+                        PolarisEntitySubType.ICEBERG_TABLE,
+                        tableIdentifier,
+                        Map.of(),
+                        Map.of("polaris.encryption.key-id-pinned", "true"),
+                        metadataFile)
+                    .setName("table1")
+                    .setCatalogId(1)
+                    .setCreateTimestamp(100)
+                    .build())
+            .build();
+
+    Assertions.assertThatThrownBy(() -> handler.handleTask(addTaskLocation(task), callContext))
+        .isInstanceOf(NonRetryableTaskException.class)
+        .hasMessage("Table cleanup stopped because metadata failed integrity validation")
+        .cause()
+        .isInstanceOf(TableMetadataIntegrityException.class)
+        .hasMessageContaining("Iceberg table metadata integrity check failed for")
+        .hasMessageContaining(": encryption key ID does not match trusted catalog state");
+    assertThat(fileIO.newInputFile(metadataFile).exists()).isTrue();
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/task/TaskExecutorImplTest.java
@@ -26,6 +26,7 @@ import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.AsyncTaskType;
+import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.TaskEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.service.TestServices;
@@ -290,5 +291,66 @@ public class TaskExecutorImplTest {
 
     // We verify at least the first call happened (throw leads to exception path).
     assertThat(handlerCalls.get()).isGreaterThanOrEqualTo(1);
+  }
+
+  @Test
+  void asyncNonRetryableFailureStopsAfterFirstAttemptAndKeepsTask() {
+    String realm = "myrealm";
+    RealmContext realmContext = () -> realm;
+    TestServices testServices = TestServices.builder().realmContext(realmContext).build();
+    PolarisMetaStoreManager metaStoreManager = testServices.metaStoreManager();
+    PolarisCallContext polarisCallCtx = testServices.newCallContext();
+
+    TaskEntity taskEntity =
+        new TaskEntity.Builder()
+            .setName("non-retryable-task")
+            .setId(metaStoreManager.generateNewEntityId(polarisCallCtx).getId())
+            .setCreateTimestamp(testServices.clock().millis())
+            .build();
+    metaStoreManager.createEntityIfNotExists(polarisCallCtx, null, taskEntity);
+
+    AtomicInteger handlerCalls = new AtomicInteger();
+    TaskExecutorImpl executor =
+        new TaskExecutorImpl(
+            Runnable::run,
+            null,
+            testServices.clock(),
+            testServices.metaStoreManagerFactory(),
+            new TaskFileIOSupplier(
+                testServices.fileIOFactory(), testServices.storageAccessConfigProvider()),
+            new RealmContextHolder(),
+            testServices.polarisEventDispatcher(),
+            testServices.eventMetadataFactory(),
+            null,
+            new PolarisPrincipalHolder(),
+            testServices.principal());
+    executor.addTaskHandler(
+        new TaskHandler() {
+          @Override
+          public boolean canHandleTask(TaskEntity task) {
+            return true;
+          }
+
+          @Override
+          public void handleTask(TaskEntity task, CallContext callContext) {
+            handlerCalls.incrementAndGet();
+            throw new NonRetryableTaskException(
+                "deterministic failure", new IllegalStateException("invalid trusted state"));
+          }
+        });
+
+    executor.addTaskHandlerContext(taskEntity.getId(), polarisCallCtx);
+
+    assertThat(handlerCalls).hasValue(1);
+    assertThat(
+            metaStoreManager
+                .loadEntity(polarisCallCtx, 0L, taskEntity.getId(), PolarisEntityType.TASK)
+                .getEntity())
+        .isNotNull();
+    PolarisEvent afterEvent =
+        ((InMemoryEventCollector) testServices.polarisEventDispatcher())
+            .getLatest(PolarisEventType.AFTER_ATTEMPT_TASK);
+    assertThat(afterEvent.attributes().getRequired(EventAttributes.TASK_ATTEMPT)).isEqualTo(1);
+    assertThat(afterEvent.attributes().getRequired(EventAttributes.TASK_SUCCESS)).isFalse();
   }
 }

--- a/runtime/service/src/test/resources/table-metadata-integrity-v1.json
+++ b/runtime/service/src/test/resources/table-metadata-integrity-v1.json
@@ -1,0 +1,204 @@
+{
+  "format-version": 3,
+  "table-uuid": "11111111-2222-3333-4444-555555555555",
+  "location": "s3://bucket/table",
+  "last-sequence-number": 2,
+  "last-updated-ms": 1700000002000,
+  "last-column-id": 3,
+  "next-row-id": 15,
+  "current-schema-id": 1,
+  "schemas": [
+    {
+      "type": "struct",
+      "schema-id": 0,
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": true,
+          "type": "long"
+        }
+      ]
+    },
+    {
+      "type": "struct",
+      "schema-id": 1,
+      "identifier-field-ids": [
+        1
+      ],
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": true,
+          "type": "long"
+        },
+        {
+          "id": 2,
+          "name": "y",
+          "required": false,
+          "type": "string",
+          "doc": "comment"
+        },
+        {
+          "id": 3,
+          "name": "z",
+          "required": true,
+          "type": "int"
+        }
+      ]
+    }
+  ],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    }
+  ],
+  "last-partition-id": 1000,
+  "default-sort-order-id": 3,
+  "sort-orders": [
+    {
+      "order-id": 3,
+      "fields": [
+        {
+          "transform": "identity",
+          "source-id": 2,
+          "direction": "asc",
+          "null-order": "nulls-first"
+        },
+        {
+          "transform": "bucket[4]",
+          "source-id": 3,
+          "direction": "desc",
+          "null-order": "nulls-last"
+        }
+      ]
+    }
+  ],
+  "properties": {
+    "encryption.key-id": "test-key",
+    "write.metadata.previous-versions-max": "10"
+  },
+  "current-snapshot-id": 102,
+  "refs": {
+    "main": {
+      "snapshot-id": 102,
+      "type": "branch",
+      "min-snapshots-to-keep": 2,
+      "max-snapshot-age-ms": 86400000,
+      "max-ref-age-ms": 604800000
+    },
+    "audit": {
+      "snapshot-id": 101,
+      "type": "tag",
+      "max-ref-age-ms": 604800000
+    }
+  },
+  "snapshots": [
+    {
+      "sequence-number": 1,
+      "snapshot-id": 101,
+      "timestamp-ms": 1700000001000,
+      "summary": {
+        "operation": "append",
+        "added-data-files": "1"
+      },
+      "manifest-list": "s3://bucket/table/metadata/snap-101.avro",
+      "schema-id": 1,
+      "first-row-id": 0,
+      "added-rows": 10,
+      "key-id": "data-key-1"
+    },
+    {
+      "sequence-number": 2,
+      "snapshot-id": 102,
+      "parent-snapshot-id": 101,
+      "timestamp-ms": 1700000002000,
+      "summary": {
+        "operation": "append",
+        "added-data-files": "1"
+      },
+      "manifest-list": "s3://bucket/table/metadata/snap-102.avro",
+      "schema-id": 1,
+      "first-row-id": 10,
+      "added-rows": 5,
+      "key-id": "data-key-2"
+    }
+  ],
+  "statistics": [
+    {
+      "snapshot-id": 102,
+      "statistics-path": "s3://bucket/table/metadata/stats-102.puffin",
+      "file-size-in-bytes": 128,
+      "file-footer-size-in-bytes": 16,
+      "blob-metadata": [
+        {
+          "type": "ndv",
+          "snapshot-id": 102,
+          "sequence-number": 2,
+          "fields": [
+            1,
+            2
+          ],
+          "properties": {
+            "algorithm": "theta"
+          }
+        }
+      ]
+    }
+  ],
+  "partition-statistics": [
+    {
+      "snapshot-id": 102,
+      "statistics-path": "s3://bucket/table/metadata/partition-stats-102.parquet",
+      "file-size-in-bytes": 256
+    }
+  ],
+  "encryption-keys": [
+    {
+      "key-id": "data-key-1",
+      "encrypted-key-metadata": "AQID",
+      "encrypted-by-id": "test-key",
+      "properties": {
+        "algorithm": "AES-GCM"
+      }
+    },
+    {
+      "key-id": "data-key-2",
+      "encrypted-key-metadata": "BAUG",
+      "encrypted-by-id": "test-key",
+      "properties": {
+        "algorithm": "AES-GCM"
+      }
+    }
+  ],
+  "snapshot-log": [
+    {
+      "snapshot-id": 101,
+      "timestamp-ms": 1700000001000
+    },
+    {
+      "snapshot-id": 102,
+      "timestamp-ms": 1700000002000
+    }
+  ],
+  "metadata-log": [
+    {
+      "timestamp-ms": 1699999999000,
+      "metadata-file": "s3://bucket/table/metadata/v0.metadata.json"
+    },
+    {
+      "timestamp-ms": 1700000001000,
+      "metadata-file": "s3://bucket/table/metadata/v1.metadata.json"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Store a versioned canonical SHA-256 digest for protected encrypted Iceberg metadata in trusted Polaris internal entity state.
- Verify the key-ID pin and digest when metadata is loaded and before asynchronous cleanup traverses it.
- Define register new and missing-table notification as authorized trust-on-first-use admissions.
- Define register overwrite as `TABLE_FULL_METADATA`-authorized re-admission after key-ID validation.
- Reject notification updates of existing protected encrypted tables until an authenticated expected digest can be bound to the request.
- Map integrity failures to non-retryable HTTP 422 responses and stop asynchronous cleanup without deleting storage when verification fails.

This implements the metadata-integrity alternative in Iceberg's [catalog security requirements](https://iceberg.apache.org/docs/nightly/encryption/#catalog-security-requirements) for deployments where plaintext `metadata.json` is held in storage that must not be treated as authoritative. The digest construction follows Iceberg HiveCatalog: canonical `TableMetadataParser` JSON, UTF-8 SHA-256, and Base64 storage outside the metadata file.

## Stack

This is **2/2** of a stacked change and depends on the key-ID pinning PR: https://github.com/apache/polaris/pull/5185.

Both PRs target `main` because their head branches are in an external fork. The branch for this PR contains the first PR's commit followed by one metadata-integrity commit. Until the first PR lands, the incremental second-layer diff is:

https://github.com/hkwi/polaris/compare/upstream/enforce-immutable-encryption-key-id...upstream/enforce-encrypted-metadata-integrity

After the first PR is merged, this head branch will need to be updated against the resulting `main` history so that this PR contains only the metadata-integrity layer. This follow-up Git operation is required because the fork-only parent branch cannot be selected as the base of a PR in `apache/polaris`.

## Guarantee and compatibility boundary

- New protected encrypted tables atomically store the pin marker, exact key ID, metadata pointer, digest, and digest version.
- Protected encrypted state with a missing or unsupported digest fails closed.
- Existing unpinned tables retain legacy behavior without automatic digest backfill.
- Direct object-storage rereads by clients that ignore inline REST metadata remain outside the guarantee.

## Verification

- `./gradlew format compileAll`
- Runtime-service checkstyle passed.
- All 22,103 runtime-service unit tests passed (0 failures, 0 errors, 43 skipped).
- Runtime-service integration tests fail before test execution in the common Quarkus `TestHTTPResourceManager` initialization path; all 28 suites report the same `ParameterResolutionException` caused by the NPE at `TestHTTPResourceManager.java:190`.

## Checklist

- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: related to #2829 and complementary to #5060
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed): not needed for internal catalog invariants
