### PR TITLE
Remove listNamespaces(Namespace) convenience overload from IcebergCatalogHandler

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java
@@ -183,17 +183,6 @@ public class CatalogHandlerUtils {
     return Pair.of(subList, nextPageToken);
   }
 
-  public ListNamespacesResponse listNamespaces(SupportsNamespaces catalog, Namespace parent) {
-    List<Namespace> results;
-    if (parent.isEmpty()) {
-      results = catalog.listNamespaces();
-    } else {
-      results = catalog.listNamespaces(parent);
-    }
-
-    return ListNamespacesResponse.builder().addAll(results).build();
-  }
-
   public ListNamespacesResponse listNamespaces(
       SupportsNamespaces catalog, Namespace parent, String pageToken, Integer pageSize) {
     List<Namespace> results;

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -267,13 +267,6 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     this.viewCatalog = (baseCatalog instanceof ViewCatalog) ? (ViewCatalog) baseCatalog : null;
   }
 
-  public ListNamespacesResponse listNamespaces(Namespace parent) {
-    PolarisAuthorizableOperation op = PolarisAuthorizableOperation.LIST_NAMESPACES;
-    authorizeBasicNamespaceOperationOrThrow(op, parent);
-
-    return catalogHandlerUtils().listNamespaces(namespaceCatalog, parent);
-  }
-
   public ListNamespacesResponse listNamespaces(
       Namespace parent, String pageToken, Integer pageSize) {
     PolarisAuthorizableOperation op = PolarisAuthorizableOperation.LIST_NAMESPACES;

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
@@ -312,7 +312,9 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
 
     // Just activating PRINCIPAL_ROLE1 should also work.
     Assertions.assertThat(
-            newHandler(Set.of(PRINCIPAL_ROLE1)).listNamespaces(Namespace.of(), null, null).namespaces())
+            newHandler(Set.of(PRINCIPAL_ROLE1))
+                .listNamespaces(Namespace.of(), null, null)
+                .namespaces())
         .containsAll(List.of(NS1, NS2));
 
     // If we only activate PRINCIPAL_ROLE2 it won't have the privilege.

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
@@ -158,7 +158,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
   @TestFactory
   Stream<DynamicNode> testListNamespacesPrivileges() {
     return authzTestsBuilder("listNamespaces")
-        .action(() -> newHandler().listNamespaces(Namespace.of()))
+        .action(() -> newHandler().listNamespaces(Namespace.of(), null, null))
         .shouldPassWith(PolarisPrivilege.NAMESPACE_LIST)
         .shouldPassWith(PolarisPrivilege.NAMESPACE_READ_PROPERTIES)
         .shouldPassWith(PolarisPrivilege.NAMESPACE_WRITE_PROPERTIES)
@@ -204,7 +204,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
     Stream<DynamicNode> beforeRotationTests =
         Stream.of(
                 authzTestsBuilder("listNamespaces (before rotation)")
-                    .action(() -> handler.get().listNamespaces(Namespace.of()))
+                    .action(() -> handler.get().listNamespaces(Namespace.of(), null, null))
                     .principalName(principalName)
                     .shouldFailWithAnyPrivilege()
                     .createTests(),
@@ -258,7 +258,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
     Stream<DynamicNode> afterRotationTests =
         Stream.of(
                 authzTestsBuilder("listNamespaces (after rotation)")
-                    .action(() -> refreshedWrapper.get().listNamespaces(Namespace.of()))
+                    .action(() -> refreshedWrapper.get().listNamespaces(Namespace.of(), null, null))
                     .principalName(principalName)
                     .shouldPassWith(PolarisPrivilege.NAMESPACE_LIST)
                     .shouldPassWith(PolarisPrivilege.NAMESPACE_CREATE)
@@ -307,17 +307,17 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         newRootAdminService()
             .grantPrivilegeOnCatalogToRole(
                 CATALOG_NAME, CATALOG_ROLE1, PolarisPrivilege.NAMESPACE_LIST));
-    Assertions.assertThat(newHandler().listNamespaces(Namespace.of()).namespaces())
+    Assertions.assertThat(newHandler().listNamespaces(Namespace.of(), null, null).namespaces())
         .containsAll(List.of(NS1, NS2));
 
     // Just activating PRINCIPAL_ROLE1 should also work.
     Assertions.assertThat(
-            newHandler(Set.of(PRINCIPAL_ROLE1)).listNamespaces(Namespace.of()).namespaces())
+            newHandler(Set.of(PRINCIPAL_ROLE1)).listNamespaces(Namespace.of(), null, null).namespaces())
         .containsAll(List.of(NS1, NS2));
 
     // If we only activate PRINCIPAL_ROLE2 it won't have the privilege.
     Assertions.assertThatThrownBy(
-            () -> newHandler(Set.of(PRINCIPAL_ROLE2)).listNamespaces(Namespace.of()))
+            () -> newHandler(Set.of(PRINCIPAL_ROLE2)).listNamespaces(Namespace.of(), null, null))
         .isInstanceOf(ForbiddenException.class)
         .hasMessageContaining("is not authorized");
 
@@ -326,7 +326,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         newRootAdminService()
             .revokePrivilegeOnCatalogFromRole(
                 CATALOG_NAME, CATALOG_ROLE1, PolarisPrivilege.NAMESPACE_LIST));
-    Assertions.assertThatThrownBy(() -> newHandler().listNamespaces(Namespace.of()))
+    Assertions.assertThatThrownBy(() -> newHandler().listNamespaces(Namespace.of(), null, null))
         .isInstanceOf(ForbiddenException.class);
   }
 
@@ -339,19 +339,19 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                 CATALOG_NAME, CATALOG_ROLE1, NS1, PolarisPrivilege.NAMESPACE_LIST));
 
     // Listing directly on NS1 succeeds
-    Assertions.assertThat(newHandler().listNamespaces(NS1).namespaces())
+    Assertions.assertThat(newHandler().listNamespaces(NS1, null, null).namespaces())
         .containsAll(List.of(NS1A, NS1B));
 
     // Root listing fails
-    Assertions.assertThatThrownBy(() -> newHandler().listNamespaces(Namespace.of()))
+    Assertions.assertThatThrownBy(() -> newHandler().listNamespaces(Namespace.of(), null, null))
         .isInstanceOf(ForbiddenException.class);
 
     // NS2 listing fails
-    Assertions.assertThatThrownBy(() -> newHandler().listNamespaces(Namespace.of()))
+    Assertions.assertThatThrownBy(() -> newHandler().listNamespaces(Namespace.of(), null, null))
         .isInstanceOf(ForbiddenException.class);
 
     // Listing on a child of NS1 succeeds
-    Assertions.assertThat(newHandler().listNamespaces(NS1A).namespaces())
+    Assertions.assertThat(newHandler().listNamespaces(NS1A, null, null).namespaces())
         .containsAll(List.of(NS1AA));
   }
 


### PR DESCRIPTION
The `listNamespaces(Namespace)` overload was only called from test code and diverged from the
production `listNamespaces(Namespace, pageToken, pageSize)` path: it skipped the `isFederated`
branch and pagination. This removes it and updates the 11 authz-test call sites to the
production overload.

Part of #4709.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Linked related issue: Part of #4709
- [x] 🧪 Updated the authz test; `:polaris-runtime-service:check` passes
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
