### PR TITLE
DefaultAuthenticator: do not merge attributes

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/AuthenticatingAugmentor.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/AuthenticatingAugmentor.java
@@ -61,11 +61,12 @@ public class AuthenticatingAugmentor implements SecurityIdentityAugmentor {
 
   private SecurityIdentity authenticatePolarisPrincipal(SecurityIdentity identity) {
     PolarisPrincipal polarisPrincipal = authenticator.authenticate(identity);
+    // Do not merge the principal attributes into the security identity's attributes:
+    // these must stay separate.
     return QuarkusSecurityIdentity.builder(identity)
         .setAnonymous(false)
         .setPrincipal(polarisPrincipal)
         .addRoles(polarisPrincipal.getRoles())
-        .addAttributes(polarisPrincipal.getAttributes())
         .build();
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/DefaultAuthenticator.java
@@ -162,15 +162,16 @@ public class DefaultAuthenticator implements Authenticator {
 
   protected Map<String, Object> resolvePrincipalAttributes(
       SecurityIdentity identity, PrincipalEntity principalEntity, boolean allRolesRequested) {
+    // Do not merge the security identity's attributes into the principal attributes:
+    // these must stay separate.
     ImmutableMap.Builder<String, Object> principalAttributes =
         ImmutableMap.<String, Object>builder()
-            .putAll(identity.getAttributes())
             .put(PolarisPrincipal.PRINCIPAL_ENTITY_ATTRIBUTE_KEY, principalEntity)
             .put(PolarisPrincipal.PRINCIPAL_ROLE_ALL_ATTRIBUTE_KEY, allRolesRequested);
     if (identity.getPrincipal() instanceof JsonWebToken jwt) {
       principalAttributes.put(PolarisPrincipal.JWT_ATTRIBUTE_KEY, jwt.getRawToken());
     }
-    return principalAttributes.buildKeepingLast();
+    return principalAttributes.build();
   }
 
   /**

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/AuthenticatingAugmentorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/AuthenticatingAugmentorTest.java
@@ -28,6 +28,8 @@ import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.smallrye.mutiny.Uni;
 import java.security.Principal;
+import java.util.Map;
+import java.util.Set;
 import org.apache.polaris.core.auth.PolarisPrincipal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,8 +82,8 @@ public class AuthenticatingAugmentorTest {
   @Test
   public void testAugmentSuccessfulAuthentication() {
     // Given
-    PolarisPrincipal polarisPrincipal = mock(PolarisPrincipal.class);
-    when(polarisPrincipal.getName()).thenReturn("user1");
+    PolarisPrincipal polarisPrincipal =
+        PolarisPrincipal.of("user1", Map.of("attribute1", "value1"), Set.of("role1", "role2"));
     PolarisCredential credential = mock(PolarisCredential.class);
     SecurityIdentity identity =
         QuarkusSecurityIdentity.builder()
@@ -98,6 +100,7 @@ public class AuthenticatingAugmentorTest {
     // Then
     assertThat(result).isNotNull();
     assertThat(result.getPrincipal()).isSameAs(polarisPrincipal);
-    assertThat(result.getPrincipal().getName()).isEqualTo("user1");
+    // principal attributes should not be merged
+    assertThat(result.getAttributes()).isEmpty();
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/AuthenticatingAugmentorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/AuthenticatingAugmentorTest.java
@@ -101,6 +101,6 @@ public class AuthenticatingAugmentorTest {
     assertThat(result).isNotNull();
     assertThat(result.getPrincipal()).isSameAs(polarisPrincipal);
     // principal attributes should not be merged
-    assertThat(result.getAttributes()).isEmpty();
+    assertThat(result.getAttributes()).doesNotContainKey("attribute1");
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/DefaultAuthenticatorTest.java
@@ -420,7 +420,7 @@ public class DefaultAuthenticatorTest {
   }
 
   @Test
-  void testInputIdentityAttributesPassedThrough() {
+  void testInputIdentityAttributesNotMerged() {
     // Given: an identity that already carries a custom attribute
     PolarisCredential credentials =
         PolarisCredential.of(null, PRINCIPAL_NAME, Set.of(DefaultAuthenticator.PRINCIPAL_ROLE_ALL));
@@ -434,8 +434,8 @@ public class DefaultAuthenticatorTest {
     // When: authenticating
     PolarisPrincipal result = authenticator.authenticate(identityWithAttrs);
 
-    // Then: custom attribute must be present alongside the Polaris-specific ones
-    assertThat(result.getAttribute("custom-key", String.class)).hasValue("custom-value");
+    // Then: custom attribute must not be present in the principal's attributes
+    assertThat(result.getAttribute("custom-key", String.class)).isEmpty();
   }
 
   private PrincipalEntity createPrincipal(String name, String... roles) {


### PR DESCRIPTION
In #5085, typed attributes were introduced in the PolarisPrincipal interface.

That same PR also started merging attributes from `SecurityIdentity` to `PolarisPrincipal` and vice versa, as a convenience to expose the same attributes on both interfaces.

In hindsight, that was probably a bad choice: both interfaces expose typed attributes, so a bulk merge from one to the other could break the type safety guarantees.

Furthermore, the merge was using Guava's `buildKeepingLast()`: likely another bad choice, as duplicate attributes would be silently overrridden.

This PR removes the attribute merge logic entirely.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
