### PR TITLE
Delegate HTTP status resolution to PolarisException hierarchy

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/exceptions/AlreadyExistsException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/exceptions/AlreadyExistsException.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.core.exceptions;
 
+import jakarta.ws.rs.core.Response;
+
 /**
  * A {@link PolarisException} implementation for when Polaris is unable to create an entity that
  * already exists.
@@ -33,6 +35,6 @@ public class AlreadyExistsException extends PolarisException {
 
   @Override
   public int httpStatusCode() {
-    return 409;
+    return Response.Status.CONFLICT.getStatusCode();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/exceptions/AlreadyExistsException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/exceptions/AlreadyExistsException.java
@@ -30,4 +30,9 @@ public class AlreadyExistsException extends PolarisException {
   public AlreadyExistsException(String message, Throwable cause) {
     super(message, cause);
   }
+
+  @Override
+  public int httpStatusCode() {
+    return 409;
+  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/exceptions/CommitConflictException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/exceptions/CommitConflictException.java
@@ -20,6 +20,7 @@
 package org.apache.polaris.core.exceptions;
 
 import com.google.errorprone.annotations.FormatMethod;
+import jakarta.ws.rs.core.Response;
 
 public class CommitConflictException extends PolarisException {
   public CommitConflictException(String message) {
@@ -42,6 +43,6 @@ public class CommitConflictException extends PolarisException {
 
   @Override
   public int httpStatusCode() {
-    return 409;
+    return Response.Status.CONFLICT.getStatusCode();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/exceptions/CommitConflictException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/exceptions/CommitConflictException.java
@@ -39,4 +39,9 @@ public class CommitConflictException extends PolarisException {
   public CommitConflictException(String message, Throwable cause) {
     super(message, cause);
   }
+
+  @Override
+  public int httpStatusCode() {
+    return 409;
+  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/exceptions/FileIOUnknownHostException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/exceptions/FileIOUnknownHostException.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.core.exceptions;
 
+import jakarta.ws.rs.core.Response;
+
 /**
  * A {@link PolarisException} implementation for when an UnknownHostException happens during File IO
  * to S3, GCS, or Azure.
@@ -25,5 +27,10 @@ package org.apache.polaris.core.exceptions;
 public class FileIOUnknownHostException extends PolarisException {
   public FileIOUnknownHostException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  @Override
+  public int httpStatusCode() {
+    return Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/exceptions/PolarisException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/exceptions/PolarisException.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.core.exceptions;
 
+import jakarta.ws.rs.core.Response;
+
 /**
  * Base class for Polaris-specific runtime exceptions.
  *
@@ -40,6 +42,6 @@ public abstract class PolarisException extends RuntimeException {
    * return a more specific status code.
    */
   public int httpStatusCode() {
-    return 500;
+    return Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/exceptions/PolarisException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/exceptions/PolarisException.java
@@ -22,6 +22,7 @@ package org.apache.polaris.core.exceptions;
  * Base class for Polaris-specific runtime exceptions.
  *
  * <p>All custom exceptions in Polaris should extend this class to provide specific error details.
+ * Subclasses override {@link #httpStatusCode()} to declare their HTTP response status.
  */
 public abstract class PolarisException extends RuntimeException {
 
@@ -31,5 +32,14 @@ public abstract class PolarisException extends RuntimeException {
 
   public PolarisException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  /**
+   * Returns the HTTP status code that should be used when this exception is mapped to an HTTP
+   * response. Defaults to {@code 500} (Internal Server Error). Subclasses should override this to
+   * return a more specific status code.
+   */
+  public int httpStatusCode() {
+    return 500;
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/exceptions/PolarisException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/exceptions/PolarisException.java
@@ -18,13 +18,11 @@
  */
 package org.apache.polaris.core.exceptions;
 
-import jakarta.ws.rs.core.Response;
-
 /**
  * Base class for Polaris-specific runtime exceptions.
  *
  * <p>All custom exceptions in Polaris should extend this class to provide specific error details.
- * Subclasses override {@link #httpStatusCode()} to declare their HTTP response status.
+ * Subclasses must implement {@link #httpStatusCode()} to declare their HTTP response status.
  */
 public abstract class PolarisException extends RuntimeException {
 
@@ -38,10 +36,7 @@ public abstract class PolarisException extends RuntimeException {
 
   /**
    * Returns the HTTP status code that should be used when this exception is mapped to an HTTP
-   * response. Defaults to {@code 500} (Internal Server Error). Subclasses should override this to
-   * return a more specific status code.
+   * response.
    */
-  public int httpStatusCode() {
-    return Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
-  }
+  public abstract int httpStatusCode();
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/exceptions/PolarisServiceUnavailableException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/exceptions/PolarisServiceUnavailableException.java
@@ -37,4 +37,9 @@ public class PolarisServiceUnavailableException extends PolarisException {
   public int getRetryAfterSeconds() {
     return retryAfterSeconds;
   }
+
+  @Override
+  public int httpStatusCode() {
+    return 503;
+  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/exceptions/PolarisServiceUnavailableException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/exceptions/PolarisServiceUnavailableException.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.core.exceptions;
 
 import com.google.errorprone.annotations.FormatMethod;
+import jakarta.ws.rs.core.Response;
 
 /**
  * Signals a transient failure that the client may resolve by retrying. Mapped to HTTP 503 (Service
@@ -40,6 +41,6 @@ public class PolarisServiceUnavailableException extends PolarisException {
 
   @Override
   public int httpStatusCode() {
-    return 503;
+    return Response.Status.SERVICE_UNAVAILABLE.getStatusCode();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolicyMappingAlreadyExistsException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolicyMappingAlreadyExistsException.java
@@ -45,4 +45,9 @@ public class PolicyMappingAlreadyExistsException extends PolarisException {
   public PolarisPolicyMappingRecord getExistingRecord() {
     return this.existingRecord;
   }
+
+  @Override
+  public int httpStatusCode() {
+    return 409;
+  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolicyMappingAlreadyExistsException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolicyMappingAlreadyExistsException.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.core.persistence;
 
 import com.google.errorprone.annotations.FormatMethod;
+import jakarta.ws.rs.core.Response;
 import org.apache.polaris.core.exceptions.PolarisException;
 import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
 
@@ -48,6 +49,6 @@ public class PolicyMappingAlreadyExistsException extends PolarisException {
 
   @Override
   public int httpStatusCode() {
-    return 409;
+    return Response.Status.CONFLICT.getStatusCode();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/NoSuchPolicyException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/NoSuchPolicyException.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.core.policy.exceptions;
 
+import jakarta.ws.rs.core.Response;
 import org.apache.polaris.core.exceptions.PolarisException;
 
 public class NoSuchPolicyException extends PolarisException {
@@ -32,6 +33,6 @@ public class NoSuchPolicyException extends PolarisException {
 
   @Override
   public int httpStatusCode() {
-    return 404;
+    return Response.Status.NOT_FOUND.getStatusCode();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/NoSuchPolicyException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/NoSuchPolicyException.java
@@ -29,4 +29,9 @@ public class NoSuchPolicyException extends PolarisException {
   public NoSuchPolicyException(String message, Throwable cause) {
     super(message, cause);
   }
+
+  @Override
+  public int httpStatusCode() {
+    return 404;
+  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyAttachException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyAttachException.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.core.policy.exceptions;
 
 import com.google.errorprone.annotations.FormatMethod;
+import jakarta.ws.rs.core.Response;
 import org.apache.polaris.core.exceptions.PolarisException;
 
 public class PolicyAttachException extends PolarisException {
@@ -34,6 +35,6 @@ public class PolicyAttachException extends PolarisException {
 
   @Override
   public int httpStatusCode() {
-    return 400;
+    return Response.Status.BAD_REQUEST.getStatusCode();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyAttachException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyAttachException.java
@@ -31,4 +31,9 @@ public class PolicyAttachException extends PolarisException {
   public PolicyAttachException(Throwable cause, String message, Object... args) {
     super(String.format(message, args), cause);
   }
+
+  @Override
+  public int httpStatusCode() {
+    return 400;
+  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyInUseException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyInUseException.java
@@ -19,6 +19,7 @@
 package org.apache.polaris.core.policy.exceptions;
 
 import com.google.errorprone.annotations.FormatMethod;
+import jakarta.ws.rs.core.Response;
 import org.apache.polaris.core.exceptions.PolarisException;
 
 public class PolicyInUseException extends PolarisException {
@@ -34,6 +35,6 @@ public class PolicyInUseException extends PolarisException {
 
   @Override
   public int httpStatusCode() {
-    return 400;
+    return Response.Status.BAD_REQUEST.getStatusCode();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyInUseException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyInUseException.java
@@ -31,4 +31,9 @@ public class PolicyInUseException extends PolarisException {
   public PolicyInUseException(Throwable cause, String message, Object... args) {
     super(String.format(message, args), cause);
   }
+
+  @Override
+  public int httpStatusCode() {
+    return 400;
+  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyVersionMismatchException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyVersionMismatchException.java
@@ -28,4 +28,9 @@ public class PolicyVersionMismatchException extends PolarisException {
   public PolicyVersionMismatchException(String message, Throwable cause) {
     super(message, cause);
   }
+
+  @Override
+  public int httpStatusCode() {
+    return 409;
+  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyVersionMismatchException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/exceptions/PolicyVersionMismatchException.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.core.policy.exceptions;
 
+import jakarta.ws.rs.core.Response;
 import org.apache.polaris.core.exceptions.PolarisException;
 
 public class PolicyVersionMismatchException extends PolarisException {
@@ -31,6 +32,6 @@ public class PolicyVersionMismatchException extends PolarisException {
 
   @Override
   public int httpStatusCode() {
-    return 409;
+    return Response.Status.CONFLICT.getStatusCode();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/validator/InvalidPolicyException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/validator/InvalidPolicyException.java
@@ -33,4 +33,9 @@ public class InvalidPolicyException extends PolarisException {
   public InvalidPolicyException(Throwable cause) {
     super("Invalid policy", cause);
   }
+
+  @Override
+  public int httpStatusCode() {
+    return 400;
+  }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/policy/validator/InvalidPolicyException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/policy/validator/InvalidPolicyException.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.core.policy.validator;
 
+import jakarta.ws.rs.core.Response;
 import org.apache.polaris.core.exceptions.PolarisException;
 
 /** Exception thrown when a policy is invalid or violates defined rules. */
@@ -36,6 +37,6 @@ public class InvalidPolicyException extends PolarisException {
 
   @Override
   public int httpStatusCode() {
-    return 400;
+    return Response.Status.BAD_REQUEST.getStatusCode();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/semantic/exceptions/NoSuchSemanticModelException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/semantic/exceptions/NoSuchSemanticModelException.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.core.semantic.exceptions;
 
+import jakarta.ws.rs.core.Response;
 import org.apache.polaris.core.exceptions.PolarisException;
 
 /** Thrown when a semantic model cannot be found. Maps to HTTP 404. */
@@ -28,5 +29,10 @@ public class NoSuchSemanticModelException extends PolarisException {
 
   public NoSuchSemanticModelException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  @Override
+  public int httpStatusCode() {
+    return Response.Status.NOT_FOUND.getStatusCode();
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/semantic/exceptions/SemanticModelVersionMismatchException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/semantic/exceptions/SemanticModelVersionMismatchException.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.core.semantic.exceptions;
 
+import jakarta.ws.rs.core.Response;
 import org.apache.polaris.core.exceptions.PolarisException;
 
 /**
@@ -31,5 +32,10 @@ public class SemanticModelVersionMismatchException extends PolarisException {
 
   public SemanticModelVersionMismatchException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  @Override
+  public int httpStatusCode() {
+    return Response.Status.CONFLICT.getStatusCode();
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/exception/PolarisExceptionMapper.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/exception/PolarisExceptionMapper.java
@@ -25,69 +25,37 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.apache.iceberg.rest.responses.ErrorResponse;
-import org.apache.polaris.core.exceptions.AlreadyExistsException;
-import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.exceptions.PolarisException;
 import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
-import org.apache.polaris.core.persistence.PolicyMappingAlreadyExistsException;
-import org.apache.polaris.core.policy.exceptions.NoSuchPolicyException;
-import org.apache.polaris.core.policy.exceptions.PolicyAttachException;
-import org.apache.polaris.core.policy.exceptions.PolicyInUseException;
-import org.apache.polaris.core.policy.exceptions.PolicyVersionMismatchException;
-import org.apache.polaris.core.policy.validator.InvalidPolicyException;
-import org.apache.polaris.core.semantic.exceptions.NoSuchSemanticModelException;
-import org.apache.polaris.core.semantic.exceptions.SemanticModelVersionMismatchException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 /**
- * An {@link ExceptionMapper} implementation for {@link PolarisException}s modeled after {@link
- * IcebergExceptionMapper}
+ * An {@link ExceptionMapper} implementation for {@link PolarisException}s. Delegates HTTP status
+ * resolution to {@link PolarisException#httpStatusCode()}.
  */
 @Provider
 public class PolarisExceptionMapper implements ExceptionMapper<PolarisException> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PolarisExceptionMapper.class);
 
-  private Response.Status getStatus(PolarisException exception) {
-    return switch (exception) {
-      case PolarisServiceUnavailableException polarisServiceUnavailableException ->
-          Response.Status.SERVICE_UNAVAILABLE;
-      case AlreadyExistsException alreadyExistsException -> Response.Status.CONFLICT;
-      case CommitConflictException commitConflictException -> Response.Status.CONFLICT;
-      case InvalidPolicyException invalidPolicyException -> Response.Status.BAD_REQUEST;
-      case PolicyAttachException policyAttachException -> Response.Status.BAD_REQUEST;
-      case NoSuchPolicyException noSuchPolicyException -> Response.Status.NOT_FOUND;
-      case PolicyVersionMismatchException policyVersionMismatchException ->
-          Response.Status.CONFLICT;
-      case PolicyMappingAlreadyExistsException policyMappingAlreadyExistsException ->
-          Response.Status.CONFLICT;
-      case PolicyInUseException policyInUseException -> Response.Status.BAD_REQUEST;
-      case NoSuchSemanticModelException noSuchSemanticModelException -> Response.Status.NOT_FOUND;
-      case SemanticModelVersionMismatchException semanticModelVersionMismatchException ->
-          Response.Status.CONFLICT;
-      default -> Response.Status.INTERNAL_SERVER_ERROR;
-    };
-  }
-
   @Override
   public Response toResponse(PolarisException exception) {
-    Response.Status status = getStatus(exception);
+    int statusCode = exception.httpStatusCode();
     getLogger()
-        .atLevel(
-            status.getFamily() == Response.Status.Family.SERVER_ERROR ? Level.INFO : Level.DEBUG)
+        .atLevel(statusCode >= 500 ? Level.INFO : Level.DEBUG)
         .setCause(exception)
         .log("Full PolarisException");
 
     ErrorResponse errorResponse =
         ErrorResponse.builder()
-            .responseCode(status.getStatusCode())
+            .responseCode(statusCode)
             .withType(exception.getClass().getSimpleName())
             .withMessage(exception.getMessage())
             .build();
     Response.ResponseBuilder builder =
-        Response.status(status).entity(errorResponse).type(MediaType.APPLICATION_JSON_TYPE);
+        Response.status(statusCode).entity(errorResponse).type(MediaType.APPLICATION_JSON_TYPE);
     if (exception instanceof PolarisServiceUnavailableException e
         && e.getRetryAfterSeconds() != 0) {
       builder.header(HttpHeaders.RETRY_AFTER, e.getRetryAfterSeconds());

--- a/runtime/service/src/main/java/org/apache/polaris/service/exception/PolarisExceptionMapper.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/exception/PolarisExceptionMapper.java
@@ -25,64 +25,37 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.apache.iceberg.rest.responses.ErrorResponse;
-import org.apache.polaris.core.exceptions.AlreadyExistsException;
-import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.exceptions.PolarisException;
 import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
-import org.apache.polaris.core.persistence.PolicyMappingAlreadyExistsException;
-import org.apache.polaris.core.policy.exceptions.NoSuchPolicyException;
-import org.apache.polaris.core.policy.exceptions.PolicyAttachException;
-import org.apache.polaris.core.policy.exceptions.PolicyInUseException;
-import org.apache.polaris.core.policy.exceptions.PolicyVersionMismatchException;
-import org.apache.polaris.core.policy.validator.InvalidPolicyException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 /**
- * An {@link ExceptionMapper} implementation for {@link PolarisException}s modeled after {@link
- * IcebergExceptionMapper}
+ * An {@link ExceptionMapper} implementation for {@link PolarisException}s. Delegates HTTP status
+ * resolution to {@link PolarisException#httpStatusCode()}.
  */
 @Provider
 public class PolarisExceptionMapper implements ExceptionMapper<PolarisException> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PolarisExceptionMapper.class);
 
-  private Response.Status getStatus(PolarisException exception) {
-    return switch (exception) {
-      case PolarisServiceUnavailableException polarisServiceUnavailableException ->
-          Response.Status.SERVICE_UNAVAILABLE;
-      case AlreadyExistsException alreadyExistsException -> Response.Status.CONFLICT;
-      case CommitConflictException commitConflictException -> Response.Status.CONFLICT;
-      case InvalidPolicyException invalidPolicyException -> Response.Status.BAD_REQUEST;
-      case PolicyAttachException policyAttachException -> Response.Status.BAD_REQUEST;
-      case NoSuchPolicyException noSuchPolicyException -> Response.Status.NOT_FOUND;
-      case PolicyVersionMismatchException policyVersionMismatchException ->
-          Response.Status.CONFLICT;
-      case PolicyMappingAlreadyExistsException policyMappingAlreadyExistsException ->
-          Response.Status.CONFLICT;
-      case PolicyInUseException policyInUseException -> Response.Status.BAD_REQUEST;
-      default -> Response.Status.INTERNAL_SERVER_ERROR;
-    };
-  }
-
   @Override
   public Response toResponse(PolarisException exception) {
-    Response.Status status = getStatus(exception);
+    int statusCode = exception.httpStatusCode();
     getLogger()
-        .atLevel(
-            status.getFamily() == Response.Status.Family.SERVER_ERROR ? Level.INFO : Level.DEBUG)
+        .atLevel(statusCode >= 500 ? Level.INFO : Level.DEBUG)
         .setCause(exception)
         .log("Full PolarisException");
 
     ErrorResponse errorResponse =
         ErrorResponse.builder()
-            .responseCode(status.getStatusCode())
+            .responseCode(statusCode)
             .withType(exception.getClass().getSimpleName())
             .withMessage(exception.getMessage())
             .build();
     Response.ResponseBuilder builder =
-        Response.status(status).entity(errorResponse).type(MediaType.APPLICATION_JSON_TYPE);
+        Response.status(statusCode).entity(errorResponse).type(MediaType.APPLICATION_JSON_TYPE);
     if (exception instanceof PolarisServiceUnavailableException e
         && e.getRetryAfterSeconds() != 0) {
       builder.header(HttpHeaders.RETRY_AFTER, e.getRetryAfterSeconds());

--- a/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
@@ -47,6 +47,8 @@ import org.apache.polaris.core.policy.exceptions.PolicyAttachException;
 import org.apache.polaris.core.policy.exceptions.PolicyInUseException;
 import org.apache.polaris.core.policy.exceptions.PolicyVersionMismatchException;
 import org.apache.polaris.core.policy.validator.InvalidPolicyException;
+import org.apache.polaris.core.semantic.exceptions.NoSuchSemanticModelException;
+import org.apache.polaris.core.semantic.exceptions.SemanticModelVersionMismatchException;
 import org.jboss.logmanager.Level;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -140,6 +142,8 @@ public class ExceptionMapperTest {
         Arguments.of(new NoSuchPolicyException("msg"), 404),
         Arguments.of(new PolicyVersionMismatchException("msg"), 409),
         Arguments.of(new PolicyMappingAlreadyExistsException("msg"), 409),
+        Arguments.of(new NoSuchSemanticModelException("msg"), 404),
+        Arguments.of(new SemanticModelVersionMismatchException("msg"), 409),
         Arguments.of(new FileIOUnknownHostException("msg", new RuntimeException()), 500));
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
@@ -38,7 +38,15 @@ import java.util.stream.Stream;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.polaris.core.exceptions.AlreadyExistsException;
 import org.apache.polaris.core.exceptions.CommitConflictException;
+import org.apache.polaris.core.exceptions.FileIOUnknownHostException;
+import org.apache.polaris.core.exceptions.PolarisException;
 import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
+import org.apache.polaris.core.persistence.PolicyMappingAlreadyExistsException;
+import org.apache.polaris.core.policy.exceptions.NoSuchPolicyException;
+import org.apache.polaris.core.policy.exceptions.PolicyAttachException;
+import org.apache.polaris.core.policy.exceptions.PolicyInUseException;
+import org.apache.polaris.core.policy.exceptions.PolicyVersionMismatchException;
+import org.apache.polaris.core.policy.validator.InvalidPolicyException;
 import org.jboss.logmanager.Level;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -109,6 +117,30 @@ public class ExceptionMapperTest {
         mapper.toResponse(new PolarisServiceUnavailableException(3, "transient conflict"));
     assertThat(response.getStatus()).isEqualTo(503);
     assertThat(response.getHeaderString(HttpHeaders.RETRY_AFTER)).isEqualTo("3");
+  }
+
+  @ParameterizedTest
+  @MethodSource("polarisExceptionStatusCodes")
+  public void testPolarisExceptionStatusCodes(PolarisException exception, int expectedStatus) {
+    assertThat(exception.httpStatusCode()).isEqualTo(expectedStatus);
+
+    PolarisExceptionMapper mapper = new PolarisExceptionMapper();
+    Response response = mapper.toResponse(exception);
+    assertThat(response.getStatus()).isEqualTo(expectedStatus);
+  }
+
+  static Stream<Arguments> polarisExceptionStatusCodes() {
+    return Stream.of(
+        Arguments.of(new AlreadyExistsException("msg"), 409),
+        Arguments.of(new CommitConflictException("msg"), 409),
+        Arguments.of(new PolarisServiceUnavailableException(0, "msg"), 503),
+        Arguments.of(new InvalidPolicyException("msg"), 400),
+        Arguments.of(new PolicyAttachException("msg"), 400),
+        Arguments.of(new PolicyInUseException("msg"), 400),
+        Arguments.of(new NoSuchPolicyException("msg"), 404),
+        Arguments.of(new PolicyVersionMismatchException("msg"), 409),
+        Arguments.of(new PolicyMappingAlreadyExistsException("msg"), 409),
+        Arguments.of(new FileIOUnknownHostException("msg", new RuntimeException()), 500));
   }
 
   static Stream<Arguments> testFullExceptionIsLogged() {


### PR DESCRIPTION
## Summary

Today `PolarisExceptionMapper` maintains a centralized switch statement that maps every `PolarisException` subtype to an HTTP status code. This creates tight coupling between the mapper and every exception class, and requires updating the mapper whenever a new exception type is added.

This PR inverts that relationship by adding an abstract `httpStatusCode()` method to `PolarisException` and implementing it in each subclass with the correct status code. The mapper now delegates to `exception.httpStatusCode()` instead of maintaining the switch.

The method returns a plain `int` so the signature stays transport neutral. The implementations reference `Response.Status` constants, which is fine because `jakarta.ws.rs` is already a declared dependency of `polaris-core`. Every subclass now declares its own status explicitly, including `FileIOUnknownHostException`, which returns 500 to match its current behavior.

Fixes #5167

## Checklist
- [x] Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues: Fixes #5167
- [x] Added/updated tests with good coverage, or manually tested (and explained how)
- [x] Added comments for complex logic
- [ ] Updated `CHANGELOG.md` (if needed)
- [ ] Updated documentation in `site/content/in-dev/unreleased` (if needed)

## Test plan

- Added a parameterized test (`testPolarisExceptionStatusCodes`) covering all 10 `PolarisException` subclasses, verifying both `httpStatusCode()` on the exception and the HTTP response from the mapper.
- Existing `ExceptionMapperTest` cases continue to pass unchanged.
- Ran `./gradlew format compileAll` and `./gradlew :polaris-core:check` locally with all tests passing.
