### PR TITLE
Avoid deleting table metadata on ambiguous commit failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 ## [Unreleased]
 
 ### Highlights
+- Table and view commits no longer delete newly written metadata when the metastore write outcome
+  is unknown (e.g. a dropped connection); they still clean up on known failures. JDBC reports an
+  unknown outcome as `PersistenceCommitStateUnknownException` (HTTP 500), and a definite non-write
+  where the connection could not be acquired as `PersistenceWriteNotStartedException` (HTTP 503),
+  which is safe to retry and lets the orphaned metadata be cleaned up.
 
 ### Upgrade notes
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -60,6 +60,14 @@ public class DatasourceOperations {
   private static final String UNIQUENESS_CONSTRAINT_VIOLATION_SQL_CODE = "23505";
   private static final String RELATION_DOES_NOT_EXIST = "42P01";
 
+  // SQLSTATE codes treated as ambiguous commit outcomes (the write may already have committed).
+  // Class 08 (connection exception) is SQL-standard and portable across databases.
+  private static final String CONNECTION_EXCEPTION_SQL_STATE_CLASS = "08";
+  // POSTGRES: query_canceled, e.g. statement_timeout (also CockroachDB via PG compatibility)
+  private static final String POSTGRES_QUERY_CANCELED_SQL_STATE = "57014";
+  // ODBC: timeout expired (used by some drivers, e.g. jTDS and older MySQL connectors)
+  private static final String ODBC_TIMEOUT_SQL_STATE = "HYT00";
+
   // H2 STATUS CODES
   // 90079 = Schema not found, 42S02 = Table or view not found, 42S04 = Table or view not found
   // (database empty). The latter surfaces for unqualified table references against a fresh
@@ -181,7 +189,8 @@ public class DatasourceOperations {
             executeSelectOverStreamWithConnection(query, converterInstance, consumer, connection);
             return null;
           }
-        });
+        },
+        false);
   }
 
   /** Connection-aware version for use inside runWithinTransaction. */
@@ -195,7 +204,8 @@ public class DatasourceOperations {
         () -> {
           executeSelectOverStreamWithConnection(query, converterInstance, consumer, connection);
           return null;
-        });
+        },
+        false);
   }
 
   /**
@@ -244,7 +254,7 @@ public class DatasourceOperations {
     return withRetries(
         () -> {
           logQuery(preparedQuery);
-          try (Connection connection = borrowConnection();
+          try (Connection connection = acquireConnection();
               PreparedStatement statement = connection.prepareStatement(preparedQuery.sql())) {
             List<Object> params = preparedQuery.parameters();
             for (int i = 0; i < params.size(); i++) {
@@ -278,7 +288,7 @@ public class DatasourceOperations {
     AtomicInteger successCount = new AtomicInteger();
     return withRetries(
         () -> {
-          try (Connection connection = borrowConnection();
+          try (Connection connection = acquireConnection();
               PreparedStatement statement = connection.prepareStatement(preparedQueries.sql())) {
             boolean autoCommit = connection.getAutoCommit();
             boolean success = false;
@@ -327,7 +337,7 @@ public class DatasourceOperations {
   public void runWithinTransaction(TransactionCallback callback) throws SQLException {
     withRetries(
         () -> {
-          try (Connection connection = borrowConnection()) {
+          try (Connection connection = acquireConnection()) {
             boolean autoCommit = connection.getAutoCommit();
             boolean success = false;
             connection.setAutoCommit(false);
@@ -361,7 +371,101 @@ public class DatasourceOperations {
     }
   }
 
-  private boolean isRetryable(SQLException e) {
+  /**
+   * Whether a SQLException indicates the statement may already have been applied on the server
+   * while the client cannot confirm the outcome (connection loss, timeout, cancellation).
+   *
+   * <p>Callers must not treat these as definite failures for cleanup or safe retry of CAS writes.
+   */
+  public boolean isAmbiguousCommitOutcome(SQLException e) {
+    // A connection that was never acquired is a definite non-write, never an ambiguous outcome,
+    // even though the driver may tag the acquisition failure with a connection-class SQLSTATE that
+    // would otherwise match below. Check this first so classification is independent of call order.
+    if (isConnectionAcquisitionFailure(e)) {
+      return false;
+    }
+    // Walk the cause chain: withRetries rewraps the original SQLException in a generic SQLException
+    // on its final throw, so the subtype/SQLSTATE that identifies an ambiguous outcome (timeout,
+    // connection loss) is frequently only visible on a cause rather than the top-level exception.
+    for (Throwable t = e; t != null; t = t.getCause()) {
+      if (t instanceof SQLException && indicatesAmbiguousOutcome((SQLException) t)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean indicatesAmbiguousOutcome(SQLException e) {
+    if (e instanceof java.sql.SQLTimeoutException) {
+      return true;
+    }
+    if (e instanceof java.sql.SQLTransientConnectionException
+        || e instanceof java.sql.SQLNonTransientConnectionException) {
+      return true;
+    }
+    String sqlState = e.getSQLState();
+    if (sqlState != null) {
+      if (sqlState.startsWith(CONNECTION_EXCEPTION_SQL_STATE_CLASS)
+          || sqlState.equals(POSTGRES_QUERY_CANCELED_SQL_STATE)
+          || sqlState.equals(ODBC_TIMEOUT_SQL_STATE)) {
+        return true;
+      }
+    }
+    return messageContainsAny(
+        e,
+        "connection reset",
+        "connection refused",
+        "connection is closed",
+        "broken pipe",
+        "query canceled",
+        "canceling statement due to statement timeout");
+  }
+
+  /**
+   * Whether a failure to obtain a connection (before any statement was sent) is present in the
+   * cause chain. Such a failure is a definite non-write, so callers can distinguish it from an
+   * ambiguous commit outcome after execution.
+   */
+  public boolean isConnectionAcquisitionFailure(SQLException e) {
+    for (Throwable t = e; t != null; t = t.getCause()) {
+      if (t instanceof ConnectionAcquisitionException) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Whether the exception message contains any of the given lowercase needles. The message is
+   * lowercased once; a null message matches nothing.
+   */
+  private static boolean messageContainsAny(SQLException e, String... needles) {
+    String message = e.getMessage();
+    if (message == null) {
+      return false;
+    }
+    String lower = message.toLowerCase(Locale.ROOT);
+    for (String needle : needles) {
+      if (lower.contains(needle)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isRetryable(SQLException e, boolean mutating) {
+    // A connection that could never be acquired means the statement never ran: the write
+    // definitely did not happen, so retrying the whole operation is always safe, even for writes.
+    if (e instanceof ConnectionAcquisitionException) {
+      return true;
+    }
+    // For mutating operations an ambiguous outcome (connection loss, timeout, cancellation) may
+    // mean the write already committed under auto-commit, so retrying risks a double-apply or a
+    // misreported result. Reads have no commit outcome to protect, so they stay retryable.
+    if (mutating && isAmbiguousCommitOutcome(e)) {
+      return false;
+    }
+
     String sqlState = e.getSQLState();
 
     if (sqlState != null) {
@@ -369,14 +473,20 @@ public class DatasourceOperations {
     }
 
     // Additionally, one might check for specific error messages or other conditions
-    return e.getMessage().toLowerCase(Locale.ROOT).contains("connection refused")
-        || e.getMessage().toLowerCase(Locale.ROOT).contains("connection reset");
+    return messageContainsAny(e, "connection refused", "connection reset");
   }
 
   // TODO: consider refactoring to use a retry library, inorder to have fair retries
   // and more knobs for tuning retry pattern.
   @VisibleForTesting
   <T> T withRetries(Operation<T> operation) throws SQLException {
+    // Default to the mutating policy: it is the safe choice when the caller does not state whether
+    // the operation writes.
+    return withRetries(operation, true);
+  }
+
+  @VisibleForTesting
+  <T> T withRetries(Operation<T> operation, boolean mutating) throws SQLException {
     int attempts = 0;
     // maximum number of retries.
     int maxAttempts = relationalJdbcConfiguration.maxRetries().orElse(1);
@@ -412,7 +522,7 @@ public class DatasourceOperations {
         attempts++;
         long timeLeft =
             Math.max((maxRetryTime - TimeUnit.NANOSECONDS.toMillis(System.nanoTime())), 0L);
-        if (timeLeft == 0 || attempts >= maxAttempts || !isRetryable(sqlException)) {
+        if (timeLeft == 0 || attempts >= maxAttempts || !isRetryable(sqlException, mutating)) {
           String exceptionMessage =
               String.format(
                   "Failed due to '%s' (error code %d, sql-state '%s'), after %s attempts and %s milliseconds",
@@ -471,6 +581,30 @@ public class DatasourceOperations {
 
   private Connection borrowConnection() throws SQLException {
     return datasource.getConnection();
+  }
+
+  /**
+   * Obtains a connection, tagging any acquisition failure with {@link
+   * ConnectionAcquisitionException} so callers can tell a definite non-write (the statement was
+   * never sent) apart from an ambiguous outcome after execution.
+   */
+  private Connection acquireConnection() throws SQLException {
+    try {
+      return borrowConnection();
+    } catch (SQLException e) {
+      throw new ConnectionAcquisitionException(e);
+    }
+  }
+
+  /**
+   * Marks a failure to obtain a JDBC connection, before any statement was sent. Such a failure is a
+   * definite non-write: it must not be classified as an ambiguous commit outcome, and the whole
+   * operation is safe to retry. The original message, SQLSTATE and vendor code are preserved.
+   */
+  static final class ConnectionAcquisitionException extends SQLException {
+    ConnectionAcquisitionException(SQLException cause) {
+      super(cause.getMessage(), cause.getSQLState(), cause.getErrorCode(), cause);
+    }
   }
 
   private static void logQuery(QueryGenerator.PreparedQuery query) {

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -254,6 +254,7 @@ public class DatasourceOperations {
     return withRetries(
         () -> {
           logQuery(preparedQuery);
+          boolean[] writeStarted = {false};
           try (Connection connection = acquireConnection();
               PreparedStatement statement = connection.prepareStatement(preparedQuery.sql())) {
             List<Object> params = preparedQuery.parameters();
@@ -263,10 +264,13 @@ public class DatasourceOperations {
             boolean autoCommit = connection.getAutoCommit();
             connection.setAutoCommit(true);
             try {
+              writeStarted[0] = true;
               return statement.executeUpdate();
             } finally {
               connection.setAutoCommit(autoCommit);
             }
+          } catch (SQLException e) {
+            throw classifyByPhase(e, writeStarted[0]);
           }
         });
   }
@@ -288,6 +292,7 @@ public class DatasourceOperations {
     AtomicInteger successCount = new AtomicInteger();
     return withRetries(
         () -> {
+          boolean[] writeStarted = {false};
           try (Connection connection = acquireConnection();
               PreparedStatement statement = connection.prepareStatement(preparedQueries.sql())) {
             boolean autoCommit = connection.getAutoCommit();
@@ -304,11 +309,13 @@ public class DatasourceOperations {
                 statement.addBatch(); // Add to batch
 
                 if (i % batchSize == 0) {
+                  writeStarted[0] = true;
                   successCount.addAndGet(Arrays.stream(statement.executeBatch()).sum());
                 }
               }
 
               // Execute remaining queries in the batch
+              writeStarted[0] = true;
               successCount.addAndGet(Arrays.stream(statement.executeBatch()).sum());
               success = true;
             } finally {
@@ -323,6 +330,8 @@ public class DatasourceOperations {
                 connection.setAutoCommit(autoCommit);
               }
             }
+          } catch (SQLException e) {
+            throw classifyByPhase(e, writeStarted[0]);
           }
           return successCount.get();
         });
@@ -337,12 +346,18 @@ public class DatasourceOperations {
   public void runWithinTransaction(TransactionCallback callback) throws SQLException {
     withRetries(
         () -> {
+          boolean[] writeStarted = {false};
           try (Connection connection = acquireConnection()) {
             boolean autoCommit = connection.getAutoCommit();
             boolean success = false;
             connection.setAutoCommit(false);
             try {
               try {
+                // Entering the callback (and the commit below) is the mutating phase; failures
+                // before this point are definite non-writes. Statements run by the callback via
+                // execute() tag their own pre-execution failures, so a prepareStatement failure
+                // there still surfaces as WriteNotStartedException.
+                writeStarted[0] = true;
                 success = callback.execute(connection);
               } finally {
                 if (success) {
@@ -354,6 +369,8 @@ public class DatasourceOperations {
             } finally {
               connection.setAutoCommit(autoCommit);
             }
+          } catch (SQLException e) {
+            throw classifyByPhase(e, writeStarted[0]);
           }
           return null;
         });
@@ -362,12 +379,16 @@ public class DatasourceOperations {
   public Integer execute(Connection connection, QueryGenerator.PreparedQuery preparedQuery)
       throws SQLException {
     logQuery(preparedQuery);
+    boolean[] writeStarted = {false};
     try (PreparedStatement statement = connection.prepareStatement(preparedQuery.sql())) {
       List<Object> params = preparedQuery.parameters();
       for (int i = 0; i < params.size(); i++) {
         statement.setObject(i + 1, params.get(i));
       }
+      writeStarted[0] = true;
       return statement.executeUpdate();
+    } catch (SQLException e) {
+      throw classifyByPhase(e, writeStarted[0]);
     }
   }
 
@@ -378,10 +399,11 @@ public class DatasourceOperations {
    * <p>Callers must not treat these as definite failures for cleanup or safe retry of CAS writes.
    */
   public boolean isAmbiguousCommitOutcome(SQLException e) {
-    // A connection that was never acquired is a definite non-write, never an ambiguous outcome,
-    // even though the driver may tag the acquisition failure with a connection-class SQLSTATE that
-    // would otherwise match below. Check this first so classification is independent of call order.
-    if (isConnectionAcquisitionFailure(e)) {
+    // A definite non-write (nothing sent to the server: connection acquisition, statement
+    // preparation, parameter binding, or auto-commit setup failed) is never an ambiguous outcome,
+    // even though the driver may tag it with a connection-class SQLSTATE that would otherwise match
+    // below. Check this first so classification is independent of call order.
+    if (isWriteNotStartedFailure(e)) {
       return false;
     }
     // Walk the cause chain: withRetries rewraps the original SQLException in a generic SQLException
@@ -422,13 +444,14 @@ public class DatasourceOperations {
   }
 
   /**
-   * Whether a failure to obtain a connection (before any statement was sent) is present in the
-   * cause chain. Such a failure is a definite non-write, so callers can distinguish it from an
-   * ambiguous commit outcome after execution.
+   * Whether a failure that happened before the mutating call was entered (connection acquisition,
+   * statement preparation, parameter binding, auto-commit setup) is present in the cause chain.
+   * Such a failure is a definite non-write, so callers can distinguish it from an ambiguous commit
+   * outcome after execution.
    */
-  public boolean isConnectionAcquisitionFailure(SQLException e) {
+  public boolean isWriteNotStartedFailure(SQLException e) {
     for (Throwable t = e; t != null; t = t.getCause()) {
-      if (t instanceof ConnectionAcquisitionException) {
+      if (t instanceof WriteNotStartedException) {
         return true;
       }
     }
@@ -454,9 +477,9 @@ public class DatasourceOperations {
   }
 
   private boolean isRetryable(SQLException e, boolean mutating) {
-    // A connection that could never be acquired means the statement never ran: the write
-    // definitely did not happen, so retrying the whole operation is always safe, even for writes.
-    if (e instanceof ConnectionAcquisitionException) {
+    // A definite non-write (the mutating call was never entered) means the write did not happen, so
+    // retrying the whole operation is always safe, even for writes.
+    if (e instanceof WriteNotStartedException) {
       return true;
     }
     // For mutating operations an ambiguous outcome (connection loss, timeout, cancellation) may
@@ -584,25 +607,46 @@ public class DatasourceOperations {
   }
 
   /**
-   * Obtains a connection, tagging any acquisition failure with {@link
-   * ConnectionAcquisitionException} so callers can tell a definite non-write (the statement was
-   * never sent) apart from an ambiguous outcome after execution.
+   * Obtains a connection, tagging any acquisition failure with {@link WriteNotStartedException} so
+   * callers can tell a definite non-write (no statement was sent) apart from an ambiguous outcome
+   * after execution.
    */
   private Connection acquireConnection() throws SQLException {
     try {
       return borrowConnection();
     } catch (SQLException e) {
-      throw new ConnectionAcquisitionException(e);
+      throw new WriteNotStartedException(e);
     }
   }
 
   /**
-   * Marks a failure to obtain a JDBC connection, before any statement was sent. Such a failure is a
-   * definite non-write: it must not be classified as an ambiguous commit outcome, and the whole
-   * operation is safe to retry. The original message, SQLSTATE and vendor code are preserved.
+   * Classifies a failure by execution phase. If the mutating call has not yet been entered (or the
+   * failure is already a definite non-write), the failure is tagged {@link
+   * WriteNotStartedException} so it is retried and any orphaned state is cleaned up; otherwise the
+   * original exception is returned unchanged so {@link #isAmbiguousCommitOutcome} can decide the
+   * commit outcome.
+   *
+   * <p>This moves the ambiguity boundary from connection acquisition to the mutating call itself:
+   * failures thrown after {@code getConnection()} but before {@code executeUpdate()}/{@code
+   * executeBatch()}/{@code commit()} (for example a pooled driver reporting SQLSTATE {@code 08003}
+   * from {@code prepareStatement()}) are definite non-writes rather than ambiguous outcomes.
    */
-  static final class ConnectionAcquisitionException extends SQLException {
-    ConnectionAcquisitionException(SQLException cause) {
+  private static SQLException classifyByPhase(SQLException e, boolean writeStarted) {
+    if (writeStarted || e instanceof WriteNotStartedException) {
+      return e;
+    }
+    return new WriteNotStartedException(e);
+  }
+
+  /**
+   * Marks a failure that happened before the mutating JDBC call was entered — obtaining the
+   * connection, preparing the statement, binding parameters, or configuring auto-commit — so no DML
+   * reached the server. Such a failure is a definite non-write: it must not be classified as an
+   * ambiguous commit outcome, and the whole operation is safe to retry. The original message,
+   * SQLSTATE and vendor code are preserved.
+   */
+  static final class WriteNotStartedException extends SQLException {
+    WriteNotStartedException(SQLException cause) {
       super(cause.getMessage(), cause.getSQLState(), cause.getErrorCode(), cause);
     }
   }

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -56,6 +56,8 @@ import org.apache.polaris.core.exceptions.AlreadyExistsException;
 import org.apache.polaris.core.persistence.BasePersistence;
 import org.apache.polaris.core.persistence.EntityAlreadyExistsException;
 import org.apache.polaris.core.persistence.IntegrationPersistence;
+import org.apache.polaris.core.persistence.PersistenceCommitStateUnknownException;
+import org.apache.polaris.core.persistence.PersistenceWriteNotStartedException;
 import org.apache.polaris.core.persistence.PolicyMappingAlreadyExistsException;
 import org.apache.polaris.core.persistence.PrincipalSecretsGenerator;
 import org.apache.polaris.core.persistence.RetryOnConcurrencyException;
@@ -144,7 +146,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
             return datasourceOperations.executeUpdate(preparedQuery);
           });
     } catch (SQLException e) {
-      throw new RuntimeException("Error persisting entity", e);
+      throw wrapEntityWriteFailure(e);
     }
   }
 
@@ -169,10 +171,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
             return true;
           });
     } catch (SQLException e) {
-      throw new RuntimeException(
-          String.format(
-              "Error executing the transaction for writing entities due to %s", e.getMessage()),
-          e);
+      throw wrapEntityWriteFailure(e, "Error executing the transaction for writing entities");
     }
   }
 
@@ -236,8 +235,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
           throw new RetryOnConcurrencyException(
               e, "Conflicting entity is not visible in the current transaction snapshot; retry");
         }
-        throw new RuntimeException(
-            String.format("Failed to write entity due to %s", e.getMessage()), e);
+        throw wrapEntityWriteFailure(e);
       }
     } else {
       // CAS on both entity_version and grant_records_version because grant operations only
@@ -274,10 +272,27 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
               originalEntity.getGrantRecordsVersion());
         }
       } catch (SQLException e) {
-        throw new RuntimeException(
-            String.format("Failed to write entity due to %s", e.getMessage()), e);
+        throw wrapEntityWriteFailure(e);
       }
     }
+  }
+
+  private RuntimeException wrapEntityWriteFailure(SQLException e) {
+    return wrapEntityWriteFailure(e, "Failed to write entity");
+  }
+
+  private RuntimeException wrapEntityWriteFailure(SQLException e, String context) {
+    // Check connection acquisition first: a connection that was never established is a definite
+    // non-write, even though its SQLSTATE (e.g. class 08) would otherwise look ambiguous.
+    if (datasourceOperations.isConnectionAcquisitionFailure(e)) {
+      return new PersistenceWriteNotStartedException(
+          String.format("%s due to %s; the write did not start", context, e.getMessage()), e);
+    }
+    if (datasourceOperations.isAmbiguousCommitOutcome(e)) {
+      return new PersistenceCommitStateUnknownException(
+          String.format("%s due to %s; commit outcome is unknown", context, e.getMessage()), e);
+    }
+    return new RuntimeException(String.format("%s due to %s", context, e.getMessage()), e);
   }
 
   @Override

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -282,9 +282,10 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
   }
 
   private RuntimeException wrapEntityWriteFailure(SQLException e, String context) {
-    // Check connection acquisition first: a connection that was never established is a definite
+    // Check the not-started phase first: a failure before the mutating call was entered (connection
+    // acquisition, statement preparation, parameter binding, auto-commit setup) is a definite
     // non-write, even though its SQLSTATE (e.g. class 08) would otherwise look ambiguous.
-    if (datasourceOperations.isConnectionAcquisitionFailure(e)) {
+    if (datasourceOperations.isWriteNotStartedFailure(e)) {
       return new PersistenceWriteNotStartedException(
           String.format("%s due to %s; the write did not start", context, e.getMessage()), e);
     }

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
@@ -228,18 +228,19 @@ public class DatasourceOperationsTest {
 
   @Test
   void testSuccessfulExecutionAfterOneRetry() throws SQLException {
-    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(4));
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(3));
     when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(2000L));
     when(relationalJdbcConfiguration.initialDelayInMs()).thenReturn(Optional.of(0L));
+    // Only serialization failures (definite rollback) are retryable; connection-class errors are
+    // treated as ambiguous commit outcomes and must not be retried.
     when(mockOperation.execute())
         .thenThrow(new SQLException("Retryable error", "40001"))
-        .thenThrow(new SQLException("connection refused"))
-        .thenThrow(new SQLException("connection reset"))
+        .thenThrow(new SQLException("Retryable error", "40001"))
         .thenReturn("Success!");
 
     String result = datasourceOperations.withRetries(mockOperation);
     assertEquals("Success!", result);
-    verify(mockOperation, times(4)).execute();
+    verify(mockOperation, times(3)).execute();
   }
 
   @Test
@@ -322,5 +323,105 @@ public class DatasourceOperationsTest {
 
     assertThrows(SQLException.class, () -> datasourceOperations.withRetries(mockOperation));
     verify(mockOperation, times(1)).execute();
+  }
+
+  @Test
+  void isAmbiguousCommitOutcome_classifiesConnectionAndTimeoutFailures() {
+    assertTrue(datasourceOperations.isAmbiguousCommitOutcome(new SQLException("reset", "08006")));
+    assertTrue(
+        datasourceOperations.isAmbiguousCommitOutcome(new SQLException("canceled", "57014")));
+    assertTrue(
+        datasourceOperations.isAmbiguousCommitOutcome(
+            new SQLException("Connection reset by peer")));
+    assertTrue(
+        datasourceOperations.isAmbiguousCommitOutcome(new java.sql.SQLTimeoutException("timeout")));
+    // Serialization failure is a definite rollback — retryable, not ambiguous commit success.
+    assertTrue(
+        !datasourceOperations.isAmbiguousCommitOutcome(new SQLException("serialization", "40001")));
+    // Constraint violations are definite failures.
+    assertTrue(!datasourceOperations.isAmbiguousCommitOutcome(new SQLException("unique", "23505")));
+  }
+
+  @Test
+  void withRetries_doesNotRetryAmbiguousConnectionFailure() throws Exception {
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(3));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(5000L));
+    when(relationalJdbcConfiguration.initialDelayInMs()).thenReturn(Optional.of(1L));
+    when(mockOperation.execute()).thenThrow(new SQLException("Connection reset", "08006"));
+
+    assertThrows(SQLException.class, () -> datasourceOperations.withRetries(mockOperation));
+    verify(mockOperation, times(1)).execute();
+  }
+
+  @Test
+  void withRetries_retriesAmbiguousConnectionFailureForReads() throws Exception {
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(3));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(5000L));
+    when(relationalJdbcConfiguration.initialDelayInMs()).thenReturn(Optional.of(1L));
+    // A read has no commit outcome to protect, so a transient connection failure is retried.
+    when(mockOperation.execute())
+        .thenThrow(new SQLException("Connection reset by peer"))
+        .thenThrow(new SQLException("Connection reset by peer"))
+        .thenReturn("Success!");
+
+    String result = datasourceOperations.withRetries(mockOperation, false);
+    assertEquals("Success!", result);
+    verify(mockOperation, times(3)).execute();
+  }
+
+  @Test
+  void isAmbiguousCommitOutcome_walksCauseChain() {
+    // withRetries rewraps the original SQLException in a generic SQLException on its terminal
+    // throw, so the ambiguous subtype is only reachable through the cause chain.
+    SQLException rewrappedTimeout =
+        new SQLException(
+            "Failed after retries", null, 0, new java.sql.SQLTimeoutException("statement timeout"));
+    assertTrue(datasourceOperations.isAmbiguousCommitOutcome(rewrappedTimeout));
+
+    // A definite failure in the cause chain must not be misread as ambiguous.
+    SQLException rewrappedConstraint =
+        new SQLException("wrapper", null, 0, new SQLException("unique violation", "23505"));
+    assertTrue(!datasourceOperations.isAmbiguousCommitOutcome(rewrappedConstraint));
+  }
+
+  @Test
+  void executeUpdate_retriesWhenConnectionAcquisitionFails() throws Exception {
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(3));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(5000L));
+    when(relationalJdbcConfiguration.initialDelayInMs()).thenReturn(Optional.of(1L));
+
+    QueryGenerator.PreparedQuery query =
+        new QueryGenerator.PreparedQuery("UPDATE users SET active = ?", List.of());
+    // The connection cannot be acquired on the first two attempts, then succeeds. A write whose
+    // statement never ran is a definite non-write, so it must be retried even for a mutating op.
+    when(mockDataSource.getConnection())
+        .thenThrow(new SQLException("Connection refused", "08001"))
+        .thenThrow(new SQLException("Connection refused", "08001"))
+        .thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(query.sql())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeUpdate()).thenReturn(1);
+
+    int result = datasourceOperations.executeUpdate(query);
+
+    assertEquals(1, result);
+    verify(mockPreparedStatement, times(1)).executeUpdate();
+  }
+
+  @Test
+  void executeUpdate_connectionAcquisitionFailureIsReportedAsDefiniteNonWrite() throws Exception {
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(1));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(1000L));
+
+    QueryGenerator.PreparedQuery query =
+        new QueryGenerator.PreparedQuery("UPDATE users SET active = ?", List.of());
+    when(mockDataSource.getConnection()).thenThrow(new SQLException("Connection refused", "08001"));
+
+    SQLException thrown =
+        assertThrows(SQLException.class, () -> datasourceOperations.executeUpdate(query));
+
+    // Even though the underlying SQLSTATE (class 08) would otherwise look ambiguous, a connection
+    // that was never acquired is a definite non-write; callers rely on this to clean up orphans.
+    assertTrue(datasourceOperations.isConnectionAcquisitionFailure(thrown));
+    assertTrue(!datasourceOperations.isAmbiguousCommitOutcome(thrown));
   }
 }

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
@@ -421,7 +421,50 @@ public class DatasourceOperationsTest {
 
     // Even though the underlying SQLSTATE (class 08) would otherwise look ambiguous, a connection
     // that was never acquired is a definite non-write; callers rely on this to clean up orphans.
-    assertTrue(datasourceOperations.isConnectionAcquisitionFailure(thrown));
+    assertTrue(datasourceOperations.isWriteNotStartedFailure(thrown));
     assertTrue(!datasourceOperations.isAmbiguousCommitOutcome(thrown));
+  }
+
+  @Test
+  void executeUpdate_prepareStatementFailureIsDefiniteNonWrite() throws Exception {
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(1));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(1000L));
+
+    QueryGenerator.PreparedQuery query =
+        new QueryGenerator.PreparedQuery("UPDATE users SET active = ?", List.of());
+    // The connection is acquired, but a pooled/stale connection reports SQLSTATE 08003 ("connection
+    // does not exist") from prepareStatement, before any DML is sent. This is a definite non-write
+    // even though 08003 is in the connection-exception class that otherwise looks ambiguous.
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(query.sql()))
+        .thenThrow(new SQLException("connection does not exist", "08003"));
+
+    SQLException thrown =
+        assertThrows(SQLException.class, () -> datasourceOperations.executeUpdate(query));
+
+    assertTrue(datasourceOperations.isWriteNotStartedFailure(thrown));
+    assertTrue(!datasourceOperations.isAmbiguousCommitOutcome(thrown));
+    verify(mockPreparedStatement, times(0)).executeUpdate();
+  }
+
+  @Test
+  void executeUpdate_executeFailureIsAmbiguousNotNonWrite() throws Exception {
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(1));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(1000L));
+
+    QueryGenerator.PreparedQuery query =
+        new QueryGenerator.PreparedQuery("UPDATE users SET active = ?", List.of());
+    // The statement is prepared and executeUpdate is entered, then the connection drops (SQLSTATE
+    // 08006). Because the mutating call had started, the outcome is ambiguous, not a non-write.
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(query.sql())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeUpdate())
+        .thenThrow(new SQLException("connection reset", "08006"));
+
+    SQLException thrown =
+        assertThrows(SQLException.class, () -> datasourceOperations.executeUpdate(query));
+
+    assertTrue(datasourceOperations.isAmbiguousCommitOutcome(thrown));
+    assertTrue(!datasourceOperations.isWriteNotStartedFailure(thrown));
   }
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PersistenceCommitStateUnknownException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PersistenceCommitStateUnknownException.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.persistence;
+
+import jakarta.ws.rs.core.Response;
+import org.apache.polaris.core.exceptions.PolarisException;
+
+/**
+ * Thrown when a persistence write may have committed but the client cannot confirm the outcome (for
+ * example a connection drop or timeout after the database applied an auto-commit update). Named to
+ * distinguish it from Iceberg's table-commit {@code CommitStateUnknownException}.
+ *
+ * <p>Callers must not treat this as a definite failure: newly written metadata files must not be
+ * deleted, and clients should not blindly retry the same commit.
+ *
+ * <p>Note: the simple class name is surfaced to clients as the {@code type} field of the REST error
+ * payload (see {@code PolarisExceptionMapper}). Renaming this class changes that wire value, which
+ * clients may use to recognize an unknown commit outcome.
+ */
+public class PersistenceCommitStateUnknownException extends PolarisException {
+
+  public PersistenceCommitStateUnknownException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public PersistenceCommitStateUnknownException(String message) {
+    super(message);
+  }
+
+  @Override
+  public int httpStatusCode() {
+    // Iceberg REST: unknown commit outcome must be 5xx so clients do not treat it as cleanable.
+    return Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PersistenceWriteNotStartedException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PersistenceWriteNotStartedException.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.persistence;
+
+import jakarta.ws.rs.core.Response;
+import org.apache.polaris.core.exceptions.PolarisException;
+
+/**
+ * Thrown when a persistence write never started because the backing store could not be reached (for
+ * example, a JDBC connection could not be acquired before any statement was sent). This is the
+ * definite-non-write counterpart to {@link PersistenceCommitStateUnknownException}: the write
+ * certainly did not happen, so callers may safely clean up anything they wrote in anticipation of
+ * the commit (e.g. a newly written table metadata file) and the request is safe to retry.
+ *
+ * <p>Note: the simple class name is surfaced to clients as the {@code type} field of the REST error
+ * payload (see {@code PolarisExceptionMapper}). Renaming this class changes that wire value.
+ */
+public class PersistenceWriteNotStartedException extends PolarisException {
+
+  public PersistenceWriteNotStartedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public PersistenceWriteNotStartedException(String message) {
+    super(message);
+  }
+
+  @Override
+  public int httpStatusCode() {
+    // The write definitely did not happen and the store was unreachable, so this is a transient,
+    // safely retryable failure rather than an unknown outcome.
+    return Response.Status.SERVICE_UNAVAILABLE.getStatusCode();
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -72,6 +72,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
@@ -119,6 +120,8 @@ import org.apache.polaris.core.entity.PolarisTaskConstants;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
+import org.apache.polaris.core.persistence.PersistenceCommitStateUnknownException;
+import org.apache.polaris.core.persistence.PersistenceWriteNotStartedException;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
@@ -1705,6 +1708,37 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
   }
 
   /**
+   * Whether newly written metadata files may be deleted after a table/view commit failure.
+   *
+   * <p>Follows Iceberg's rule: cleanup is only safe when the commit outcome is a known failure
+   * ({@link CleanableFailure} and related definite-failure types). When the outcome is unknown —
+   * connection loss after the metastore may already have applied the pointer update — the metadata
+   * file must be retained so a published pointer cannot dangle.
+   */
+  @VisibleForTesting
+  static boolean shouldCleanupMetadataOnCommitFailure(Throwable failure) {
+    if (failure == null) {
+      return false;
+    }
+    // Never delete metadata when the commit may already have been applied.
+    if (failure instanceof PersistenceCommitStateUnknownException) {
+      return false;
+    }
+    // A write that never started (e.g. the connection could not be acquired) is a definite
+    // non-write, so the freshly written metadata is a safe-to-delete orphan.
+    if (failure instanceof PersistenceWriteNotStartedException) {
+      return true;
+    }
+    if (failure instanceof CleanableFailure) {
+      return true;
+    }
+    // Definite pre- or post-CAS failures that do not implement CleanableFailure.
+    return failure instanceof AlreadyExistsException
+        || failure instanceof NotFoundException
+        || failure instanceof CommitConflictException;
+  }
+
+  /**
    * An implementation of {@link TableOperations} that integrates with {@link LocalIcebergCatalog}.
    * Much of this code was originally copied from {@link
    * org.apache.iceberg.BaseMetastoreTableOperations}. CODE_COPIED_TO_POLARIS From Apache Iceberg
@@ -1967,6 +2001,8 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       String newLocation = writeResult.location();
       String oldLocation = base == null ? null : base.metadataFileLocation();
       boolean writeSucceeded = false;
+      boolean persistenceAttempted = false;
+      RuntimeException commitFailure = null;
       try {
         // TODO: Consider using the entity from doRefresh() directly to do the conflict detection
         // instead of a two-layer CAS (checking metadataLocation to detect concurrent modification
@@ -2032,6 +2068,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
               tableIdentifier, oldLocation, newLocation, existingLocation);
         }
 
+        persistenceAttempted = true;
         if (null == existingLocation) {
           createTableLike(tableIdentifier, entity, false);
         } else {
@@ -2039,8 +2076,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         }
         // We diverge from `BaseMetastoreTableOperations`: only update the in-memory state after
         // the metastore persistence succeeds. If we updated it before and persistence threw,
-        // the finally-block cleanup would delete newLocation while this ops instance still
-        // pointed at it — leaving a dangling reference until the caller refreshes.
+        // cleanup could delete newLocation while this ops instance still pointed at it.
         if (makeMetadataCurrentOnCommit) {
           currentMetadata =
               TableMetadata.buildFrom(metadata)
@@ -2050,10 +2086,21 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
           currentMetadataLocation = newLocation;
         }
         writeSucceeded = true;
+      } catch (RuntimeException e) {
+        commitFailure = e;
+        throw e;
       } finally {
+        // Pre-write failures leave a definite orphan and are always cleaned up. Once the
+        // persistence call has been attempted, only delete on known failures: an ambiguous outcome
+        // (connection drop after the pointer may already have been applied) must leave the file in
+        // place — see Iceberg SnapshotProducer / TableOperations commit contract.
         if (!writeSucceeded && writeResult.written()) {
-          IcebergCatalogHandler.cleanupWrittenMetadataFiles(
-              List.of(new IcebergCatalogHandler.FileToDelete(io(), newLocation)));
+          boolean cleanup =
+              !persistenceAttempted || shouldCleanupMetadataOnCommitFailure(commitFailure);
+          if (cleanup) {
+            IcebergCatalogHandler.cleanupWrittenMetadataFiles(
+                List.of(new IcebergCatalogHandler.FileToDelete(io(), newLocation)));
+          }
         }
       }
     }
@@ -2430,6 +2477,8 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       String newLocation = writeResult.location();
       String oldLocation = base == null ? null : currentMetadataLocation;
       boolean writeSucceeded = false;
+      boolean persistenceAttempted = false;
+      RuntimeException commitFailure = null;
       try {
         IcebergTableLikeEntity entity =
             IcebergTableLikeEntity.of(
@@ -2465,6 +2514,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
                   + "because it has been concurrently modified to %s",
               identifier, oldLocation, newLocation, existingLocation);
         }
+        persistenceAttempted = true;
         if (null == existingLocation) {
           createTableLike(identifier, entity, true);
         } else {
@@ -2476,10 +2526,20 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
           currentMetadataLocation = newLocation;
         }
         writeSucceeded = true;
+      } catch (RuntimeException e) {
+        commitFailure = e;
+        throw e;
       } finally {
+        // Pre-write failures leave a definite orphan and are always cleaned up. Once the
+        // persistence call has been attempted, only delete on known failures (not unknown/ambiguous
+        // outcomes) so a possibly-published pointer cannot be left dangling.
         if (!writeSucceeded && writeResult.written()) {
-          IcebergCatalogHandler.cleanupWrittenMetadataFiles(
-              List.of(new IcebergCatalogHandler.FileToDelete(io(), newLocation)));
+          boolean cleanup =
+              !persistenceAttempted || shouldCleanupMetadataOnCommitFailure(commitFailure);
+          if (cleanup) {
+            IcebergCatalogHandler.cleanupWrittenMetadataFiles(
+                List.of(new IcebergCatalogHandler.FileToDelete(io(), newLocation)));
+          }
         }
       }
     }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitMetadataCleanupTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/CommitMetadataCleanupTest.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import static org.apache.polaris.service.admin.PolarisAuthzTestBase.SCHEMA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.ws.rs.core.Response;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.polaris.core.admin.model.Catalog;
+import org.apache.polaris.core.admin.model.CatalogProperties;
+import org.apache.polaris.core.admin.model.CreateCatalogRequest;
+import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
+import org.apache.polaris.core.admin.model.StorageConfigInfo;
+import org.apache.polaris.core.exceptions.CommitConflictException;
+import org.apache.polaris.core.persistence.PersistenceCommitStateUnknownException;
+import org.apache.polaris.core.persistence.PersistenceWriteNotStartedException;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.EntityResult;
+import org.apache.polaris.service.TestServices;
+import org.apache.polaris.service.catalog.AccessDelegationMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+/**
+ * Tests that single-table commit cleanup of newly written metadata files only runs for known
+ * failures, not when the metastore write may already have succeeded (ambiguous outcome).
+ */
+public class CommitMetadataCleanupTest {
+  private static final String NAMESPACE = "ns";
+  private static final String CATALOG = "test-catalog";
+  private static final String PROPERTY_NAME = "custom-property-1";
+  private static final UUID IDEMPOTENCY_KEY = new UUID(116617318654508422L, -7820829973016961092L);
+
+  @Test
+  void retainsMetadataWhenPersistenceThrowsAfterSuccessfulWrite(@TempDir Path tempDir)
+      throws Exception {
+    String location = catalogBaseLocation(tempDir);
+    AtomicBoolean shouldFail = new AtomicBoolean(false);
+    TestServices testServices =
+        TestServices.builder()
+            .config(
+                Map.of(
+                    "ALLOW_INSECURE_STORAGE_TYPES",
+                    "true",
+                    "SUPPORTED_CATALOG_STORAGE_TYPES",
+                    List.of("FILE")))
+            .metaStoreManagerDecorator(
+                msm -> {
+                  PolarisMetaStoreManager spy = Mockito.spy(msm);
+                  Mockito.doAnswer(
+                          invocation -> {
+                            Object result = invocation.callRealMethod();
+                            if (shouldFail.get()) {
+                              // Simulate: DB applied the CAS, then client lost the ack.
+                              throw new RuntimeException(
+                                  "boom", new SQLException("Connection reset", "08006"));
+                            }
+                            return result;
+                          })
+                      .when(spy)
+                      .updateEntityPropertiesIfNotChanged(
+                          Mockito.any(), Mockito.any(), Mockito.any());
+                  return spy;
+                })
+            .build();
+
+    createCatalogAndNamespace(testServices, location);
+    String tableName = "ambiguous-cleanup-table";
+    createTable(testServices, tableName, location);
+    TableIdentifier tableId = TableIdentifier.of(NAMESPACE, tableName);
+
+    Set<Path> metadataFilesBefore = metadataFiles(tempDir);
+    shouldFail.set(true);
+
+    assertThatThrownBy(() -> updateTable(testServices, tableId, "value-after"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("boom");
+
+    Set<Path> metadataFilesAfter = metadataFiles(tempDir);
+    assertThat(metadataFilesAfter)
+        .as("New metadata must be retained when commit outcome may be success")
+        .hasSizeGreaterThan(metadataFilesBefore.size());
+    assertThat(metadataFilesAfter).containsAll(metadataFilesBefore);
+
+    // Catalog pointer was applied before the thrown error; load must still resolve.
+    shouldFail.set(false);
+    String metadataLocation =
+        testServices
+            .catalogAdapter()
+            .newHandler(testServices.securityContext(), CATALOG)
+            .loadTable(
+                tableId, "all", null, EnumSet.noneOf(AccessDelegationMode.class), Optional.empty())
+            .get()
+            .tableMetadata()
+            .metadataFileLocation();
+    assertThat(Path.of(java.net.URI.create(metadataLocation).getPath())).exists();
+  }
+
+  @Test
+  void cleansUpMetadataOnKnownConcurrentModificationFailure(@TempDir Path tempDir)
+      throws Exception {
+    String location = catalogBaseLocation(tempDir);
+    AtomicBoolean shouldFail = new AtomicBoolean(false);
+    TestServices testServices =
+        TestServices.builder()
+            .config(
+                Map.of(
+                    "ALLOW_INSECURE_STORAGE_TYPES",
+                    "true",
+                    "SUPPORTED_CATALOG_STORAGE_TYPES",
+                    List.of("FILE")))
+            .metaStoreManagerDecorator(
+                msm -> {
+                  PolarisMetaStoreManager spy = Mockito.spy(msm);
+                  Mockito.doAnswer(
+                          invocation -> {
+                            if (shouldFail.get()) {
+                              return new EntityResult(
+                                  BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED,
+                                  "simulated concurrent modification");
+                            }
+                            return invocation.callRealMethod();
+                          })
+                      .when(spy)
+                      .updateEntityPropertiesIfNotChanged(
+                          Mockito.any(), Mockito.any(), Mockito.any());
+                  return spy;
+                })
+            .build();
+
+    createCatalogAndNamespace(testServices, location);
+    String tableName = "known-failure-cleanup-table";
+    createTable(testServices, tableName, location);
+    TableIdentifier tableId = TableIdentifier.of(NAMESPACE, tableName);
+
+    Set<Path> metadataFilesBefore = metadataFiles(tempDir);
+    shouldFail.set(true);
+
+    assertThatThrownBy(() -> updateTable(testServices, tableId, "value-conflict"))
+        .isInstanceOf(CommitConflictException.class);
+
+    Set<Path> metadataFilesAfter = metadataFiles(tempDir);
+    assertThat(metadataFilesAfter)
+        .as("Orphan metadata from a known CAS failure should be cleaned up")
+        .isEqualTo(metadataFilesBefore);
+  }
+
+  @Test
+  void cleansUpMetadataWhenWriteNeverStarted(@TempDir Path tempDir) throws Exception {
+    String location = catalogBaseLocation(tempDir);
+    AtomicBoolean shouldFail = new AtomicBoolean(false);
+    TestServices testServices =
+        TestServices.builder()
+            .config(
+                Map.of(
+                    "ALLOW_INSECURE_STORAGE_TYPES",
+                    "true",
+                    "SUPPORTED_CATALOG_STORAGE_TYPES",
+                    List.of("FILE")))
+            .metaStoreManagerDecorator(
+                msm -> {
+                  PolarisMetaStoreManager spy = Mockito.spy(msm);
+                  Mockito.doAnswer(
+                          invocation -> {
+                            if (shouldFail.get()) {
+                              // Simulate: the DB connection could not be acquired, so the write
+                              // never started (a definite non-write).
+                              throw new PersistenceWriteNotStartedException(
+                                  "write did not start",
+                                  new SQLException("Connection refused", "08001"));
+                            }
+                            return invocation.callRealMethod();
+                          })
+                      .when(spy)
+                      .updateEntityPropertiesIfNotChanged(
+                          Mockito.any(), Mockito.any(), Mockito.any());
+                  return spy;
+                })
+            .build();
+
+    createCatalogAndNamespace(testServices, location);
+    String tableName = "write-not-started-cleanup-table";
+    createTable(testServices, tableName, location);
+    TableIdentifier tableId = TableIdentifier.of(NAMESPACE, tableName);
+
+    Set<Path> metadataFilesBefore = metadataFiles(tempDir);
+    shouldFail.set(true);
+
+    assertThatThrownBy(() -> updateTable(testServices, tableId, "value-not-started"))
+        .isInstanceOf(PersistenceWriteNotStartedException.class);
+
+    Set<Path> metadataFilesAfter = metadataFiles(tempDir);
+    assertThat(metadataFilesAfter)
+        .as("Orphan metadata from a definite non-write should be cleaned up")
+        .isEqualTo(metadataFilesBefore);
+  }
+
+  @ParameterizedTest
+  @MethodSource("cleanupDecisionCases")
+  void shouldCleanupMetadataOnCommitFailure(Throwable failure, boolean expectedCleanup) {
+    assertThat(LocalIcebergCatalog.shouldCleanupMetadataOnCommitFailure(failure))
+        .isEqualTo(expectedCleanup);
+  }
+
+  static Stream<Arguments> cleanupDecisionCases() {
+    return Stream.of(
+        Arguments.of(null, false),
+        Arguments.of(new RuntimeException("opaque boom"), false),
+        Arguments.of(
+            new RuntimeException("boom", new SQLException("Connection reset", "08006")), false),
+        Arguments.of(
+            new PersistenceCommitStateUnknownException(
+                "unknown", new SQLException("timeout", "57014")),
+            false),
+        // A write that never started (connection could not be acquired) is a definite non-write:
+        // the freshly written metadata is a safe-to-delete orphan.
+        Arguments.of(
+            new PersistenceWriteNotStartedException(
+                "write did not start", new SQLException("Connection refused", "08001")),
+            true),
+        Arguments.of(
+            new org.apache.iceberg.exceptions.CommitStateUnknownException(
+                new RuntimeException("db timeout")),
+            false),
+        Arguments.of(new CommitFailedException("concurrent metadata location"), true),
+        Arguments.of(new CommitConflictException("concurrent entity version"), true),
+        Arguments.of(new AlreadyExistsException("table exists"), true),
+        Arguments.of(new NotFoundException("missing"), true),
+        Arguments.of(new ValidationException("invalid"), true));
+  }
+
+  private static String catalogBaseLocation(Path tempDir) {
+    String location = tempDir.toAbsolutePath().toUri().toString();
+    if (location.endsWith("/")) {
+      location = location.substring(0, location.length() - 1);
+    }
+    return location;
+  }
+
+  private static Set<Path> metadataFiles(Path directory) throws Exception {
+    try (Stream<Path> files = Files.walk(directory)) {
+      return files.filter(p -> p.toString().endsWith(".metadata.json")).collect(Collectors.toSet());
+    }
+  }
+
+  private void updateTable(TestServices services, TableIdentifier tableId, String propertyValue) {
+    UpdateTableRequest request =
+        UpdateTableRequest.create(
+            tableId,
+            List.of(),
+            List.of(new MetadataUpdate.SetProperties(Map.of(PROPERTY_NAME, propertyValue))));
+    services
+        .catalogAdapter()
+        .newHandler(services.securityContext(), CATALOG)
+        .updateTable(tableId, request);
+  }
+
+  private void createCatalogAndNamespace(TestServices services, String catalogLocation) {
+    CatalogProperties.Builder propertiesBuilder =
+        CatalogProperties.builder()
+            .setDefaultBaseLocation(String.format("%s/%s", catalogLocation, CATALOG));
+
+    StorageConfigInfo config =
+        FileStorageConfigInfo.builder()
+            .setStorageType(StorageConfigInfo.StorageTypeEnum.FILE)
+            .build();
+    Catalog catalogObject =
+        new Catalog(
+            Catalog.TypeEnum.INTERNAL, CATALOG, propertiesBuilder.build(), 0L, 0L, 1, config);
+    try (Response response =
+        services
+            .catalogsApi()
+            .createCatalog(
+                new CreateCatalogRequest(catalogObject),
+                services.realmContext(),
+                services.securityContext())) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.CREATED.getStatusCode());
+    }
+
+    CreateNamespaceRequest createNamespaceRequest =
+        CreateNamespaceRequest.builder().withNamespace(Namespace.of(NAMESPACE)).build();
+    try (Response response =
+        services
+            .restApi()
+            .createNamespace(
+                CATALOG,
+                createNamespaceRequest,
+                IDEMPOTENCY_KEY,
+                services.realmContext(),
+                services.securityContext())) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
+  }
+
+  private void createTable(TestServices services, String tableName, String baseLocation) {
+    CreateTableRequest createTableRequest =
+        CreateTableRequest.builder()
+            .withName(tableName)
+            .withLocation(String.format("%s/%s/%s/%s", baseLocation, CATALOG, NAMESPACE, tableName))
+            .withSchema(SCHEMA)
+            .build();
+    services
+        .restApi()
+        .createTable(
+            CATALOG,
+            NAMESPACE,
+            createTableRequest,
+            null,
+            IDEMPOTENCY_KEY,
+            services.realmContext(),
+            services.securityContext());
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
@@ -44,6 +44,8 @@ import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.exceptions.FileIOUnknownHostException;
 import org.apache.polaris.core.exceptions.PolarisException;
 import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
+import org.apache.polaris.core.persistence.PersistenceCommitStateUnknownException;
+import org.apache.polaris.core.persistence.PersistenceWriteNotStartedException;
 import org.apache.polaris.core.persistence.PolicyMappingAlreadyExistsException;
 import org.apache.polaris.core.policy.exceptions.NoSuchPolicyException;
 import org.apache.polaris.core.policy.exceptions.PolicyAttachException;
@@ -129,6 +131,28 @@ public class ExceptionMapperTest {
     Optional<Integer> code =
         IcebergExceptionMapper.mapCloudExceptionToResponseCode(nullMessageCloudException);
     assertThat(code).contains(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+  }
+
+  @Test
+  public void testCommitStateUnknownExceptionIsInternalServerError() {
+    PolarisExceptionMapper mapper = new PolarisExceptionMapper();
+    Response response =
+        mapper.toResponse(
+            new PersistenceCommitStateUnknownException(
+                "commit outcome unknown", new RuntimeException("connection reset")));
+    assertThat(response.getStatus()).isEqualTo(500);
+  }
+
+  @Test
+  public void testWriteNotStartedExceptionIsServiceUnavailable() {
+    PolarisExceptionMapper mapper = new PolarisExceptionMapper();
+    Response response =
+        mapper.toResponse(
+            new PersistenceWriteNotStartedException(
+                "write did not start", new RuntimeException("connection refused")));
+    // A definite non-write is transient and safe to retry, so it maps to 503, not the 500 used
+    // for an unknown commit outcome.
+    assertThat(response.getStatus()).isEqualTo(503);
   }
 
   @ParameterizedTest


### PR DESCRIPTION

Single-table and view `doCommit` previously deleted newly written `metadata.json` for every throwable after the object-store write, including opaque JDBC failures where the metastore pointer may already have been applied. That can leave the catalog pointing at a deleted file (unreadable table until manual repair).

This change:
- Cleans up newly written metadata only on known failures (`CleanableFailure`, concurrent modification, already-exists, not-found, etc.).
- Does not clean up on unknown/opaque outcomes (connection drop, timeout-class SQL, generic `RuntimeException`).
- Surfaces connection/timeout-class SQL errors from relational JDBC as `CommitStateUnknownException` (HTTP 500), aligned with Iceberg's commit-unknown contract.