### PR TITLE
Return 503 instead of 500 when the metastore fails during authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   `CREATE NAMESPACE` fell back to a realm-wide scan instead of the intended indexed lookup. A new
   schema version 6 creates the index on `(realm_id, catalog_id, location_without_scheme)`; H2 was
   already correct. Existing deployments need a manual index recreation — see Upgrade notes.
+- A metastore failure while resolving a principal's roles during authentication now returns HTTP 503, as it already did when looking up the principal entity. Previously the failure propagated unwrapped and was reported as HTTP 500, so a backend that served the principal lookup but failed on the grant lookups was reported as a server defect.
 
 ### Commits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   `CREATE NAMESPACE` fell back to a realm-wide scan instead of the intended indexed lookup. A new
   schema version 6 creates the index on `(realm_id, catalog_id, location_without_scheme)`; H2 was
   already correct. Existing deployments need a manual index recreation — see Upgrade notes.
-- A metastore failure while resolving a principal's roles during authentication now returns HTTP 503, as it already did when looking up the principal entity; previously it propagated unwrapped and was reported as HTTP 500. All three lookups now report `PolarisServiceUnavailableException` as the error `type`, where the principal entity lookup previously reported `ServiceUnavailableException` with the same status.
+- A metastore failure while resolving a principal's roles during authentication now returns HTTP 503, as it already did when looking up the principal entity; previously it propagated unwrapped and was reported as HTTP 500. All three lookups now report `PolarisServiceUnavailableException` as the error `type`, where the principal entity lookup previously reported `ServiceUnavailableException` with the same status. All three also send `Retry-After: 0`; the Iceberg REST spec has a client retry a non-idempotent request only when that header is present.
 
 ### Commits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   `CREATE NAMESPACE` fell back to a realm-wide scan instead of the intended indexed lookup. A new
   schema version 6 creates the index on `(realm_id, catalog_id, location_without_scheme)`; H2 was
   already correct. Existing deployments need a manual index recreation — see Upgrade notes.
-- A metastore failure while resolving a principal's roles during authentication now returns HTTP 503, as it already did when looking up the principal entity. Previously the failure propagated unwrapped and was reported as HTTP 500, so a backend that served the principal lookup but failed on the grant lookups was reported as a server defect.
+- A metastore failure while resolving a principal's roles during authentication now returns HTTP 503, as it already did when looking up the principal entity; previously it propagated unwrapped and was reported as HTTP 500. All three lookups now report `PolarisServiceUnavailableException` as the error `type`, where the principal entity lookup previously reported `ServiceUnavailableException` with the same status.
 
 ### Commits
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/exceptions/PolarisServiceUnavailableException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/exceptions/PolarisServiceUnavailableException.java
@@ -24,6 +24,9 @@ import jakarta.ws.rs.core.Response;
 /**
  * Signals a transient failure that the client may resolve by retrying. Mapped to HTTP 503 (Service
  * Unavailable) with a {@code Retry-After} header whose value is {@link #getRetryAfterSeconds()}.
+ *
+ * <p>{@code Retry-After} admits only a non-negative delay, so a negative {@code retryAfterSeconds}
+ * is stored as {@code 0}.
  */
 public class PolarisServiceUnavailableException extends PolarisException {
 
@@ -32,7 +35,7 @@ public class PolarisServiceUnavailableException extends PolarisException {
   @FormatMethod
   public PolarisServiceUnavailableException(int retryAfterSeconds, String message, Object... args) {
     super(String.format(message, args));
-    this.retryAfterSeconds = retryAfterSeconds;
+    this.retryAfterSeconds = Math.max(0, retryAfterSeconds);
   }
 
   public int getRetryAfterSeconds() {

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
@@ -311,6 +311,7 @@ public class DefaultAuthenticator implements Authenticator {
       Exception cause, String logMessage, String responseMessage) {
     LOGGER
         .atError()
+        .setCause(cause)
         .addKeyValue(StructuredLogKeys.ERR_MSG, cause.getMessage())
         .addKeyValue(StructuredLogKeys.STACK_TRACE, Throwables.getStackTraceAsString(cause))
         .log(logMessage);

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
@@ -25,7 +25,6 @@ import io.quarkus.security.identity.SecurityIdentity;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.ServiceUnavailableException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -40,6 +39,7 @@ import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
+import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.dao.entity.LoadGrantsResult;
 import org.eclipse.microprofile.jwt.JsonWebToken;
@@ -307,7 +307,7 @@ public class DefaultAuthenticator implements Authenticator {
    * Logs a metastore failure raised during authentication and returns the exception to throw, so
    * that a failing backend is reported as a transient condition instead of an internal error.
    */
-  private static ServiceUnavailableException metaStoreUnavailable(
+  private static PolarisServiceUnavailableException metaStoreUnavailable(
       Exception cause, String logMessage, String responseMessage) {
     LOGGER
         .atError()
@@ -315,7 +315,7 @@ public class DefaultAuthenticator implements Authenticator {
         .addKeyValue(StructuredLogKeys.ERR_MSG, cause.getMessage())
         .addKeyValue(StructuredLogKeys.STACK_TRACE, Throwables.getStackTraceAsString(cause))
         .log(logMessage);
-    return new ServiceUnavailableException(responseMessage);
+    return new PolarisServiceUnavailableException(0, "%s", responseMessage);
   }
 
   protected record PrincipalRoleSelection(Set<String> roles, boolean allRolesRequested) {}

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
@@ -146,8 +146,10 @@ public class DefaultAuthenticator implements Authenticator {
     } catch (Exception e) {
       throw metaStoreUnavailable(
           e,
-          "Unable to resolve principal entity from credentials",
-          "Unable to fetch principal entity");
+          "Unable to fetch principal entity",
+          "Unable to resolve principal entity from credentials, principalName={} principalId={}",
+          credentials.getPrincipalName(),
+          credentials.getPrincipalId());
     }
 
     if (principal == null || principal.getType() != PolarisEntityType.PRINCIPAL) {
@@ -194,7 +196,7 @@ public class DefaultAuthenticator implements Authenticator {
 
     Set<String> activeRoles =
         loadGrantsResult.getGrantRecords().stream()
-            .map(gr -> loadSecurableEntity(gr, entitiesById))
+            .map(gr -> loadSecurableEntity(gr, entitiesById, principal))
             .filter(Objects::nonNull)
             .filter(entity -> entity.getType() == PolarisEntityType.PRINCIPAL_ROLE)
             .map(PrincipalRoleEntity::of)
@@ -261,7 +263,11 @@ public class DefaultAuthenticator implements Authenticator {
       principalGrantResults = metaStoreManager.loadGrantsToGrantee(polarisContext, principal);
     } catch (Exception e) {
       throw metaStoreUnavailable(
-          e, "Unable to load grants for principal", "Unable to fetch principal grants");
+          e,
+          "Unable to fetch principal grants",
+          "Unable to load grants, principalName={} principalId={}",
+          principal.getName(),
+          principal.getId());
     }
     diagnostics.check(
         principalGrantResults.isSuccess(),
@@ -281,10 +287,13 @@ public class DefaultAuthenticator implements Authenticator {
   /**
    * Resolves the securable entity for a grant record, using preloaded entities when available and
    * falling back to {@link PolarisMetaStoreManager#loadEntity} only when the metastore did not
-   * populate {@link LoadGrantsResult#getEntities()}.
+   * populate {@link LoadGrantsResult#getEntities()}. The principal identifies the failing request
+   * if that fallback hits a metastore failure.
    */
   private @Nullable PolarisBaseEntity loadSecurableEntity(
-      PolarisGrantRecord grant, @Nullable Map<Long, PolarisBaseEntity> entitiesById) {
+      PolarisGrantRecord grant,
+      @Nullable Map<Long, PolarisBaseEntity> entitiesById,
+      PrincipalEntity principal) {
     if (entitiesById != null) {
       return entitiesById.get(grant.getSecurableId());
     }
@@ -299,21 +308,33 @@ public class DefaultAuthenticator implements Authenticator {
           .getEntity();
     } catch (Exception e) {
       throw metaStoreUnavailable(
-          e, "Unable to load securable entity for grant", "Unable to fetch securable entity");
+          e,
+          "Unable to fetch securable entity",
+          "Unable to load securable entity for grant, principalName={} principalId={} "
+              + "securableCatalogId={} securableId={}",
+          principal.getName(),
+          principal.getId(),
+          grant.getSecurableCatalogId(),
+          grant.getSecurableId());
     }
   }
 
   /**
    * Logs a metastore failure raised during authentication and returns the exception to throw, so
    * that a failing backend is reported as a transient condition instead of an internal error.
+   *
+   * @param cause the metastore failure
+   * @param responseMessage the message returned to the client
+   * @param logMessage the log message, with SLF4J placeholders for {@code logArgs}
+   * @param logArgs the values for the placeholders in {@code logMessage}
    */
   private static PolarisServiceUnavailableException metaStoreUnavailable(
-      Exception cause, String logMessage, String responseMessage) {
+      Exception cause, String responseMessage, String logMessage, Object... logArgs) {
     LOGGER
         .atError()
         .addKeyValue(StructuredLogKeys.ERR_MSG, cause.getMessage())
         .addKeyValue(StructuredLogKeys.STACK_TRACE, Throwables.getStackTraceAsString(cause))
-        .log(logMessage);
+        .log(logMessage, logArgs);
     return new PolarisServiceUnavailableException(0, "%s", responseMessage);
   }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
@@ -144,12 +144,10 @@ public class DefaultAuthenticator implements Authenticator {
                 .orElse(null);
       }
     } catch (Exception e) {
-      LOGGER
-          .atError()
-          .addKeyValue(StructuredLogKeys.ERR_MSG, e.getMessage())
-          .addKeyValue(StructuredLogKeys.STACK_TRACE, Throwables.getStackTraceAsString(e))
-          .log("Unable to resolve principal entity from credentials");
-      throw new ServiceUnavailableException("Unable to fetch principal entity");
+      throw metaStoreUnavailable(
+          e,
+          "Unable to resolve principal entity from credentials",
+          "Unable to fetch principal entity");
     }
 
     if (principal == null || principal.getType() != PolarisEntityType.PRINCIPAL) {
@@ -258,8 +256,13 @@ public class DefaultAuthenticator implements Authenticator {
    */
   protected LoadGrantsResult loadPrincipalGrants(PrincipalEntity principal) {
     PolarisCallContext polarisContext = callContext.getPolarisCallContext();
-    LoadGrantsResult principalGrantResults =
-        metaStoreManager.loadGrantsToGrantee(polarisContext, principal);
+    LoadGrantsResult principalGrantResults;
+    try {
+      principalGrantResults = metaStoreManager.loadGrantsToGrantee(polarisContext, principal);
+    } catch (Exception e) {
+      throw metaStoreUnavailable(
+          e, "Unable to load grants for principal", "Unable to fetch principal grants");
+    }
     diagnostics.check(
         principalGrantResults.isSuccess(),
         "Failed to resolve principal roles for principal name={} id={}",
@@ -285,13 +288,33 @@ public class DefaultAuthenticator implements Authenticator {
     if (entitiesById != null) {
       return entitiesById.get(grant.getSecurableId());
     }
-    return metaStoreManager
-        .loadEntity(
-            callContext.getPolarisCallContext(),
-            grant.getSecurableCatalogId(),
-            grant.getSecurableId(),
-            PolarisEntityType.PRINCIPAL_ROLE)
-        .getEntity();
+    PolarisCallContext polarisContext = callContext.getPolarisCallContext();
+    try {
+      return metaStoreManager
+          .loadEntity(
+              polarisContext,
+              grant.getSecurableCatalogId(),
+              grant.getSecurableId(),
+              PolarisEntityType.PRINCIPAL_ROLE)
+          .getEntity();
+    } catch (Exception e) {
+      throw metaStoreUnavailable(
+          e, "Unable to load securable entity for grant", "Unable to fetch securable entity");
+    }
+  }
+
+  /**
+   * Logs a metastore failure raised during authentication and returns the exception to throw, so
+   * that a failing backend is reported as a transient condition instead of an internal error.
+   */
+  private static ServiceUnavailableException metaStoreUnavailable(
+      Exception cause, String logMessage, String responseMessage) {
+    LOGGER
+        .atError()
+        .addKeyValue(StructuredLogKeys.ERR_MSG, cause.getMessage())
+        .addKeyValue(StructuredLogKeys.STACK_TRACE, Throwables.getStackTraceAsString(cause))
+        .log(logMessage);
+    return new ServiceUnavailableException(responseMessage);
   }
 
   protected record PrincipalRoleSelection(Set<String> roles, boolean allRolesRequested) {}

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
@@ -311,7 +311,6 @@ public class DefaultAuthenticator implements Authenticator {
       Exception cause, String logMessage, String responseMessage) {
     LOGGER
         .atError()
-        .setCause(cause)
         .addKeyValue(StructuredLogKeys.ERR_MSG, cause.getMessage())
         .addKeyValue(StructuredLogKeys.STACK_TRACE, Throwables.getStackTraceAsString(cause))
         .log(logMessage);

--- a/runtime/service/src/main/java/org/apache/polaris/service/exception/PolarisExceptionMapper.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/exception/PolarisExceptionMapper.java
@@ -57,7 +57,7 @@ public class PolarisExceptionMapper implements ExceptionMapper<PolarisException>
     Response.ResponseBuilder builder =
         Response.status(statusCode).entity(errorResponse).type(MediaType.APPLICATION_JSON_TYPE);
     if (exception instanceof PolarisServiceUnavailableException e
-        && e.getRetryAfterSeconds() != 0) {
+        && e.getRetryAfterSeconds() >= 0) {
       builder.header(HttpHeaders.RETRY_AFTER, e.getRetryAfterSeconds());
     }
     return builder.build();

--- a/runtime/service/src/main/java/org/apache/polaris/service/exception/PolarisExceptionMapper.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/exception/PolarisExceptionMapper.java
@@ -56,8 +56,7 @@ public class PolarisExceptionMapper implements ExceptionMapper<PolarisException>
             .build();
     Response.ResponseBuilder builder =
         Response.status(statusCode).entity(errorResponse).type(MediaType.APPLICATION_JSON_TYPE);
-    if (exception instanceof PolarisServiceUnavailableException e
-        && e.getRetryAfterSeconds() >= 0) {
+    if (exception instanceof PolarisServiceUnavailableException e) {
       builder.header(HttpHeaders.RETRY_AFTER, e.getRetryAfterSeconds());
     }
     return builder.build();

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
@@ -155,6 +155,53 @@ public class DefaultAuthenticatorTest {
   }
 
   @Test
+  void testLoadGrantsThrowsServiceExceptionOnMetastoreException() {
+    // Given: a metastore that fails while loading the principal's grants
+    PolarisCredential credentials =
+        PolarisCredential.of(
+            principalEntity.getId(), null, Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL));
+
+    PolarisMetaStoreManager metaStoreManagerSpy = Mockito.spy(metaStoreManager);
+    Mockito.doThrow(new RuntimeException("Metastore exception"))
+        .when(metaStoreManagerSpy)
+        .loadGrantsToGrantee(any(), any());
+
+    DefaultAuthenticator standaloneAuthenticator = newStandaloneAuthenticator(metaStoreManagerSpy);
+
+    // When/Then: the metastore failure should surface as ServiceUnavailableException
+    assertThatThrownBy(() -> standaloneAuthenticator.authenticate(identityFor(credentials)))
+        .isInstanceOf(ServiceUnavailableException.class);
+  }
+
+  @Test
+  void testLoadSecurableEntityThrowsServiceExceptionOnMetastoreException() {
+    // Given: grants without preloaded entities, so role resolution falls back to loadEntity,
+    // and a metastore that fails on that fallback
+    LoadGrantsResult grants =
+        metaStoreManager.loadGrantsToGrantee(callContext.getPolarisCallContext(), principalEntity);
+    LoadGrantsResult grantsWithoutEntities =
+        new LoadGrantsResult(grants.getGrantsVersion(), grants.getGrantRecords(), null);
+
+    PolarisMetaStoreManager metaStoreManagerSpy = Mockito.spy(metaStoreManager);
+    Mockito.doReturn(grantsWithoutEntities)
+        .when(metaStoreManagerSpy)
+        .loadGrantsToGrantee(
+            any(), Mockito.argThat(p -> p != null && p.getId() == principalEntity.getId()));
+    Mockito.doThrow(new RuntimeException("Metastore exception"))
+        .when(metaStoreManagerSpy)
+        .loadEntity(any(), anyLong(), anyLong(), Mockito.eq(PolarisEntityType.PRINCIPAL_ROLE));
+
+    PolarisCredential credentials =
+        PolarisCredential.of(null, PRINCIPAL_NAME, Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL));
+
+    DefaultAuthenticator standaloneAuthenticator = newStandaloneAuthenticator(metaStoreManagerSpy);
+
+    // When/Then: the metastore failure should surface as ServiceUnavailableException
+    assertThatThrownBy(() -> standaloneAuthenticator.authenticate(identityFor(credentials)))
+        .isInstanceOf(ServiceUnavailableException.class);
+  }
+
+  @Test
   void testAuthenticationByPrincipalId() {
     // Given: credentials with principal ID instead of name
     PolarisCredential credentials =

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
@@ -151,7 +151,9 @@ public class DefaultAuthenticatorTest {
     DefaultAuthenticator standaloneAuthenticator = newStandaloneAuthenticator(metaStoreManagerSpy);
 
     assertThatThrownBy(() -> standaloneAuthenticator.authenticate(identityFor(credentials)))
-        .isInstanceOf(PolarisServiceUnavailableException.class);
+        .isInstanceOfSatisfying(
+            PolarisServiceUnavailableException.class,
+            e -> assertThat(e.getRetryAfterSeconds()).isZero());
   }
 
   @Test
@@ -170,7 +172,9 @@ public class DefaultAuthenticatorTest {
 
     // When/Then: the metastore failure should surface as PolarisServiceUnavailableException
     assertThatThrownBy(() -> standaloneAuthenticator.authenticate(identityFor(credentials)))
-        .isInstanceOf(PolarisServiceUnavailableException.class);
+        .isInstanceOfSatisfying(
+            PolarisServiceUnavailableException.class,
+            e -> assertThat(e.getRetryAfterSeconds()).isZero());
   }
 
   @Test
@@ -198,7 +202,9 @@ public class DefaultAuthenticatorTest {
 
     // When/Then: the metastore failure should surface as PolarisServiceUnavailableException
     assertThatThrownBy(() -> standaloneAuthenticator.authenticate(identityFor(credentials)))
-        .isInstanceOf(PolarisServiceUnavailableException.class);
+        .isInstanceOfSatisfying(
+            PolarisServiceUnavailableException.class,
+            e -> assertThat(e.getRetryAfterSeconds()).isZero());
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
@@ -34,7 +34,6 @@ import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.ServiceUnavailableException;
 import java.util.Map;
 import java.util.Set;
 import org.apache.polaris.core.PolarisDiagnostics;
@@ -46,6 +45,7 @@ import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.PrincipalRoleEntity;
+import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.dao.entity.LoadGrantsResult;
@@ -151,7 +151,7 @@ public class DefaultAuthenticatorTest {
     DefaultAuthenticator standaloneAuthenticator = newStandaloneAuthenticator(metaStoreManagerSpy);
 
     assertThatThrownBy(() -> standaloneAuthenticator.authenticate(identityFor(credentials)))
-        .isInstanceOf(ServiceUnavailableException.class);
+        .isInstanceOf(PolarisServiceUnavailableException.class);
   }
 
   @Test
@@ -168,9 +168,9 @@ public class DefaultAuthenticatorTest {
 
     DefaultAuthenticator standaloneAuthenticator = newStandaloneAuthenticator(metaStoreManagerSpy);
 
-    // When/Then: the metastore failure should surface as ServiceUnavailableException
+    // When/Then: the metastore failure should surface as PolarisServiceUnavailableException
     assertThatThrownBy(() -> standaloneAuthenticator.authenticate(identityFor(credentials)))
-        .isInstanceOf(ServiceUnavailableException.class);
+        .isInstanceOf(PolarisServiceUnavailableException.class);
   }
 
   @Test
@@ -196,9 +196,9 @@ public class DefaultAuthenticatorTest {
 
     DefaultAuthenticator standaloneAuthenticator = newStandaloneAuthenticator(metaStoreManagerSpy);
 
-    // When/Then: the metastore failure should surface as ServiceUnavailableException
+    // When/Then: the metastore failure should surface as PolarisServiceUnavailableException
     assertThatThrownBy(() -> standaloneAuthenticator.authenticate(identityFor(credentials)))
-        .isInstanceOf(ServiceUnavailableException.class);
+        .isInstanceOf(PolarisServiceUnavailableException.class);
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
@@ -116,9 +116,7 @@ public class ExceptionMapperTest {
   }
 
   @ParameterizedTest
-  @CsvSource(
-      value = {"3, 3", "0, 0", "-1, null"},
-      nullValues = "null")
+  @CsvSource({"3, 3", "0, 0", "-1, 0"})
   public void testServiceUnavailableRetryAfter(int retryAfterSeconds, String expectedHeader) {
     PolarisExceptionMapper mapper = new PolarisExceptionMapper();
     Response response =

--- a/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
@@ -56,6 +56,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -114,13 +115,17 @@ public class ExceptionMapperTest {
     assertThat(response.getStatus()).isEqualTo(409);
   }
 
-  @Test
-  public void testServiceUnavailableWithRetryAfter() {
+  @ParameterizedTest
+  @CsvSource(
+      value = {"3, 3", "0, 0", "-1, null"},
+      nullValues = "null")
+  public void testServiceUnavailableRetryAfter(int retryAfterSeconds, String expectedHeader) {
     PolarisExceptionMapper mapper = new PolarisExceptionMapper();
     Response response =
-        mapper.toResponse(new PolarisServiceUnavailableException(3, "transient conflict"));
+        mapper.toResponse(
+            new PolarisServiceUnavailableException(retryAfterSeconds, "transient conflict"));
     assertThat(response.getStatus()).isEqualTo(503);
-    assertThat(response.getHeaderString(HttpHeaders.RETRY_AFTER)).isEqualTo("3");
+    assertThat(response.getHeaderString(HttpHeaders.RETRY_AFTER)).isEqualTo(expectedHeader);
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.azure.core.exception.AzureException;
 import com.azure.core.exception.HttpResponseException;
 import com.google.cloud.storage.StorageException;
-import jakarta.ws.rs.ServiceUnavailableException;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -119,9 +118,7 @@ public class IcebergExceptionMapperTest {
         Arguments.of(new CommitStateUnknownException(new RuntimeException("db timeout")), 500),
         Arguments.of(new CommitFailedException("commit failed"), 409),
         Arguments.of(new AlreadyExistsException("already exists"), 409),
-        Arguments.of(new ValidationException("invalid"), 400),
-        // The JAX-RS exception, not Iceberg's; handled by the WebApplicationException case.
-        Arguments.of(new ServiceUnavailableException("service unavailable"), 503));
+        Arguments.of(new ValidationException("invalid"), 400));
   }
 
   @ParameterizedTest

--- a/runtime/service/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/exception/IcebergExceptionMapperTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.azure.core.exception.AzureException;
 import com.azure.core.exception.HttpResponseException;
 import com.google.cloud.storage.StorageException;
+import jakarta.ws.rs.ServiceUnavailableException;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -118,7 +119,9 @@ public class IcebergExceptionMapperTest {
         Arguments.of(new CommitStateUnknownException(new RuntimeException("db timeout")), 500),
         Arguments.of(new CommitFailedException("commit failed"), 409),
         Arguments.of(new AlreadyExistsException("already exists"), 409),
-        Arguments.of(new ValidationException("invalid"), 400));
+        Arguments.of(new ValidationException("invalid"), 400),
+        // The JAX-RS exception, not Iceberg's; handled by the WebApplicationException case.
+        Arguments.of(new ServiceUnavailableException("service unavailable"), 503));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
`DefaultAuthenticator.authenticate()` reaches the metastore in three places, and only one of them
translates a backend failure into a retryable error:

| lookup | site | on metastore failure |
| --- | --- | --- |
| `findPrincipalById` / `findPrincipalByName` | `resolvePrincipalEntity` | `ServiceUnavailableException` -> 503 |
| `loadGrantsToGrantee` | `loadPrincipalGrants` | propagates unwrapped -> 500 |
| `loadEntity` | `loadSecurableEntity` fallback | propagates unwrapped -> 500 |

Nothing between the query and the response turns that failure into a 503.
`JdbcBasePersistenceImpl.loadAllGrantRecordsOnGrantee` reports a `SQLException` as a plain
`RuntimeException`, neither `AtomicOperationMetaStoreManager.loadGrantsToGrantee` nor
`loadPrincipalGrants` catches it, and `IcebergExceptionMapper` falls through to
`default -> INTERNAL_SERVER_ERROR`.

Running first does not make `resolvePrincipalEntity` a gate in front of the other two. It shields them
only when its own query fails, and a backend that fails some queries and not others lets the request
through:

- Failure is per query, not per outage. Against the relational backend, `authenticate()` issues four
  queries for a principal that has grants: the principal lookup, then
  `lookupEntityGrantRecordsVersion`, `loadAllGrantRecordsOnGrantee` and `lookupEntities` inside
  `loadGrantsToGrantee`. Only the first returns 503 today. A saturated connection pool, an overloaded
  node or a timeout under variable load fails individual queries rather than all of them at once, and
  three of the four are the unwrapped ones. The same is true when a full outage begins: a request
  already past the principal lookup takes the 500 path.
- The four are not equally exposed, either. Three of them read `entities` by an indexed key: by id, or
  by the unique name constraint. `loadAllGrantRecordsOnGrantee` filters `grant_records` by grantee, and
  on the CockroachDB schemas in this repo the only index on that table is its primary key, which puts
  the securable columns ahead of the grantee ones.

This is not a new status-mapping proposal: it applies a decision the project already made. During the
#5085 review @flyrain
[flagged](https://github.com/apache/polaris/pull/5085#discussion_r3606848779) exactly this on the
entity path:

> This used to throw Iceberg's `ServiceFailureException`, which `IcebergExceptionMapper` maps to 503
> (SERVICE_UNAVAILABLE). `InternalServerErrorException` is 500. So a transient metastore hiccup during
> auth flips from a retryable 503 to a non-retryable 500 for clients. Is the 500 intended? If so, it's
> worth a CHANGELOG line next to the 401 note.

and @adutra
[replied](https://github.com/apache/polaris/pull/5085#discussion_r3616365279):

> Good catch! No, I intended to keep using 503 but used the wrong exception class. I will amend.

That amend covered `resolvePrincipalEntity`. The grants lookup and the `loadEntity` fallback never came
up in that review.

The logging follows the status. Today neither of these two sites logs anything when its query throws,
so the failure is described by the mapper's fall-through:
`ERROR "Unhandled exception returning INTERNAL_SERVER_ERROR"`, which reports it as a condition the
server does not recognize. After the change the ERROR names the failure where it happens, and the
mapper takes its non-500 path at INFO, which is what the entity lookup already does.

## Change

Both unwrapped lookups now go through the same translation as the entity lookup. That made the logging
block identical in three places, so it moves into a private helper; the existing log and response messages
are passed in unchanged. The helper throws `PolarisServiceUnavailableException`, so all three lookups now
report that as the error `type`, `resolvePrincipalEntity` included; the status stays 503 there.

It passes `0` for `retryAfterSeconds`, so the three responses carry `Retry-After: 0`. Nothing in
`authenticate()` can predict when the metastore recovers, and the Iceberg REST spec has a client retry a
non-idempotent request only when the header is present. `PolarisExceptionMapper` sent the header for a
non-zero value only, so it now sends it for any non-negative one.

This fixes the one method where the project has already decided what the status should be:
`authenticate()` treats one of its own three lookups as a 503 on purpose, and the other two were left
behind.

## Tests

- Three cases in `DefaultAuthenticatorTest`: `loadGrantsToGrantee` throwing, the `loadEntity` fallback
  throwing, and the existing `testFetchPrincipalThrowsServiceExceptionOnMetastoreException`, which now
  expects the same exception. Each pins `retryAfterSeconds` at `0`. Reverting `DefaultAuthenticator` to
  `main` fails all three.
- `ExceptionMapperTest` now drives its `Retry-After` case with `3`, `0` and `-1`, covering the values the
  mapper sends as a header and the one it skips. The 503 status itself was already pinned there.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md`
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (not needed; no page documents these status codes)
