### PR TITLE
Remove CLI dead code

### DIFF
--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -466,15 +466,10 @@ class SetupCommand(Command):
                 ns_details = catalog_api.load_namespace_metadata(
                     prefix=catalog_name, namespace=UNIT_SEPARATOR.join(ns)
                 )
-                if hasattr(ns_details, "location") or hasattr(ns_details, "properties"):
-                    ns_info = {"name": ns_name}
-                    if hasattr(ns_details, "location") and ns_details.location:
-                        ns_info["location"] = ns_details.location
-                    if hasattr(ns_details, "properties") and ns_details.properties:
-                        ns_info["properties"] = ns_details.properties
-                    namespaces_list.append(ns_info)
-                else:
-                    namespaces_list.append(ns_name)
+                ns_info: Dict[str, Any] = {"name": ns_name}
+                if ns_details.properties:
+                    ns_info["properties"] = ns_details.properties
+                namespaces_list.append(ns_info)
         except Exception:
             self._record_failure(
                 f"Failed to export namespaces for catalog '{catalog_name}'"

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -34,6 +34,7 @@ from apache_polaris.sdk.management import (
     FileStorageConfigInfo,
     AwsStorageConfigInfo,
 )
+from apache_polaris.sdk.catalog import GetNamespaceResponse
 
 
 class TestSetupCommand(CLITestBase):
@@ -349,7 +350,9 @@ class TestSetupCommand(CLITestBase):
             return SimpleNamespace(namespaces=namespaces[parent])
 
         catalog_api.list_namespaces.side_effect = list_namespaces
-        catalog_api.load_namespace_metadata.return_value = object()
+        catalog_api.load_namespace_metadata.return_value = GetNamespaceResponse(
+            namespace=["parent"], properties={}
+        )
 
         policy_api = mock_policy_api_class.return_value
         policy_api.list_policies.side_effect = lambda prefix, namespace: (
@@ -395,7 +398,9 @@ class TestSetupCommand(CLITestBase):
 
         catalog = command._export_catalogs(mock_client)[0]
 
-        self.assertEqual(catalog["namespaces"], ["parent", "parent.child"])
+        self.assertEqual(
+            catalog["namespaces"], [{"name": "parent"}, {"name": "parent.child"}]
+        )
         self.assertEqual(
             catalog["policies"],
             {


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

`load_namespace_metadata` returns `GetNamespaceResponse` which doesn't have `location` :
```
class GetNamespaceResponse(BaseModel):
    """
    GetNamespaceResponse
    """ # noqa: E501
    namespace: List[StrictStr] = Field(description="Reference to one or more levels of a namespace")
    properties: Optional[Dict[str, StrictStr]] = Field(default=None, description="Properties stored on the namespace, if supported by the server. If the server does not support namespace properties, it should return null for this field. If namespace properties are supported, but none are set, it should return an empty object.")
    __properties: ClassVar[List[str]] = ["namespace", "properties"]

    model_config = ConfigDict(
        populate_by_name=True,
        validate_assignment=True,
        protected_namespaces=(),
    )
```

Thus, the conditional statement always set the following:
```
ns_info = {"name": ns_name}
```

and set properties if has one:
```
ns_info["properties"] = ns_details.properties
```


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
