### PR TITLE
Avoid re-reading view metadata from storage after a commit

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -75,6 +75,17 @@ public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
               .defaultValue(true)
               .buildBehaviorChangeConfiguration();
 
+  public static final BehaviorChangeConfiguration<Boolean>
+      VIEW_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT =
+          PolarisConfiguration.<Boolean>builder()
+              .key("VIEW_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT")
+              .description(
+                  "If true, BasePolarisViewOperations should mark the metadata that is passed into"
+                      + " `commit` as current, and reuse it to skip a trip to object storage to re-construct"
+                      + " the committed metadata again.")
+              .defaultValue(true)
+              .buildBehaviorChangeConfiguration();
+
   public static final BehaviorChangeConfiguration<Boolean> ALLOW_NAMESPACE_CUSTOM_LOCATION =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_NAMESPACE_CUSTOM_LOCATION")

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -1017,9 +1017,17 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
   }
 
   @VisibleForTesting
+  public ViewOperations newViewOps(
+      TableIdentifier identifier, boolean makeMetadataCurrentOnCommit) {
+    return new BasePolarisViewOperations(catalogFileIO, identifier, makeMetadataCurrentOnCommit);
+  }
+
   @Override
   protected ViewOperations newViewOps(TableIdentifier identifier) {
-    return new BasePolarisViewOperations(catalogFileIO, identifier);
+    boolean makeMetadataCurrentOnCommit =
+        realmConfig.getConfig(
+            BehaviorChangeConfiguration.VIEW_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT);
+    return newViewOps(identifier, makeMetadataCurrentOnCommit);
   }
 
   /**
@@ -2210,12 +2218,15 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       implements ViewOperations {
     private final TableIdentifier identifier;
     private final String fullViewName;
+    private final boolean makeMetadataCurrentOnCommit;
     private FileIO viewFileIO;
 
-    BasePolarisViewOperations(FileIO defaultFileIO, TableIdentifier identifier) {
+    BasePolarisViewOperations(
+        FileIO defaultFileIO, TableIdentifier identifier, boolean makeMetadataCurrentOnCommit) {
       this.viewFileIO = defaultFileIO;
       this.identifier = identifier;
       this.fullViewName = ViewUtil.fullViewName(catalogName, identifier);
+      this.makeMetadataCurrentOnCommit = makeMetadataCurrentOnCommit;
     }
 
     @Override
@@ -2448,6 +2459,11 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
           createTableLike(identifier, entity, true);
         } else {
           updateTableLike(identifier, entity, true);
+        }
+        if (makeMetadataCurrentOnCommit) {
+          currentMetadata =
+              ViewMetadata.buildFrom(metadata).setMetadataLocation(newLocation).build();
+          currentMetadataLocation = newLocation;
         }
         writeSucceeded = true;
       } finally {

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -102,6 +102,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceSet;
@@ -110,6 +111,7 @@ import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
 import org.apache.iceberg.view.ImmutableViewVersion;
 import org.apache.iceberg.view.ViewMetadata;
 import org.apache.iceberg.view.ViewMetadataParser;
+import org.apache.iceberg.view.ViewOperations;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
@@ -3050,6 +3052,52 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
           Mockito.times(expectedReads));
     } finally {
       catalog.dropTable(TABLE, true);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testViewOperationsDoesNotRefreshAfterCommit(boolean updateMetadataOnCommit) {
+    Assumptions.assumeTrue(
+        requiresNamespaceCreate(),
+        "Only applicable if namespaces must be created before adding children");
+
+    catalog.createNamespace(NS);
+    catalog
+        .buildView(TABLE)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(NS)
+        .withQuery("spark", VIEW_QUERY)
+        .create();
+
+    ViewOperations ops = catalog.newViewOps(TABLE, updateMetadataOnCommit);
+
+    try (MockedStatic<ViewMetadataParser> mocked =
+        Mockito.mockStatic(ViewMetadataParser.class, Mockito.CALLS_REAL_METHODS)) {
+      ViewMetadata base1 = ops.current();
+      mocked.verify(() -> ViewMetadataParser.read(Mockito.any(InputFile.class)), Mockito.times(1));
+
+      ViewMetadata base2 = ops.refresh();
+      mocked.verify(() -> ViewMetadataParser.read(Mockito.any(InputFile.class)), Mockito.times(1));
+
+      Assertions.assertThat(base1.metadataFileLocation()).isEqualTo(base2.metadataFileLocation());
+
+      ViewMetadata newMetadata =
+          ViewMetadata.buildFrom(base2).setProperties(Map.of("new_prop", "new_value")).build();
+      ops.commit(base2, newMetadata);
+      mocked.verify(() -> ViewMetadataParser.read(Mockito.any(InputFile.class)), Mockito.times(1));
+
+      ops.current();
+      int expectedReads = updateMetadataOnCommit ? 1 : 2;
+      mocked.verify(
+          () -> ViewMetadataParser.read(Mockito.any(InputFile.class)),
+          Mockito.times(expectedReads));
+      ops.refresh();
+      mocked.verify(
+          () -> ViewMetadataParser.read(Mockito.any(InputFile.class)),
+          Mockito.times(expectedReads));
+    } finally {
+      catalog.dropView(TABLE);
     }
   }
 

--- a/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_behavior_changes.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_behavior_changes.md
@@ -79,3 +79,12 @@ If true, validate that view locations don't overlap when views are created
 - **Default:** `true`
 
 ---
+
+##### `polaris.behavior-changes."VIEW_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT"`
+
+If true, BasePolarisViewOperations should mark the metadata that is passed into `commit` as current, and reuse it to skip a trip to object storage to re-construct the committed metadata again.
+
+- **Type:** `Boolean`
+- **Default:** `true`
+
+---


### PR DESCRIPTION
 `BasePolarisViewOperations` leaves `currentMetadata` and `currentMetadataLocation` untouched after a successful commit, so the refresh that follows finds a stale metadata location and re-reads the metadata file that was just written back from object storage. `BasePolarisTableOperations` already marks the committed metadata as current for exactly this reason, gated by `TABLE_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT`, but views never got the same treatment, so every view commit pays an avoidable storage round trip. This mirrors the table behaviour for views behind a matching `VIEW_OPERATIONS_MAKE_METADATA_CURRENT_ON_COMMIT` flag, updating the in-memory state only after the metastore write succeeds so a failed commit cannot leave the operations instance pointing at a location the cleanup deletes.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
