### PR TITLE
Fix release-4 Docker Hub login registry and Python client PyPI publish

### DIFF
--- a/.github/workflows/release-4-publish-release.yml
+++ b/.github/workflows/release-4-publish-release.yml
@@ -224,7 +224,7 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }} # zizmor: ignore[secrets-outside-env]
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }} # zizmor: ignore[secrets-outside-env]
         run: |
-          echo "${DOCKERHUB_TOKEN}" | docker login ghcr.io -u "${DOCKERHUB_USER}" --password-stdin
+          echo "${DOCKERHUB_TOKEN}" | docker login docker.io -u "${DOCKERHUB_USER}" --password-stdin
 
       - name: Publish Polaris Server Docker image to Docker Hub
         run: |
@@ -435,9 +435,19 @@ jobs:
           persist-credentials: false
 
       - name: Set up environment variables
+        env:
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
         run: |
           echo "RELEASEY_DIR=$(pwd)/releasey" >> $GITHUB_ENV
           echo "LIBS_DIR=$(pwd)/releasey/libs" >> $GITHUB_ENV
+
+          # exec_process defaults to dry-run when DRY_RUN is unset, so it must be
+          # set explicitly here or the wheel download below would silently no-op.
+          if [[ "${DRY_RUN_INPUT}" == "true" ]]; then
+            echo "DRY_RUN=1" >> $GITHUB_ENV
+          else
+            echo "DRY_RUN=0" >> $GITHUB_ENV
+          fi
 
       - name: Install Subversion
         run: |
@@ -462,6 +472,7 @@ jobs:
             "${dev_python_client_url}" dist/
 
       - name: Publish Python client release to PyPI
+        if: env.DRY_RUN == '0'
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           packages-dir: dist/


### PR DESCRIPTION
## What

Fixes two bugs in the `Release - 4 - Publish Release After Vote Success` workflow that caused these failed runs:

- https://github.com/apache/polaris/actions/runs/30733040417 (Docker login)
- https://github.com/apache/polaris/actions/runs/30732966634 (PyPI publish)

## Docker Hub login

The `Log in to Docker Hub` step logged into `ghcr.io` while the Quarkus build publishes images to `docker.io` (`quarkus.container-image.registry=docker.io`, group `apache`). Using the `DOCKERHUB_*` credentials against `ghcr.io` failed with `Error response from daemon: Get "https://ghcr.io/v2/": denied: denied`. Changed the login target to `docker.io`.

## Python client PyPI publish

The `publish-python-client` job never set `DRY_RUN`. `exec_process` in `releasey/libs/_exec.sh` defaults `DRY_RUN` to `1` (dry-run) when unset, so the svn wheel download silently no-opped (`WOULD execute 'svn export ...'`) and `dist/` was never created. The `pypa/gh-action-pypi-publish` step was not gated on dry-run, so it ran anyway and failed with `FileNotFoundError: .../dist` / "no Python distribution packages to publish".

Fix:
- Derive `DRY_RUN` from the workflow `dry_run` input in the job's environment setup (mirroring the `publish-release` job).
- Gate the PyPI publish step with `if: env.DRY_RUN == '0'`.