### PR TITLE
Fix setup policy content round trips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 ### Fixes
 - The NoSQL persistence commit log (`Commits.commitLog`) no longer stops early when a commit's recent-ancestor tail is shorter than the internal fetch page size. With a `polaris.persistence.reference-previous-head-count` smaller than the page size, the natural-order commit log previously truncated at the first short tail because trailing null entries in the fetch page were treated as end-of-history, which could also drop still-referenced objects during maintenance.
 - Python CLI REPL now shows a clear "Syntax error" message for malformed input instead of a generic "unexpected error" message.
+- Python CLI `setup apply` no longer double-encodes policy content emitted by `setup export`, so
+  exported configurations containing policies can be restored.
 - Python CLI `setup export` now includes nested namespaces and policy definitions from those
   namespaces. Previously, only top-level namespaces and their policies were exported.
 - Python CLI `setup export` now exits with an error without emitting partial YAML if any required

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -1355,7 +1355,12 @@ class SetupCommand(Command):
                             "content" in policy_data
                             and policy_data["content"] is not None
                         ):
-                            policy_content_str = json.dumps(policy_data["content"])
+                            policy_content = policy_data["content"]
+                            policy_content_str = (
+                                policy_content
+                                if isinstance(policy_content, str)
+                                else json.dumps(policy_content)
+                            )
                         elif "file" in policy_data:
                             if self.setup_config is None:
                                 logger.error(

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -20,10 +20,14 @@
 import io
 from types import SimpleNamespace
 from unittest.mock import call, patch, MagicMock, mock_open
+
+import yaml
+
 from cli_test_utils import CLITestBase, INVALID_ARGS
 from apache_polaris.cli.command.setup import SetupCommand
 from apache_polaris.cli.constants import Subcommands, UNIT_SEPARATOR
 from apache_polaris.cli.exceptions import CliError, CLI_ERROR_EXIT_CODE
+from apache_polaris.sdk.catalog.exceptions import NotFoundException
 from apache_polaris.sdk.management import (
     PolarisCatalog,
     CatalogProperties,
@@ -192,6 +196,10 @@ class TestSetupCommand(CLITestBase):
 
         self.assertEqual(command._failure_count, 0)
         mock_policy_api.return_value.create_policy.assert_called_once()
+        request = mock_policy_api.return_value.create_policy.call_args.kwargs[
+            "create_policy_request"
+        ]
+        self.assertEqual(request.content, "{}")
 
     @patch("apache_polaris.cli.command.setup.os.path.isfile")
     def test_setup_apply_s3_optional_fields(self, mock_isfile: MagicMock) -> None:
@@ -417,6 +425,48 @@ class TestSetupCommand(CLITestBase):
                 ),
             ]
         )
+
+    @patch("apache_polaris.cli.command.setup.PolicyAPI")
+    def test_setup_exported_policy_content_round_trips_through_apply(
+        self, mock_policy_api_class: MagicMock
+    ) -> None:
+        policy_content = '{"version":"2025-02-03","enable":true}'
+        policy_api = mock_policy_api_class.return_value
+        policy_api.list_policies.return_value = SimpleNamespace(
+            identifiers=[SimpleNamespace(name="compaction")]
+        )
+        policy_api.load_policy.side_effect = [
+            SimpleNamespace(
+                policy=SimpleNamespace(
+                    content=policy_content,
+                    policy_type="system.data-compaction",
+                    description=None,
+                )
+            ),
+            NotFoundException(),
+        ]
+
+        export_command = SetupCommand(
+            setup_subcommand=Subcommands.EXPORT,
+            _catalog_api=MagicMock(),
+        )
+        exported_policies = export_command._export_policies_for_catalog(
+            MagicMock(), "catalog", [["namespace"]]
+        )
+        loaded_config = yaml.safe_load(yaml.safe_dump({"policies": exported_policies}))
+
+        apply_command = SetupCommand(
+            setup_subcommand=Subcommands.APPLY,
+            _catalog_api=MagicMock(),
+        )
+        apply_command._create_policies_and_attachments(
+            MagicMock(),
+            "catalog",
+            loaded_config["policies"],
+        )
+
+        request = policy_api.create_policy.call_args.kwargs["create_policy_request"]
+        self.assertEqual(request.content, policy_content)
 
     def test_setup_export_reports_top_level_read_failures(self) -> None:
         for method_name in (


### PR DESCRIPTION
## Summary

- Preserve JSON policy strings emitted by `setup export` when `setup apply` recreates policies.
- Continue serializing mapping-style policy content from handwritten setup files.
- Cover the real export → YAML → apply path with a regression test.

## Current and expected behavior

`setup export` writes the policy API's JSON string as a YAML scalar. `setup apply`
previously passed that scalar through `json.dumps`, turning the policy document into
a JSON string literal rather than restoring the original JSON document.

`setup apply` now passes string content through unchanged and only serializes
structured content. This restores exported policies exactly while preserving the
documented mapping-style setup format.

Fixes #5189

## Validation

- `uv run pytest tests/test_setup_command.py -q`
- `uv run pre-commit run --files apache_polaris/cli/command/setup.py tests/test_setup_command.py`
- `uv run pytest tests/`
- `./gradlew format compileAll`

## Checklist

- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #5189
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
