### PR TITLE
Remove listTables(Namespace) convenience overload from IcebergCatalogHandler

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
@@ -261,11 +261,6 @@ public class CatalogHandlerUtils {
         .build();
   }
 
-  public ListTablesResponse listTables(Catalog catalog, Namespace namespace) {
-    List<TableIdentifier> idents = catalog.listTables(namespace);
-    return ListTablesResponse.builder().addAll(idents).build();
-  }
-
   public ListTablesResponse listTables(
       Catalog catalog, Namespace namespace, String pageToken, Integer pageSize) {
     List<TableIdentifier> results = catalog.listTables(namespace);

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -382,13 +382,6 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     }
   }
 
-  public ListTablesResponse listTables(Namespace namespace) {
-    PolarisAuthorizableOperation op = PolarisAuthorizableOperation.LIST_TABLES;
-    authorizeBasicNamespaceOperationOrThrow(op, namespace);
-
-    return catalogHandlerUtils().listTables(baseCatalog, namespace);
-  }
-
   /**
    * Create a table.
    *

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
@@ -219,7 +219,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                     .shouldFailWithAnyPrivilege()
                     .createTests(),
                 authzTestsBuilder("listTables (before rotation)")
-                    .action(() -> handler.get().listTables(NS1))
+                    .action(() -> handler.get().listTables(NS1, null, null))
                     .principalName(principalName)
                     .shouldFailWithAnyPrivilege()
                     .createTests())
@@ -283,7 +283,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                     .shouldPassWith(PolarisPrivilege.CATALOG_MANAGE_METADATA)
                     .createTests(),
                 authzTestsBuilder("listTables (after rotation)")
-                    .action(() -> refreshedWrapper.get().listTables(NS1))
+                    .action(() -> refreshedWrapper.get().listTables(NS1, null, null))
                     .principalName(principalName)
                     .shouldPassWith(PolarisPrivilege.TABLE_LIST)
                     .shouldPassWith(PolarisPrivilege.TABLE_CREATE)
@@ -463,7 +463,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
   @TestFactory
   Stream<DynamicNode> testListTablesPrivileges() {
     return authzTestsBuilder("listTables")
-        .action(() -> newHandler().listTables(NS1A))
+        .action(() -> newHandler().listTables(NS1A, null, null))
         .shouldPassWith(PolarisPrivilege.TABLE_LIST)
         .shouldPassWith(PolarisPrivilege.TABLE_READ_PROPERTIES)
         .shouldPassWith(PolarisPrivilege.TABLE_WRITE_PROPERTIES)


### PR DESCRIPTION
The `listTables(Namespace)` overload was only called from test code and diverged from the
production `listTables(Namespace, pageToken, pageSize)` path: it skipped the `isFederated`
branch and pagination. This removes it and updates the 3 authz-test call sites to the
production overload.

Part of #4709.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Linked related issue: Part of #4709
- [x] 🧪 Updated the authz test; `:polaris-runtime-service:check` passes
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
