### PR TITLE
NoSQL: Fix NPE when an entity that is not catalog content carries a location property

### DIFF
--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/MutationAttempt.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/mutation/MutationAttempt.java
@@ -535,6 +535,10 @@ public record MutationAttempt(
 
   public static void updateLocationsIndex(
       UpdatableIndex<EntityIdSet> locations, ObjBase originalObj, ObjBase entityObj) {
+    if (locations == null) {
+      return;
+    }
+
     var previousBaseLocation =
         originalObj != null ? originalObj.properties().get(ENTITY_BASE_LOCATION) : null;
     var entityBaseLocation =

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -38,6 +38,7 @@ import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.entity.AsyncTaskType;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisTaskConstants;
@@ -45,6 +46,8 @@ import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.TaskEntity;
 import org.apache.polaris.core.exceptions.AlreadyExistsException;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.DropEntityResult;
+import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.pagination.PageToken;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -558,5 +561,64 @@ public abstract class BasePolarisMetaStoreManagerTest {
                 metaStoreManager.resetPrincipalSecrets(
                     callCtx, principalB.getId(), principalAClientId, null))
         .isInstanceOf(AlreadyExistsException.class);
+  }
+
+  /**
+   * {@link PolarisEntityConstants#ENTITY_BASE_LOCATION} is an ordinary user-settable property, so
+   * entities that are not catalog content may carry it. Those entities are not location-tracked, so
+   * creating, updating and dropping them must all succeed regardless.
+   */
+  @Test
+  protected void testBaseLocationPropertyOnEntityThatIsNotCatalogContent() {
+    PolarisMetaStoreManager metaStoreManager = polarisTestMetaStoreManager.polarisMetaStoreManager;
+    PolarisCallContext callCtx = polarisTestMetaStoreManager.polarisCallContext;
+    Map<String, String> properties =
+        Map.of(PolarisEntityConstants.ENTITY_BASE_LOCATION, "s3://bucket/path/");
+
+    // creating a principal role that carries a base location must succeed
+    PolarisBaseEntity principalRole =
+        polarisTestMetaStoreManager.createEntity(
+            null,
+            PolarisEntityType.PRINCIPAL_ROLE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            "principalRoleWithLocation",
+            properties);
+    Assertions.assertThat(principalRole.getPropertiesAsMap())
+        .containsEntry(PolarisEntityConstants.ENTITY_BASE_LOCATION, "s3://bucket/path/");
+
+    // a catalog that carries one must remain updatable afterwards
+    PolarisBaseEntity catalog =
+        new PolarisBaseEntity.Builder()
+            .catalogId(PolarisEntityConstants.getNullId())
+            .id(metaStoreManager.generateNewEntityId(callCtx).getId())
+            .typeCode(PolarisEntityType.CATALOG.getCode())
+            .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
+            .parentId(PolarisEntityConstants.getRootEntityId())
+            .name("catalogWithLocation")
+            .propertiesAsMap(properties)
+            .internalPropertiesAsMap(Map.of())
+            .build();
+    catalog = metaStoreManager.createCatalog(callCtx, catalog, List.of()).getCatalog();
+    Assertions.assertThat(catalog).isNotNull();
+    catalog =
+        metaStoreManager
+            .loadEntity(callCtx, catalog.getCatalogId(), catalog.getId(), catalog.getType())
+            .getEntity();
+
+    PolarisBaseEntity relocatedCatalog =
+        new PolarisBaseEntity.Builder(catalog)
+            .propertiesAsMap(
+                Map.of(PolarisEntityConstants.ENTITY_BASE_LOCATION, "s3://bucket/other/"))
+            .build();
+    EntityResult updated =
+        metaStoreManager.updateEntityPropertiesIfNotChanged(callCtx, null, relocatedCatalog);
+    Assertions.assertThat(updated.isSuccess()).isTrue();
+    Assertions.assertThat(updated.getEntity().getPropertiesAsMap())
+        .containsEntry(PolarisEntityConstants.ENTITY_BASE_LOCATION, "s3://bucket/other/");
+
+    // and dropping a location-carrying entity must succeed too
+    DropEntityResult dropped =
+        metaStoreManager.dropEntityIfExists(callCtx, null, principalRole, null, false);
+    Assertions.assertThat(dropped.isSuccess()).isTrue();
   }
 }


### PR DESCRIPTION
`NoSQL` persistence keeps a locations index only for catalog content
(namespaces, tables/views, policies). For every other entity type —
catalog, catalog role, principal, principal role, task —
`NoSqlMetaStore.performEntityMutations` passes null for that index.

`MutationAttempt.updateLocationsIndex` dereferences it without a `null`
check, unlike the sibling changes index, which is guarded at all four
of its use sites in the same class. The method returns early when old
and new locations are equal, which is why this has gone unnoticed —
but that only holds while the entity has no "location" property at
all. As soon as one carries it, the index is dereferenced and the
mutation fails with an `NPE`.

`PolarisEntityConstants.ENTITY_BASE_LOCATION` is the literal string
"location": an ordinary, user-settable property key.
`ReservedProperties` (default config) only strips the `polaris`. prefix,
so a client-supplied "location" reaches persistence verbatim. The
management API OpenAPI schemas expose open property bags on these
entity types, so this is reachable under default configuration.

Two ways it shows up

**1. Create fails with a 500 (recoverable)**

POST /api/management/v1/principal-roles (likewise /principals and
/catalogs/{catalogName}/catalog-roles) with "properties": {"location":
"s3://bucket/path/"} throws before anything is written:
```
java.lang.NullPointerException: Cannot invoke
"org.apache.polaris.persistence.nosql.api.index.UpdatableIndex.get(...IndexKey)"
because "locations" is null
at org.apache.polaris.persistence.nosql.metastore.mutation.MutationAttempt.updateLocationsIndex(MutationAttempt.java:567)
at org.apache.polaris.persistence.nosql.metastore.mutation.MutationAttempt.applyEntityCreateMutation(MutationAttempt.java:506)
at org.apache.polaris.persistence.nosql.metastore.mutation.MutationAttempt.apply(MutationAttempt.java:115)
at org.apache.polaris.persistence.nosql.metastore.NoSqlMetaStore.lambda$performEntityMutations$19(NoSqlMetaStore.java:616)
at org.apache.polaris.persistence.nosql.metastore.NoSqlMetaStore.performEntityMutations(NoSqlMetaStore.java:601)
at org.apache.polaris.persistence.nosql.metastore.NoSqlMetaStore.createOrUpdateEntity(NoSqlMetaStore.java:369)
at org.apache.polaris.persistence.nosql.metastore.NoSqlMetaStoreManager.createEntityIfNotExists(NoSqlMetaStoreManager.java:119)
```
Nothing is persisted, so the caller can retry without the property.
Annoying, but recoverable.

**2. A catalog is left stuck on the management API**

POST /api/management/v1/catalogs with the same property succeeds,
because createCatalog is a bespoke committer that never touches the
locations index. Every subsequent mutation of that catalog goes
through the generic path and fails:

Update (PUT /api/management/v1/catalogs/{catalogName}):
```
java.lang.NullPointerException: Cannot invoke
"org.apache.polaris.persistence.nosql.api.index.UpdatableIndex.get(...IndexKey)"
because "locations" is null
at org.apache.polaris.persistence.nosql.metastore.mutation.MutationAttempt.updateLocationsIndex(MutationAttempt.java:551)
at org.apache.polaris.persistence.nosql.metastore.mutation.MutationAttempt.applyEntityUpdateMutation(MutationAttempt.java:412)
at org.apache.polaris.persistence.nosql.metastore.mutation.MutationAttempt.apply(MutationAttempt.java:125)
at org.apache.polaris.persistence.nosql.metastore.NoSqlMetaStore.lambda$performEntityMutations$19(NoSqlMetaStore.java:616)
at org.apache.polaris.persistence.nosql.metastore.NoSqlMetaStore.performEntityMutations(NoSqlMetaStore.java:601)
at org.apache.polaris.persistence.nosql.metastore.NoSqlMetaStore.createOrUpdateEntity(NoSqlMetaStore.java:369)
```
Delete (DELETE /api/management/v1/catalogs/{catalogName}):
```
java.lang.NullPointerException: Cannot invoke
"org.apache.polaris.persistence.nosql.api.index.UpdatableIndex.get(...IndexKey)"
because "locations" is null
at org.apache.polaris.persistence.nosql.metastore.mutation.MutationAttempt.updateLocationsIndex(MutationAttempt.java:551)
at org.apache.polaris.persistence.nosql.metastore.mutation.MutationAttempt.applyEntityDeleteMutation(MutationAttempt.java:207)
at org.apache.polaris.persistence.nosql.metastore.mutation.MutationAttempt.apply(MutationAttempt.java:135)
at org.apache.polaris.persistence.nosql.metastore.NoSqlMetaStore.lambda$performEntityMutations$19(NoSqlMetaStore.java:616)
at org.apache.polaris.persistence.nosql.metastore.NoSqlMetaStore.performEntityMutations(NoSqlMetaStore.java:601)
```

The catalog record remains in the metastore but cannot be updated or
deleted via the management API until the stray "location" property is
removed (e.g. direct metastore edit). Catalog content operations
(namespaces, tables) may still work, since those use the
catalog-content path with a real locations index.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
