### PR TITLE
CLI: Setup AWS missing parameters during setup/export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - OPA authorizer now includes the realm identifier in the authorization context sent to OPA (`input.context.realm`). This ensures OPA policies can enforce tenant isolation across realms, preventing potential collisions if identical principal or resource names exist in different realms.
 - Management API delete operations for principals, principal roles, catalog roles, and catalogs now return error messages that match the actual failure reason (for example, concurrent modification no longer reports a misleading protected-entity message).
 - Python CLI `setup apply` now defaults to an `INTERNAL` catalog type when the `type` field is left blank or null in the setup config, instead of crashing with `AttributeError`
+- Ptyhon CLI `setup` now preserves `endpoint_internal` and `sts_endpoint` during apply and export for S3 configuration
 
 ## [1.6.0]
 

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -318,6 +318,8 @@ class SetupCommand(Command):
                         "user_arn": c.storage_config_info.user_arn,
                         "region": c.storage_config_info.region,
                         "endpoint": c.storage_config_info.endpoint,
+                        "endpoint_internal": c.storage_config_info.endpoint_internal,
+                        "sts_endpoint": c.storage_config_info.sts_endpoint,
                         "sts_unavailable": c.storage_config_info.sts_unavailable,
                         "kms_unavailable": c.storage_config_info.kms_unavailable,
                         "path_style_access": c.storage_config_info.path_style_access,

--- a/client/python/tests/test_catalogs_command.py
+++ b/client/python/tests/test_catalogs_command.py
@@ -184,6 +184,9 @@ class TestCatalogsCommand(CLITestBase):
         )
         self.assertTrue(call_args.catalog.storage_config_info.sts_unavailable)
         self.assertTrue(call_args.catalog.storage_config_info.kms_unavailable)
+        self.assertIsNone(call_args.catalog.storage_config_info.endpoint)
+        self.assertIsNone(call_args.catalog.storage_config_info.endpoint_internal)
+        self.assertIsNone(call_args.catalog.storage_config_info.sts_endpoint)
 
         self.mock_execute(
             mock_client,
@@ -239,6 +242,41 @@ class TestCatalogsCommand(CLITestBase):
         self.assertEqual(call_args.catalog.properties.default_base_location, "x")
         self.assertEqual(call_args.catalog.storage_config_info.allowed_locations, ["a"])
         self.assertEqual(call_args.catalog.storage_config_info.region, "us-west-2")
+
+    def test_catalog_create_s3_endpoints(self) -> None:
+        mock_client = self.build_mock_client()
+        self.mock_execute(
+            mock_client,
+            [
+                "catalogs",
+                "create",
+                "s3-catalog",
+                "--storage-type",
+                "s3",
+                "--default-base-location",
+                "s3://bucket/path",
+                "--endpoint",
+                "https://s3.us-west-2.amazonaws.com",
+                "--endpoint-internal",
+                "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com",
+                "--sts-endpoint",
+                "https://sts.amazonaws.com",
+            ],
+        )
+        call_args = mock_client.create_catalog.call_args[0][0]
+        self.assertEqual(call_args.catalog.name, "s3-catalog")
+        self.assertEqual(call_args.catalog.storage_config_info.storage_type, "S3")
+        self.assertEqual(
+            call_args.catalog.storage_config_info.endpoint, "https://s3.us-west-2.amazonaws.com"
+        )
+        self.assertEqual(
+            call_args.catalog.storage_config_info.endpoint_internal,
+            "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com",
+        )
+        self.assertEqual(
+            call_args.catalog.storage_config_info.sts_endpoint,
+            "https://sts.amazonaws.com",
+        )
 
     def test_catalog_create_gcs_options(self) -> None:
         mock_client = self.build_mock_client()

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -32,6 +32,7 @@ from apache_polaris.sdk.management import (
     PolarisCatalog,
     CatalogProperties,
     FileStorageConfigInfo,
+    AwsStorageConfigInfo,
 )
 
 
@@ -540,3 +541,61 @@ class TestSetupCommand(CLITestBase):
         self.assertEqual(cm.exception.exit_code, CLI_ERROR_EXIT_CODE)
         self.assertIn("export errors: 3", str(cm.exception))
         self.assertEqual(mock_stdout.getvalue(), "")
+
+    @patch("apache_polaris.cli.command.setup.IcebergCatalogAPI")
+    def test_setup_export_s3_catalog_round_trips_sts_and_internal_endpoints(
+        self, mock_catalog_api: MagicMock
+    ) -> None:
+        mock_catalog_api.return_value.list_namespaces.return_value = []
+        mock_catalog = MagicMock()
+        mock_catalog.name = "my_catalog"
+        mock_client = self.build_mock_client()
+        mock_client.list_catalogs.return_value.catalogs = [mock_catalog]
+        mock_client.get_catalog.return_value = PolarisCatalog(
+            type="INTERNAL",
+            name="my_catalog",
+            entity_version=1,
+            properties=CatalogProperties(
+                default_base_location="s3://bucket/path",
+                additional_properties={},
+            ),
+            storage_config_info=AwsStorageConfigInfo(
+                storage_type="S3",
+                allowed_locations=["s3://bucket/path"],
+                role_arn="arn:aws:iam::123456789012:user/QuickstartUser",
+                endpoint="https://s3.us-west-2.amazonaws.com",
+                endpoint_internal="https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com",
+                sts_endpoint="https://sts.amazonaws.com",
+            ),
+        )
+        mock_client.list_catalog_roles.return_value = MagicMock(roles=[])
+
+        export_command = SetupCommand(
+            setup_subcommand=Subcommands.EXPORT,
+            _catalog_api=MagicMock(),
+        )
+        exported = export_command._export_catalogs(mock_client)
+
+        self.assertEqual(len(exported), 1)
+        self.assertEqual(
+            exported[0]["endpoint_internal"], "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com"
+        )
+        self.assertEqual(exported[0]["sts_endpoint"], "https://sts.amazonaws.com")
+
+        loaded = yaml.safe_load(yaml.safe_dump({"catalogs": exported}))
+
+        apply_client = self.build_mock_client()
+        apply_client.list_catalogs.return_value.catalogs = []
+        apply_command = SetupCommand(setup_subcommand=Subcommands.APPLY)
+        apply_command._create_catalogs(apply_client, loaded["catalogs"])
+
+        apply_client.create_catalog.assert_called_once()
+        created = apply_client.create_catalog.call_args[0][0].catalog
+        self.assertEqual(
+            created.storage_config_info.endpoint_internal,
+            "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com",
+        )
+        self.assertEqual(
+            created.storage_config_info.sts_endpoint, "https://sts.amazonaws.com"
+        )
+

--- a/site/content/guides/assets/polaris/reference-setup-config.yaml
+++ b/site/content/guides/assets/polaris/reference-setup-config.yaml
@@ -179,6 +179,10 @@ catalogs:
     region: "us-west-2"
     # Custom S3 endpoint.
     endpoint: "https://s3.us-west-2.amazonaws.com"
+    # Private S3 endpoint that Polaris server uses (defaults to `endpoint`).
+    endpoint_internal: "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com"
+    # STS endpoint that Polaris server uses (falls back to `endpoint_internal` then `endpoint`).
+    sts_endpoint: "https://sts.amazonaws.com"
     # Set to true if the storage does not support AWS STS for credential vending.
     sts_unavailable: false
     # Set to true to disable KMS key policies.


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Added the two missing fields (endpoint_internal and sts_endpoint) that got loss during setup apply/export. As we are using an valid S3 endpoint value ("https://s3.us-west-2.amazonaws.com") in `site/content/guides/assets/polaris/reference-setup-config.yaml`, I am setting endpoint_internal to "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com" (sample value obtained from https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html but with region change from us-east-1 to us-west-2 for consistency). 

Also, I added a test in `test_catalogs_command.py` to cover S3/STS endpoints are optional and they are are getting process correctly. The fall-back logic for sts_endpoint is not covered here as those are covered on the server side (but I added a comment in `site/content/guides/assets/polaris/reference-setup-config.yaml` to mention how the fall-back works).

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
