### PR TITLE
Place Spark bundle jar LICENSE/NOTICE under META-INF

### DIFF
--- a/plugins/spark/v3.5/spark/build.gradle.kts
+++ b/plugins/spark/v3.5/spark/build.gradle.kts
@@ -244,12 +244,15 @@ val createPolarisSparkJar =
       "META-INF/DEPENDENCIES",
     )
 
-    // add polaris customized LICENSE and NOTICE for the bundle jar at top level. Note that the
+    // add polaris customized LICENSE and NOTICE for the bundle jar under META-INF. Note that the
     // customized LICENSE and NOTICE file are called BUNDLE-LICENSE and BUNDLE-NOTICE,
     // and renamed to LICENSE and NOTICE after include, this is to avoid the file
-    // being excluded due to the exclude pattern matching used above.
-    from("${projectDir}/BUNDLE-LICENSE") { rename { "LICENSE" } }
-    from("${projectDir}/BUNDLE-NOTICE") { rename { "NOTICE" } }
+    // being excluded due to the exclude pattern matching used above (which matches on the
+    // source path, so BUNDLE-LICENSE/BUNDLE-NOTICE are not matched).
+    into("META-INF") {
+      from("${projectDir}/BUNDLE-LICENSE") { rename { "LICENSE" } }
+      from("${projectDir}/BUNDLE-NOTICE") { rename { "NOTICE" } }
+    }
   }
 
 // ensure the shadow jar job (which will automatically run license addition) is run for both
@@ -259,9 +262,11 @@ tasks.named("assemble") { dependsOn(createPolarisSparkJar) }
 tasks.named("build") { dependsOn(createPolarisSparkJar) }
 
 // The `src/main/no-license-notice-marker` file disables the standard META-INF/LICENSE+NOTICE
-// injection for this module, because the shadow bundle jar carries its own root-level
-// BUNDLE-LICENSE/BUNDLE-NOTICE. The main, sources and javadoc jars still need the ASF LICENSE and
-// NOTICE under META-INF, so add them back explicitly for those jars (the bundle jar is left as-is).
+// injection for this module. The bundle jar already provides its own customized
+// BUNDLE-LICENSE/BUNDLE-NOTICE under META-INF (see createPolarisSparkJar above), so it must not
+// also receive the standard injection. The main, sources and javadoc jars, however, still need the
+// ASF LICENSE and NOTICE under META-INF, so add them back explicitly for those jars only (the
+// bundle jar is intentionally left untouched here).
 listOf("jar", "sourcesJar", "javadocJar").forEach { jarTask ->
   tasks.named<Jar>(jarTask) {
     from(layout.settingsDirectory) {

--- a/plugins/spark/v4.0/spark/build.gradle.kts
+++ b/plugins/spark/v4.0/spark/build.gradle.kts
@@ -247,12 +247,15 @@ val createPolarisSparkJar =
       "META-INF/DEPENDENCIES",
     )
 
-    // add polaris customized LICENSE and NOTICE for the bundle jar at top level. Note that the
+    // add polaris customized LICENSE and NOTICE for the bundle jar under META-INF. Note that the
     // customized LICENSE and NOTICE file are called BUNDLE-LICENSE and BUNDLE-NOTICE,
     // and renamed to LICENSE and NOTICE after include, this is to avoid the file
-    // being excluded due to the exclude pattern matching used above.
-    from("${projectDir}/BUNDLE-LICENSE") { rename { "LICENSE" } }
-    from("${projectDir}/BUNDLE-NOTICE") { rename { "NOTICE" } }
+    // being excluded due to the exclude pattern matching used above (which matches on the
+    // source path, so BUNDLE-LICENSE/BUNDLE-NOTICE are not matched).
+    into("META-INF") {
+      from("${projectDir}/BUNDLE-LICENSE") { rename { "LICENSE" } }
+      from("${projectDir}/BUNDLE-NOTICE") { rename { "NOTICE" } }
+    }
   }
 
 // ensure the shadow jar job (which will automatically run license addition) is run for both
@@ -262,9 +265,11 @@ tasks.named("assemble") { dependsOn(createPolarisSparkJar) }
 tasks.named("build") { dependsOn(createPolarisSparkJar) }
 
 // The `src/main/no-license-notice-marker` file disables the standard META-INF/LICENSE+NOTICE
-// injection for this module, because the shadow bundle jar carries its own root-level
-// BUNDLE-LICENSE/BUNDLE-NOTICE. The main, sources and javadoc jars still need the ASF LICENSE and
-// NOTICE under META-INF, so add them back explicitly for those jars (the bundle jar is left as-is).
+// injection for this module. The bundle jar already provides its own customized
+// BUNDLE-LICENSE/BUNDLE-NOTICE under META-INF (see createPolarisSparkJar above), so it must not
+// also receive the standard injection. The main, sources and javadoc jars, however, still need the
+// ASF LICENSE and NOTICE under META-INF, so add them back explicitly for those jars only (the
+// bundle jar is intentionally left untouched here).
 listOf("jar", "sourcesJar", "javadocJar").forEach { jarTask ->
   tasks.named<Jar>(jarTask) {
     from(layout.settingsDirectory) {


### PR DESCRIPTION
## What

The Spark bundle jars (v3.5 and v4.0) previously copied the customized `BUNDLE-LICENSE`/`BUNDLE-NOTICE` files to the jar **root** as `LICENSE`/`NOTICE`. This change places them under `META-INF/LICENSE` and `META-INF/NOTICE` instead.

## Why

`META-INF/LICENSE` and `META-INF/NOTICE` is the conventional location for license/notice files inside a jar.

## Notes

The `createPolarisSparkJar` `exclude` patterns match on the *source* path (`BUNDLE-LICENSE`/`BUNDLE-NOTICE`), so placing the renamed files under `META-INF` does not trigger the `META-INF/**/*LICENSE*` / `META-INF/**/*NOTICE*` exclusions.

The comment explaining the `no-license-notice-marker` mechanism was also reworded to reflect the new location.

Verified by building both bundle jars: each now contains `META-INF/LICENSE` and `META-INF/NOTICE` with nothing at the jar root.