### PR TITLE
CLI: remove un-used reference

### DIFF
--- a/client/python/apache_polaris/cli/command/tables.py
+++ b/client/python/apache_polaris/cli/command/tables.py
@@ -99,11 +99,9 @@ class TableCommand(Command):
             )
             print(f"De-registering table {namespace_dot}.{table_name} completed")
         elif self.table_subcommand == Subcommands.SUMMARIZE:
-            self._generate_summary(api, catalog_api, ns_str)
+            self._generate_summary(catalog_api, ns_str)
 
-    def _generate_summary(
-        self, api: PolarisDefaultApi, catalog_api: IcebergCatalogAPI, ns_str: str
-    ) -> None:
+    def _generate_summary(self, catalog_api: IcebergCatalogAPI, ns_str: str) -> None:
         catalog_name = cast(str, self.catalog_name)
         namespace_list = cast(List[str], self.namespace)
         table_name = cast(str, self.table_name)


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

`api: PolarisDefaultApi` is never been used in `_generate_summary` for `tables.py`. It only got used in `execute` which gave us `catalog_api`

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
