### PR TITLE
Fix JDBC listEntities fetching all remaining rows instead of the requested page

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -550,7 +551,8 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       PolarisEntityType entityType,
       PolarisEntitySubType entitySubType,
       PageToken pageToken,
-      List<String> queryProjections) {
+      List<String> queryProjections,
+      boolean applyPageSizeLimit) {
     Map<String, Object> whereEquals =
         Map.of(
             "catalog_id",
@@ -570,6 +572,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
 
     String orderByColumnName = null;
     Map<String, Object> whereGreater;
+    Integer limit = null;
     if (pageToken.paginationRequested()) {
       orderByColumnName = ModelEntity.ID_COLUMN;
       whereGreater =
@@ -579,12 +582,22 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
                   entityIdToken ->
                       Map.<String, Object>of(ModelEntity.ID_COLUMN, entityIdToken.entityId()))
               .orElse(Map.of());
+      OptionalInt pageSize = pageToken.pageSize();
+      if (applyPageSizeLimit && pageSize.isPresent() && pageSize.getAsInt() < Integer.MAX_VALUE) {
+        // One more than the page size, so the caller can still tell whether a next page exists.
+        limit = pageSize.getAsInt() + 1;
+      }
     } else {
       whereGreater = Map.of();
     }
 
     return QueryGenerator.generateSelectQuery(
-        queryProjections, ModelEntity.TABLE_NAME, whereEquals, whereGreater, orderByColumnName);
+        queryProjections,
+        ModelEntity.TABLE_NAME,
+        whereEquals,
+        whereGreater,
+        orderByColumnName,
+        limit);
   }
 
   @NonNull
@@ -604,7 +617,8 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
               entityType,
               entitySubType,
               pageToken,
-              ModelEntity.ENTITY_LOOKUP_COLUMNS);
+              ModelEntity.ENTITY_LOOKUP_COLUMNS,
+              true);
       AtomicReference<Page<EntityNameLookupRecord>> results = new AtomicReference<>();
       datasourceOperations.executeSelectOverStream(
           query,
@@ -639,7 +653,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
               entityType,
               entitySubType,
               pageToken,
-              ModelEntity.getAllColumnNames(schemaVersion));
+              ModelEntity.getAllColumnNames(schemaVersion),
+              // entityFilter is applied after the fetch, so a page size limit could under-fill a
+              // page and drop its continuation token
+              false);
       AtomicReference<Page<T>> results = new AtomicReference<>();
       datasourceOperations.executeSelectOverStream(
           query,

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/QueryGenerator.java
@@ -104,9 +104,34 @@ public class QueryGenerator {
       @NonNull Map<String, Object> whereEquals,
       @NonNull Map<String, Object> whereGreater,
       @Nullable String orderByColumn) {
+    return generateSelectQuery(
+        projections, tableName, whereEquals, whereGreater, orderByColumn, null);
+  }
+
+  /**
+   * Generates a SELECT query with projection, filtering, ordering and an optional row limit.
+   *
+   * @param projections List of columns to retrieve.
+   * @param tableName Target table name.
+   * @param whereEquals Column-value pairs used in WHERE filtering.
+   * @param whereGreater Column-value pairs the row must be strictly greater than.
+   * @param orderByColumn Column to order by, or null for no ordering.
+   * @param limit Maximum number of rows to return, or null for no limit.
+   * @return A parameterized SELECT query.
+   * @throws IllegalArgumentException if any whereClause column isn't in projections or if limit is
+   *     not positive.
+   */
+  public static PreparedQuery generateSelectQuery(
+      @NonNull List<String> projections,
+      @NonNull String tableName,
+      @NonNull Map<String, Object> whereEquals,
+      @NonNull Map<String, Object> whereGreater,
+      @Nullable String orderByColumn,
+      @Nullable Integer limit) {
     QueryFragment where =
         generateWhereClause(new HashSet<>(projections), whereEquals, whereGreater);
-    PreparedQuery query = generateSelectQuery(projections, tableName, where.sql(), orderByColumn);
+    PreparedQuery query =
+        generateSelectQuery(projections, tableName, where.sql(), orderByColumn, limit);
     return new PreparedQuery(query.sql(), where.parameters());
   }
 

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImplTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImplTest.java
@@ -33,11 +33,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
 import org.apache.polaris.core.context.RealmContext;
+import org.apache.polaris.core.entity.EntityNameLookupRecord;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisChangeTrackingVersions;
 import org.apache.polaris.core.entity.PolarisEntityId;
@@ -46,6 +48,8 @@ import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.persistence.EntityAlreadyExistsException;
 import org.apache.polaris.core.persistence.RetryOnConcurrencyException;
+import org.apache.polaris.core.persistence.pagination.Page;
+import org.apache.polaris.core.persistence.pagination.PageToken;
 import org.h2.jdbcx.JdbcConnectionPool;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -514,5 +518,78 @@ class JdbcBasePersistenceImplTest {
     public Optional<String> databaseType() {
       return Optional.of("h2");
     }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2})
+  void listEntitiesBoundsPaginatedQueryByPageSize(int schemaVersion)
+      throws SQLException, IOException {
+    DatasourceOperations real = newH2DatasourceOperations("list_entities_limit_v", schemaVersion);
+    DatasourceOperations spy = Mockito.spy(real);
+    doCallRealMethod().when(spy).executeSelectOverStream(any(), any(), any());
+    TestPersistence tp = newTestPersistence(spy, schemaVersion);
+    JdbcBasePersistenceImpl impl = tp.impl();
+    PolarisCallContext callCtx = tp.callCtx();
+
+    for (int i = 0; i < 5; i++) {
+      impl.writeEntity(callCtx, newTestEntity(300L + i, "e" + i, 1, 1), false, null);
+    }
+
+    Page<EntityNameLookupRecord> page =
+        impl.listEntities(
+            callCtx,
+            0L,
+            0L,
+            PolarisEntityType.PRINCIPAL,
+            PolarisEntitySubType.ANY_SUBTYPE,
+            PageToken.fromLimit(2));
+
+    ArgumentCaptor<QueryGenerator.PreparedQuery> captor =
+        ArgumentCaptor.forClass(QueryGenerator.PreparedQuery.class);
+    verify(spy).executeSelectOverStream(captor.capture(), any(), any());
+    // One more than the page size, so the next-page token can still be produced.
+    assertThat(captor.getValue().sql()).contains("ORDER BY id ASC").contains("LIMIT 3");
+
+    // The bound must not cost the caller a page or its continuation token.
+    assertThat(page.items()).hasSize(2);
+    assertThat(page.encodedResponseToken()).isNotNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2})
+  void paginatedListEntitiesWalksEveryPageWhenTotalIsAMultipleOfPageSize(int schemaVersion)
+      throws SQLException, IOException {
+    DatasourceOperations datasourceOperations =
+        newH2DatasourceOperations("list_entities_pages_v", schemaVersion);
+    TestPersistence tp = newTestPersistence(datasourceOperations, schemaVersion);
+    JdbcBasePersistenceImpl impl = tp.impl();
+    PolarisCallContext callCtx = tp.callCtx();
+
+    // An exact multiple of the page size is the case a bound of exactly pageSize would break:
+    // the final full page would look like the end of the data and drop the continuation token.
+    for (int i = 0; i < 4; i++) {
+      impl.writeEntity(callCtx, newTestEntity(500L + i, "e" + i, 1, 1), false, null);
+    }
+
+    List<String> seen = new ArrayList<>();
+    PageToken pageToken = PageToken.fromLimit(2);
+    while (true) {
+      Page<EntityNameLookupRecord> page =
+          impl.listEntities(
+              callCtx,
+              0L,
+              0L,
+              PolarisEntityType.PRINCIPAL,
+              PolarisEntitySubType.ANY_SUBTYPE,
+              pageToken);
+      page.items().forEach(item -> seen.add(item.getName()));
+      String next = page.encodedResponseToken();
+      if (next == null) {
+        break;
+      }
+      pageToken = PageToken.build(next, 2, () -> true);
+    }
+
+    assertThat(seen).containsExactly("e0", "e1", "e2", "e3");
   }
 }


### PR DESCRIPTION
`JdbcBasePersistenceImpl.buildEntityQuery` switches to `keyset pagination` when the caller requests a page — ordering by `id` and adding `id > ?` from the page token — but never emits a matching `LIMIT`, so the statement asks the database for every remaining matching row and `Page.mapped` then keeps the first `pageSize` and discards the rest. Abandoning the stream early does not avoid the work: `executeSelectOverStream` never sets a fetch size and this path borrows a connection with autoCommit left on, so the PostgreSQL driver has no server-side cursor and materialises the entire result set client-side before the first row is read. 
Concretely, listing a namespace of `1,000` tables with a page size of `100` fetches all `1,000` rows and returns `100`, then fetches the remaining `900` and returns `100`, then `800`, and so on down to the final page — `5,500` rows transferred and materialised to return `1,000`, with the cost of every page paid again on the next one.
That makes paginating a full listing quadratic rather than bounding it, so the effect grows sharply with size: the same walk over `100k` entities moves on the order of `50M` rows, and the more carefully a client pages the worse it gets.
This change passes `pageSize + 1` through as a SQL `LIMIT` whenever pagination is requested for `listEntities`; the `+1` is what lets `Page.mapped` still see that a further row exists and emit a continuation token, and without it a final page whose size exactly divides the total would look like the end of the data and silently truncate the listing. `QueryGenerator's` internal query builder already renders both `ORDER BY` and `LIMIT`, so this only adds one public overload that carries the limit through alongside the existing ordering and keyset arguments, leaving every other call site unchanged.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
