### PR TITLE
Disable OTel LGTM for quarkusDev

### DIFF
--- a/runtime/server/build.gradle.kts
+++ b/runtime/server/build.gradle.kts
@@ -93,6 +93,7 @@ tasks.named<QuarkusDev>("quarkusDev") {
     listOf(
       "-Dpolaris.bootstrap.credentials=POLARIS,root,s3cr3t",
       "-Dquarkus.console.color=true",
+      "-Dquarkus.observability.lgtm.enabled=false",
       "-Dpolaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"=true",
       "-Dpolaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"=[\"FILE\",\"S3\",\"GCS\",\"AZURE\"]",
       "-Dpolaris.readiness.ignore-severe-issues=true",


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

I had been seeing following spamming 400 while start local polaris service via `./gradlew run`:
```
2026-08-08 23:17:51,963 INFO  [io.qua.htt.access-log] [,] [,,,] (vert.x-eventloop-thread-2) 127.0.0.1 - - [08/Aug/2026:23:17:51 -0500] "GET /q/metrics HTTP/1.1" 400 -
2026-08-08 23:18:01,994 INFO  [io.qua.htt.access-log] [,] [,,,] (vert.x-eventloop-thread-2) 127.0.0.1 - - [08/Aug/2026:23:18:01 -0500] "GET /q/metrics HTTP/1.1" 400 -
2026-08-08 23:18:11,985 INFO  [io.qua.htt.access-log] [,] [,,,] (vert.x-eventloop-thread-2) 127.0.0.1 - - [08/Aug/2026:23:18:11 -0500] "GET /q/metrics HTTP/1.1" 400 -
2026-08-08 23:18:21,992 INFO  [io.qua.htt.access-log] [,] [,,,] (vert.x-eventloop-thread-2) 127.0.0.1 - - [08/Aug/2026:23:18:21 -0500] "GET /q/metrics HTTP/1.1" 400 -
2026-08-08 23:18:31,978 INFO  [io.qua.htt.access-log] [,] [,,,] (vert.x-eventloop-thread-2) 127.0.0.1 - - [08/Aug/2026:23:18:31 -0500] "GET /q/metrics HTTP/1.1" 400 -
2026-08-08 23:18:41,996 INFO  [io.qua.htt.access-log] [,] [,,,] (vert.x-eventloop-thread-2) 127.0.0.1 - - [08/Aug/2026:23:18:41 -0500] "GET /q/metrics HTTP/1.1" 400 -
2026-08-08 23:18:51,957 INFO  [io.qua.htt.access-log] [,] [,,,] (vert.x-eventloop-thread-2) 127.0.0.1 - - [08/Aug/2026:23:18:51 -0500] "GET /q/metrics HTTP/1.1" 400 -
```

Upon debugging, this appears to be [Grafana OTel-LGTM](https://quarkus.io/guides/observability-devservices-lgtm) and this service is looking at `quarkus.http.port` (which is 8181) and not using the actual metrics port (which is 8182). Also, it uses `host.docker.internal` which then got rejected by Quarkus thus the 400 error. This is enabled by default per https://quarkus.io/guides/opentelemetry#enabling-disabling-dev-services-for-opentelemetry

This PR disabled this LGTM service when running quarkusDev (one less container will be running in this case).

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
