### PR TITLE
Use VIEW_IDENTIFIER log key on view identifier mismatch (follow-up to #5093)

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/StructuredLogKeys.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/StructuredLogKeys.java
@@ -99,7 +99,6 @@ public final class StructuredLogKeys {
 
   // --- Misc keys ---
   public static final String TYPE = "type";
-  public static final String IDENTIFIER = "identifier";
   public static final String NOTIFICATION = "notification";
   public static final String REMOTE_URL = "remoteUrl";
   public static final String JSON = "json";

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -2291,7 +2291,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
           LOGGER
               .atError()
               .addKeyValue("entity.getTableIdentifier()", entity.getTableIdentifier())
-              .addKeyValue(StructuredLogKeys.IDENTIFIER, identifier)
+              .addKeyValue(StructuredLogKeys.VIEW_IDENTIFIER, identifier)
               .log("Stored view identifier mismatches requested identifier");
         }
       }


### PR DESCRIPTION
## Summary

Follow-up to #5093.

In `LocalIcebergCatalog.doRefresh()`, the view-path call site (`PolarisEntitySubType.ICEBERG_VIEW`, log message "Stored view identifier mismatches requested identifier") used the generic `StructuredLogKeys.IDENTIFIER`. During review of #5093, @adutra and I agreed the more semantically correct constant here is `StructuredLogKeys.VIEW_IDENTIFIER` (see the [review thread](https://github.com/apache/polaris/pull/5093#discussion_r3663931817)), consistent with:
- the matching table path a few hundred lines above, which uses `TABLE_IDENTIFIER`, and
- the `EventAttributes.VIEW_IDENTIFIER` tag applied to the same value just below this call site.

The change was agreed but not committed before #5093 merged; this PR applies it.

## Changes
- `LocalIcebergCatalog.java`: `StructuredLogKeys.IDENTIFIER` -> `StructuredLogKeys.VIEW_IDENTIFIER` at the view identifier mismatch log call.

## Testing
No behavioral change beyond the emitted structured-log key name (`identifier` -> `viewIdentifier`). Compiles and passes Spotless.

## Checklist
- [x] 🛡️ Not a security issue
- [x] 🔗 Fixes #5033
- [x] 🧪 No tests needed (pure refactoring, no behavior change)
- [x] 💡 Added Javadoc for `StructuredLogKeys`
- [x] 🧾 No CHANGELOG update needed
- [x] 📚 No documentation update needed