### PR TITLE
Fix leaking TARGET_ENTITY_CONCURRENTLY_MODIFIED in AtomicOperationMetaStoreManager for renameEntity

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1056,9 +1056,15 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // persist the entity after change. This will update the lastUpdateTimestamp and bump up the
     // version. Indicate that the nameOrParent changed, so that we also update any by-name
     // lookups if applicable
-    PolarisBaseEntity renamedEntityToReturn =
-        this.persistEntityAfterChange(
-            callCtx, ms, refreshEntityToRenameBuilder.build(), true, refreshEntityToRename);
+    PolarisBaseEntity renamedEntityToReturn;
+    try {
+      renamedEntityToReturn =
+          this.persistEntityAfterChange(
+              callCtx, ms, refreshEntityToRenameBuilder.build(), true, refreshEntityToRename);
+    } catch (RetryOnConcurrencyException e) {
+      return new EntityResult(
+          BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED, e.getMessage());
+    }
 
     // TODO: Use post-validation of source and destination parent paths and/or update the
     // BasePersistence interface to support conditions on entities *other* than the main

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1068,9 +1068,15 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // persist the entity after change. This will update the lastUpdateTimestamp and bump up the
     // version. Indicate that the nameOrParent changed, so that we also update any by-name
     // lookups if applicable
-    PolarisBaseEntity renamedEntityToReturn =
-        this.persistEntityAfterChange(
-            callCtx, ms, refreshEntityToRenameBuilder.build(), true, refreshEntityToRename);
+    PolarisBaseEntity renamedEntityToReturn;
+    try {
+      renamedEntityToReturn =
+          this.persistEntityAfterChange(
+              callCtx, ms, refreshEntityToRenameBuilder.build(), true, refreshEntityToRename);
+    } catch (RetryOnConcurrencyException e) {
+      return new EntityResult(
+          BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED, e.getMessage());
+    }
 
     // TODO: Use post-validation of source and destination parent paths and/or update the
     // BasePersistence interface to support conditions on entities *other* than the main

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManagerTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManagerTest.java
@@ -20,8 +20,11 @@ package org.apache.polaris.core.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
@@ -32,16 +35,21 @@ import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisChangeTrackingVersions;
+import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.dao.entity.ResolvedEntityResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-/** Regression tests for {@link AtomicOperationMetaStoreManager#refreshResolvedEntity} (#3836). */
-public class AtomicOperationMetaStoreManagerRefreshTest {
+/**
+ * Unit tests for {@link AtomicOperationMetaStoreManager}, exercising the manager against a mocked
+ * {@link BasePersistence}.
+ */
+public class AtomicOperationMetaStoreManagerTest {
 
   private static final long CATALOG_ID = 100L;
   private static final long ENTITY_ID = 200L;
@@ -182,5 +190,26 @@ public class AtomicOperationMetaStoreManagerRefreshTest {
     assertThat(result.getEntityGrantRecords()).isNotNull();
     Mockito.verify(metaStore).loadAllGrantRecordsOnGrantee(any(), anyLong(), anyLong());
     Mockito.verify(metaStore).loadAllGrantRecordsOnSecurable(any(), anyLong(), anyLong());
+  }
+
+  @Test
+  public void testRenameMapsConcurrentModificationToResultStatus() {
+    PolarisBaseEntity current =
+        new PolarisBaseEntity.Builder(buildEntity(1, 1)).name("my_role").build();
+    PolarisEntity renamed =
+        new PolarisEntity(new PolarisBaseEntity.Builder(current).name("my_role_renamed").build());
+
+    when(metaStore.lookupEntity(any(), anyLong(), anyLong(), anyInt())).thenReturn(current);
+    when(metaStore.lookupEntityIdAndSubTypeByName(
+            any(), anyLong(), anyLong(), anyInt(), anyString()))
+        .thenReturn(null);
+    doThrow(new RetryOnConcurrencyException("entity concurrently modified"))
+        .when(metaStore)
+        .writeEntity(any(), any(), anyBoolean(), any());
+
+    EntityResult result = manager.renameEntity(callCtx, null, current, null, renamed);
+
+    assertThat(result.getReturnStatus())
+        .isEqualTo(BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED);
   }
 }


### PR DESCRIPTION
`renameEntity` in `AtomicOperationMetaStoreManager` already returns `TARGET_ENTITY_CONCURRENTLY_MODIFIED` when the caller's `entityVersion` is stale, but the final persist can still fail with `RetryOnConcurrencyException` from `persistEntityAfterChange` → `writeEntity` when the entity changes between lookup and write (including grant-records-only conflicts, since JDBC optimistic locking checks both entity_version and grant_records_version).
That exception was uncaught, so renames surfaced as `HTTP 500` instead of the `retryable 503`.

This change wraps the persist call in the same try/catch used by `updateEntityPropertiesIfNotChanged`, mapping `RetryOnConcurrencyException` to `EntityResult(TARGET_ENTITY_CONCURRENTLY_MODIFIED, …)`, which `LocalIcebergCatalog.renameTable` already translates to `PolarisServiceUnavailableException (503 + Retry-After)`. A unit test in `AtomicOperationMetaStoreManagerTest` stubs `writeEntity` to throw and verifies the status mapping.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
