### PR TITLE
Add unit tests for DefaultAuthenticator role resolution logic

### DIFF
--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
@@ -518,4 +518,158 @@ public class DefaultAuthenticatorTest {
         .isInstanceOf(AuthenticationFailedException.class)
         .hasMessageContaining("Unable to authenticate");
   }
+  // --- Tests for extractRequestedRoles ---
+
+  @Test
+  void testExtractRequestedRoles_allReturnsEmptyWithFlag() {
+    PolarisCredential credentials =
+            PolarisCredential.of(null, PRINCIPAL_NAME, Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL));
+    DefaultAuthenticator.PrincipalRoleSelection selection =
+            authenticator.extractRequestedRoles(credentials);
+
+    assertThat(selection.allRolesRequested()).isTrue();
+    assertThat(selection.roles()).isEmpty();
+  }
+
+  @Test
+  void testExtractRequestedRoles_allTakesPrecedenceOverIndividual() {
+    PolarisCredential credentials =
+            PolarisCredential.of(
+                    null,
+                    PRINCIPAL_NAME,
+                    Set.of(
+                            DefaultAuthenticator.PRINCIPAL_ROLE_ALL,
+                            DefaultAuthenticator.PRINCIPAL_ROLE_PREFIX + PRINCIPAL_ROLE1));
+    DefaultAuthenticator.PrincipalRoleSelection selection =
+            authenticator.extractRequestedRoles(credentials);
+
+    assertThat(selection.allRolesRequested()).isTrue();
+    assertThat(selection.roles()).isEmpty();
+  }
+
+  @Test
+  void testExtractRequestedRoles_individualStripsPrefix() {
+    PolarisCredential credentials =
+            PolarisCredential.of(
+                    null,
+                    PRINCIPAL_NAME,
+                    Set.of(
+                            DefaultAuthenticator.PRINCIPAL_ROLE_PREFIX + PRINCIPAL_ROLE1,
+                            DefaultAuthenticator.PRINCIPAL_ROLE_PREFIX + PRINCIPAL_ROLE2));
+    DefaultAuthenticator.PrincipalRoleSelection selection =
+            authenticator.extractRequestedRoles(credentials);
+
+    assertThat(selection.allRolesRequested()).isFalse();
+    assertThat(selection.roles()).containsExactlyInAnyOrder(PRINCIPAL_ROLE1, PRINCIPAL_ROLE2);
+  }
+
+  @Test
+  void testExtractRequestedRoles_onlyInvalidPrefixesFilteredOut() {
+    PolarisCredential credentials =
+            PolarisCredential.of(null, PRINCIPAL_NAME, Set.of("unprefixed", "also-bad"));
+    DefaultAuthenticator.PrincipalRoleSelection selection =
+            authenticator.extractRequestedRoles(credentials);
+
+    assertThat(selection.allRolesRequested()).isFalse();
+    assertThat(selection.roles()).isEmpty();
+  }
+
+  @Test
+  void testExtractRequestedRoles_mixedKeepsOnlyPrefixed() {
+    PolarisCredential credentials =
+            PolarisCredential.of(
+                    null,
+                    PRINCIPAL_NAME,
+                    Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_PREFIX + PRINCIPAL_ROLE1, "unprefixed"));
+    DefaultAuthenticator.PrincipalRoleSelection selection =
+            authenticator.extractRequestedRoles(credentials);
+
+    assertThat(selection.allRolesRequested()).isFalse();
+    assertThat(selection.roles()).containsExactly(PRINCIPAL_ROLE1);
+  }
+
+  @Test
+  void testExtractRequestedRoles_emptyReturnsEmpty() {
+    PolarisCredential credentials = PolarisCredential.of(null, PRINCIPAL_NAME, Set.of());
+    DefaultAuthenticator.PrincipalRoleSelection selection =
+            authenticator.extractRequestedRoles(credentials);
+
+    assertThat(selection.allRolesRequested()).isFalse();
+    assertThat(selection.roles()).isEmpty();
+  }
+
+  // --- Tests for resolvePrincipalRoles ---
+
+  @Test
+  void testResolvePrincipalRoles_allRequestedReturnsAllGranted() {
+    PolarisCredential credentials =
+            PolarisCredential.of(null, PRINCIPAL_NAME, Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL));
+    DefaultAuthenticator.PrincipalRoleSelection selection =
+            authenticator.resolvePrincipalRoles(credentials, principalEntity);
+
+    assertThat(selection.allRolesRequested()).isTrue();
+    assertThat(selection.roles()).containsExactlyInAnyOrder(PRINCIPAL_ROLE1, PRINCIPAL_ROLE2);
+  }
+
+  @Test
+  void testResolvePrincipalRoles_subsetReturnsOnlyRequestedGranted() {
+    PolarisCredential credentials =
+            PolarisCredential.of(
+                    null,
+                    PRINCIPAL_NAME,
+                    Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_PREFIX + PRINCIPAL_ROLE1));
+    DefaultAuthenticator.PrincipalRoleSelection selection =
+            authenticator.resolvePrincipalRoles(credentials, principalEntity);
+
+    assertThat(selection.allRolesRequested()).isFalse();
+    assertThat(selection.roles()).containsExactly(PRINCIPAL_ROLE1);
+  }
+
+  @Test
+  void testResolvePrincipalRoles_requestedButUngrantedThrows() {
+    PolarisCredential credentials =
+            PolarisCredential.of(
+                    null,
+                    PRINCIPAL_NAME,
+                    Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_PREFIX + "non-existent-role"));
+
+    assertThatThrownBy(() -> authenticator.resolvePrincipalRoles(credentials, principalEntity))
+            .isInstanceOf(AuthenticationFailedException.class);
+  }
+
+  @Test
+  void testResolvePrincipalRoles_mixedGrantedAndUngrantedThrows() {
+    PolarisCredential credentials =
+            PolarisCredential.of(
+                    null,
+                    PRINCIPAL_NAME,
+                    Set.of(
+                            DefaultAuthenticator.PRINCIPAL_ROLE_PREFIX + PRINCIPAL_ROLE1,
+                            DefaultAuthenticator.PRINCIPAL_ROLE_PREFIX + "non-existent-role"));
+
+    assertThatThrownBy(() -> authenticator.resolvePrincipalRoles(credentials, principalEntity))
+            .isInstanceOf(AuthenticationFailedException.class);
+  }
+
+  @Test
+  void testResolvePrincipalRoles_emptyRequestedReturnsEmpty() {
+    PolarisCredential credentials = PolarisCredential.of(null, PRINCIPAL_NAME, Set.of());
+    DefaultAuthenticator.PrincipalRoleSelection selection =
+            authenticator.resolvePrincipalRoles(credentials, principalEntity);
+
+    assertThat(selection.allRolesRequested()).isFalse();
+    assertThat(selection.roles()).isEmpty();
+  }
+
+  @Test
+  void testResolvePrincipalRoles_allRequestedNoGrantsReturnsEmpty() {
+    PolarisCredential credentials =
+            PolarisCredential.of(
+                    null, PRINCIPAL_NAME_NO_ROLES, Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL));
+    DefaultAuthenticator.PrincipalRoleSelection selection =
+            authenticator.resolvePrincipalRoles(credentials, principalEntityNoRoles);
+
+    assertThat(selection.allRolesRequested()).isTrue();
+    assertThat(selection.roles()).isEmpty();
+  }
 }


### PR DESCRIPTION
This PR adds dedicated, isolated unit test coverage for the protected extractRequestedRoles and resolvePrincipalRoles methods in DefaultAuthenticator, addressing Issue #5092.

While behavioral coverage existed via the main authenticate() method, these localized tests act as direct regression guards for the role resolution logic itself.

Key additions in DefaultAuthenticatorTest.java:

extractRequestedRoles tests: Verified prefix stripping (PRINCIPAL_ROLE:), handling of the :ALL flag, filtering of unprefixed invalid scopes, and empty credential scopes.

resolvePrincipalRoles tests: Verified integration with the metastore using the pre-created principalEntity, ensuring that valid subsets and the :ALL flag return correctly granted roles, while requested but ungranted roles strictly throw an AuthenticationFailedException.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #5092 
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
