### PR TITLE
Add dedicated JDBC regression tests for hasOverlappingSiblings overlap detection

### DIFF
--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplH2SchemaTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplH2SchemaTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.persistence.relational.jdbc;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Runs {@link AtomicMetastoreManagerWithJdbcBasePersistenceImplTest} against every H2 schema
+ * version on the classpath.
+ */
+@ParameterizedClass
+@MethodSource("schemaVersions")
+public class AtomicMetastoreManagerWithJdbcBasePersistenceImplH2SchemaTest
+    extends AtomicMetastoreManagerWithJdbcBasePersistenceImplTest {
+
+  @Parameter int schemaVersion;
+
+  static Stream<Integer> schemaVersions() {
+    return SchemaVersions.discoverAsStream(DatabaseType.H2);
+  }
+
+  @Override
+  public int schemaVersion() {
+    return schemaVersion;
+  }
+}

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/AtomicMetastoreManagerWithJdbcBasePersistenceImplTest.java
@@ -39,6 +39,7 @@ import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.AtomicOperationMetaStoreManager;
 import org.apache.polaris.core.persistence.BasePolarisMetaStoreManagerTest;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisTestMetaStoreManager;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Assumptions;
@@ -156,6 +157,205 @@ public abstract class AtomicMetastoreManagerWithJdbcBasePersistenceImplTest
     Assertions.assertThat(
             metaStoreManager.hasOverlappingSiblings(callContext, nonOverlappingNamespace))
         .contains(Optional.empty());
+  }
+
+  @Test
+  void testHasOverlappingSiblingsTrailingSlashVariants() {
+    Assumptions.assumeThat(schemaVersion()).isGreaterThanOrEqualTo(2);
+
+    var metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager();
+    var callContext = polarisTestMetaStoreManager.polarisCallContext();
+    PolarisBaseEntity catalog = createOverlapTestCatalog(metaStoreManager, callContext, "slash");
+
+    PolarisBaseEntity nsWithSlash =
+        buildLocationBasedNamespace(
+            catalog,
+            metaStoreManager.generateNewEntityId(callContext).getId(),
+            "ns_slash",
+            "s3://bucket/foo/bar/");
+    metaStoreManager.createEntityIfNotExists(
+        callContext, List.of(PolarisEntity.toCore(catalog)), nsWithSlash);
+
+    // Candidate without trailing slash should still detect overlap
+    TestLocationBasedEntity candidateNoSlash =
+        new TestLocationBasedEntity(
+            buildLocationBasedNamespace(
+                catalog,
+                metaStoreManager.generateNewEntityId(callContext).getId(),
+                "candidate_no_slash",
+                "s3://bucket/foo/bar"));
+
+    Assertions.assertThat(metaStoreManager.hasOverlappingSiblings(callContext, candidateNoSlash))
+        .as("Location without trailing slash must overlap with stored trailing-slash location")
+        .isPresent()
+        .contains(Optional.of("s3://bucket/foo/bar/"));
+  }
+
+  @Test
+  void testHasOverlappingSiblingsParentChildBothDirections() {
+    Assumptions.assumeThat(schemaVersion()).isGreaterThanOrEqualTo(2);
+
+    var metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager();
+    var callContext = polarisTestMetaStoreManager.polarisCallContext();
+    PolarisBaseEntity catalog =
+        createOverlapTestCatalog(metaStoreManager, callContext, "parent_child");
+
+    PolarisBaseEntity parentNs =
+        buildLocationBasedNamespace(
+            catalog,
+            metaStoreManager.generateNewEntityId(callContext).getId(),
+            "parent_ns",
+            "s3://bucket/data/");
+    metaStoreManager.createEntityIfNotExists(
+        callContext, List.of(PolarisEntity.toCore(catalog)), parentNs);
+
+    // Child of existing parent must report overlap
+    TestLocationBasedEntity childCandidate =
+        new TestLocationBasedEntity(
+            buildLocationBasedNamespace(
+                catalog,
+                metaStoreManager.generateNewEntityId(callContext).getId(),
+                "child_candidate",
+                "s3://bucket/data/nested/deep/"));
+
+    Assertions.assertThat(metaStoreManager.hasOverlappingSiblings(callContext, childCandidate))
+        .as("Child location must detect parent overlap")
+        .isPresent()
+        .contains(Optional.of("s3://bucket/data/"));
+
+    // Now add a deeply nested entity and verify a broader parent candidate detects it
+    PolarisBaseEntity deepNs =
+        buildLocationBasedNamespace(
+            catalog,
+            metaStoreManager.generateNewEntityId(callContext).getId(),
+            "deep_ns",
+            "s3://bucket/warehouse/a/b/c/");
+    metaStoreManager.createEntityIfNotExists(
+        callContext, List.of(PolarisEntity.toCore(catalog)), deepNs);
+
+    TestLocationBasedEntity parentCandidate =
+        new TestLocationBasedEntity(
+            buildLocationBasedNamespace(
+                catalog,
+                metaStoreManager.generateNewEntityId(callContext).getId(),
+                "parent_candidate",
+                "s3://bucket/warehouse/a/"));
+
+    Assertions.assertThat(metaStoreManager.hasOverlappingSiblings(callContext, parentCandidate))
+        .as("Parent location must detect existing child overlap")
+        .isPresent()
+        .contains(Optional.of("s3://bucket/warehouse/a/b/c/"));
+  }
+
+  @Test
+  void testHasOverlappingSiblingsDuplicateLocations() {
+    Assumptions.assumeThat(schemaVersion()).isGreaterThanOrEqualTo(2);
+
+    var metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager();
+    var callContext = polarisTestMetaStoreManager.polarisCallContext();
+    PolarisBaseEntity catalog =
+        createOverlapTestCatalog(metaStoreManager, callContext, "duplicate");
+
+    PolarisBaseEntity ns1 =
+        buildLocationBasedNamespace(
+            catalog,
+            metaStoreManager.generateNewEntityId(callContext).getId(),
+            "dup1",
+            "s3://bucket/shared/path/");
+    metaStoreManager.createEntityIfNotExists(
+        callContext, List.of(PolarisEntity.toCore(catalog)), ns1);
+
+    PolarisBaseEntity ns2 =
+        buildLocationBasedNamespace(
+            catalog,
+            metaStoreManager.generateNewEntityId(callContext).getId(),
+            "dup2",
+            "s3://bucket/shared/path/");
+    metaStoreManager.createEntityIfNotExists(
+        callContext, List.of(PolarisEntity.toCore(catalog)), ns2);
+
+    // A candidate with the same location must detect the overlap
+    TestLocationBasedEntity sameLocationCandidate =
+        new TestLocationBasedEntity(
+            buildLocationBasedNamespace(
+                catalog,
+                metaStoreManager.generateNewEntityId(callContext).getId(),
+                "same_loc",
+                "s3://bucket/shared/path/"));
+
+    Assertions.assertThat(
+            metaStoreManager.hasOverlappingSiblings(callContext, sameLocationCandidate))
+        .as("Exact duplicate location must report overlap")
+        .isPresent()
+        .contains(Optional.of("s3://bucket/shared/path/"));
+  }
+
+  @Test
+  void testHasOverlappingSiblingsAfterEntityDrop() {
+    Assumptions.assumeThat(schemaVersion()).isGreaterThanOrEqualTo(2);
+
+    var metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager();
+    var callContext = polarisTestMetaStoreManager.polarisCallContext();
+    PolarisBaseEntity catalog = createOverlapTestCatalog(metaStoreManager, callContext, "drop");
+
+    PolarisBaseEntity ns1 =
+        buildLocationBasedNamespace(
+            catalog,
+            metaStoreManager.generateNewEntityId(callContext).getId(),
+            "drop_ns1",
+            "s3://bucket/drop/path/");
+    metaStoreManager.createEntityIfNotExists(
+        callContext, List.of(PolarisEntity.toCore(catalog)), ns1);
+
+    PolarisBaseEntity ns2 =
+        buildLocationBasedNamespace(
+            catalog,
+            metaStoreManager.generateNewEntityId(callContext).getId(),
+            "drop_ns2",
+            "s3://bucket/drop/path/");
+    metaStoreManager.createEntityIfNotExists(
+        callContext, List.of(PolarisEntity.toCore(catalog)), ns2);
+
+    // Drop the first entity
+    metaStoreManager.dropEntityIfExists(
+        callContext, List.of(PolarisEntity.toCore(catalog)), ns1, null, false);
+
+    // Overlap must still be reported because ns2 remains
+    TestLocationBasedEntity candidate =
+        new TestLocationBasedEntity(
+            buildLocationBasedNamespace(
+                catalog,
+                metaStoreManager.generateNewEntityId(callContext).getId(),
+                "after_drop",
+                "s3://bucket/drop/path/child/"));
+
+    Assertions.assertThat(metaStoreManager.hasOverlappingSiblings(callContext, candidate))
+        .as("Overlap must persist while a duplicate entity remains")
+        .isPresent()
+        .contains(Optional.of("s3://bucket/drop/path/"));
+
+    // Drop the second entity
+    metaStoreManager.dropEntityIfExists(
+        callContext, List.of(PolarisEntity.toCore(catalog)), ns2, null, false);
+
+    // No overlap should be reported now
+    Assertions.assertThat(metaStoreManager.hasOverlappingSiblings(callContext, candidate))
+        .as("No overlap after all matching entities are dropped")
+        .isPresent()
+        .contains(Optional.empty());
+  }
+
+  private PolarisBaseEntity createOverlapTestCatalog(
+      PolarisMetaStoreManager metaStoreManager, PolarisCallContext callContext, String suffix) {
+    PolarisBaseEntity catalog =
+        new PolarisBaseEntity(
+            PolarisEntityConstants.getNullId(),
+            metaStoreManager.generateNewEntityId(callContext).getId(),
+            PolarisEntityType.CATALOG,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootEntityId(),
+            "overlap_" + suffix);
+    return metaStoreManager.createCatalog(callContext, catalog, List.of()).getCatalog();
   }
 
   private static PolarisBaseEntity buildLocationBasedNamespace(


### PR DESCRIPTION
## What

Adds comprehensive regression test coverage for `hasOverlappingSiblings` in the JDBC persistence layer, as requested in #4600. Also adds a concrete H2-based parameterized test runner so these tests can run locally without Docker.

## Why

The existing JDBC test only covered a basic parent/child overlap and a non-overlapping case. The NoSQL layer had much broader coverage for edge cases (trailing slashes, both overlap directions, duplicates, entity drops) but the JDBC layer did not. These regression tests ensure the JDBC overlap detection behaves correctly across all important scenarios and prevents future regressions.

Fixes #4600

## Changes

- Added 4 new test methods to `AtomicMetastoreManagerWithJdbcBasePersistenceImplTest`:
  - `testHasOverlappingSiblingsTrailingSlashVariants`: verifies that a location without a trailing slash still overlaps with a stored location that has one
  - `testHasOverlappingSiblingsParentChildBothDirections`: verifies overlap is detected when the candidate is a child of an existing entity AND when it is a parent of an existing entity
  - `testHasOverlappingSiblingsDuplicateLocations`: verifies that an exact duplicate base location is reported as overlapping
  - `testHasOverlappingSiblingsAfterEntityDrop`: verifies overlap persists while duplicates remain, and disappears only after all overlapping entities are dropped
- Added a `createOverlapTestCatalog` helper to reduce boilerplate across new tests
- Created `AtomicMetastoreManagerWithJdbcBasePersistenceImplH2SchemaTest` as a concrete H2 parameterized test runner (mirrors the Postgres IT pattern but runs without Docker)

## Checklist
- [x] Don't disclose security issues! (contact security@apache.org)
- [x] Clearly explained why the changes are needed, or linked related issues: Fixes #4600
- [x] Added/updated tests with good coverage (and explained how)
- [x] Added comments for complex logic
- [ ] Updated `CHANGELOG.md` (if needed)
- [ ] Updated documentation in `site/content/in-dev/unreleased` (if needed)
