### PR TITLE
Preserve setup entity properties in exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 
+- Python CLI `setup export` now preserves user-defined properties on principals and catalog roles,
+  so exported configurations restore that metadata during `setup apply`.
 - Python CLI `setup apply` no longer double-encodes policy content emitted by `setup export`, so
   exported configurations containing policies can be restored.
 - Python CLI `setup export` now includes nested namespaces and policy definitions from those

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -171,6 +171,8 @@ class SetupCommand(Command):
             principals = sorted(api.list_principals().principals, key=lambda p: p.name)
             for p in principals:
                 principal_info: Dict[str, Any] = {"type": PrincipalType.SERVICE.value}
+                if p.properties:
+                    principal_info["properties"] = p.properties
                 try:
                     assigned_roles = api.list_principal_roles_assigned(p.name).roles
                     if assigned_roles:
@@ -396,6 +398,8 @@ class SetupCommand(Command):
             )
             for r in roles:
                 role_info: Dict[str, Any] = {}
+                if r.properties:
+                    role_info["properties"] = r.properties
                 # Assignments
                 assigned_roles_resp = (
                     api.list_assignee_principal_roles_for_catalog_role(

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -306,6 +306,84 @@ class TestSetupCommand(CLITestBase):
         mock_client.list_catalog_roles.assert_called_with("my_catalog")
         mock_client.get_catalog.assert_called_with("my_catalog")
 
+    def test_setup_exported_entity_properties_round_trip_through_apply(self) -> None:
+        principal_properties = {"owner": "data-platform"}
+        catalog_role_properties = {"purpose": "migration"}
+        export_client = self.build_mock_client()
+        export_client.list_principals.return_value = SimpleNamespace(
+            principals=[
+                SimpleNamespace(
+                    name="service-user",
+                    properties=principal_properties,
+                )
+            ]
+        )
+        export_client.list_principal_roles_assigned.return_value = SimpleNamespace(
+            roles=[]
+        )
+        export_client.list_catalog_roles.return_value = SimpleNamespace(
+            roles=[
+                SimpleNamespace(
+                    name="catalog-reader",
+                    properties=catalog_role_properties,
+                )
+            ]
+        )
+        export_client.list_assignee_principal_roles_for_catalog_role.return_value = (
+            SimpleNamespace(roles=[])
+        )
+        export_client.list_grants_for_catalog_role.return_value = SimpleNamespace(
+            grants=[]
+        )
+        export_command = SetupCommand(setup_subcommand=Subcommands.EXPORT)
+
+        exported = {
+            "principals": export_command._export_principals(export_client),
+            "catalog_roles": export_command._export_catalog_roles_for_catalog(
+                export_client, "catalog"
+            ),
+        }
+        loaded = yaml.safe_load(yaml.safe_dump(exported))
+
+        self.assertEqual(
+            loaded["principals"]["service-user"]["properties"],
+            principal_properties,
+        )
+        self.assertEqual(
+            loaded["catalog_roles"]["catalog-reader"]["properties"],
+            catalog_role_properties,
+        )
+
+        apply_client = self.build_mock_client()
+        apply_client.list_principals.return_value = SimpleNamespace(principals=[])
+        apply_client.list_catalog_roles.return_value = SimpleNamespace(roles=[])
+        apply_client.create_principal.return_value = SimpleNamespace(
+            credentials=SimpleNamespace(
+                client_id="client-id",
+                client_secret=SimpleNamespace(get_secret_value=lambda: "secret"),
+            )
+        )
+        apply_command = SetupCommand(setup_subcommand=Subcommands.APPLY)
+
+        with patch("sys.stdout", new_callable=io.StringIO):
+            apply_command._create_principals(apply_client, loaded["principals"])
+        apply_command._create_catalog_roles(
+            apply_client,
+            "catalog",
+            loaded["catalog_roles"],
+        )
+
+        principal_request = apply_client.create_principal.call_args.args[0]
+        catalog_role_request = apply_client.create_catalog_role.call_args.args[1]
+        self.assertEqual(
+            principal_request.principal.properties,
+            principal_properties,
+        )
+        self.assertEqual(
+            catalog_role_request.catalog_role.properties,
+            catalog_role_properties,
+        )
+
     @patch("apache_polaris.cli.command.setup.os.path.isfile")
     def test_setup_apply_treats_null_type_as_internal(
         self, mock_isfile: MagicMock
@@ -603,4 +681,3 @@ class TestSetupCommand(CLITestBase):
         self.assertEqual(
             created.storage_config_info.sts_endpoint, "https://sts.amazonaws.com"
         )
-

--- a/site/content/guides/assets/polaris/reference-setup-config.yaml
+++ b/site/content/guides/assets/polaris/reference-setup-config.yaml
@@ -33,6 +33,9 @@ principals:
   # A principal for a quickstart user
   quickstart_user:
     type: service
+    # Optional properties persisted with the principal.
+    properties:
+      owner: data-platform
     roles:
       - quickstart_user_role
   # A principal for a readonly user
@@ -75,6 +78,9 @@ catalogs:
     # Catalog roles are scoped to this specific catalog.
     roles:
       quickstart_catalog_role:
+        # Optional properties persisted with the catalog role.
+        properties:
+          purpose: catalog-administration
         # Assigns this catalog role to one or more principal roles.
         assign_to:
           - quickstart_user_role
@@ -227,4 +233,3 @@ catalogs:
   #   service_account: "quickstart-service-account@gcs-project.iam.gserviceaccount.com"
   #   properties:
   #     catalog: quickstart_catalog_gcs
-

--- a/site/content/in-dev/unreleased/getting-started/setup-tools.md
+++ b/site/content/in-dev/unreleased/getting-started/setup-tools.md
@@ -40,7 +40,7 @@ If you already have an Apache Polaris environment, you can export its current st
 polaris setup export --client-id ${CLIENT_ID} --client-secret ${CLIENT_SECRET} > polaris_bootstrap.yaml
 ```
 
-This generates a readable YAML file containing principals, principal roles, catalogs, and their associated namespaces and catalog roles.
+This generates a readable YAML file containing principals, principal roles, catalogs, and their associated namespaces and catalog roles. User-defined properties on principals and catalog roles are preserved in the exported configuration.
 
 ## Applying a Configuration
 
@@ -103,5 +103,4 @@ The current implementation focuses on simplifying initial setup, with a few limi
 - **Non-declarative updates**: The command is create-only. If an entity already exists, it will be skipped rather than updated. There is no state reconciliation yet.
 - **Policy attachment export**: Policy attachments are not included in `setup export` due to performance considerations. However, they can still be defined in YAML and applied during `setup apply`.
 - **External catalog testing**: Support for external catalogs (e.g., Hive Metastore) exists, but full end-to-end testing has not yet been completed. It is recommended to validate configurations in a non-production environment first.
-
 


### PR DESCRIPTION
## Summary

`polaris setup export` omitted user-defined `properties` from principals and catalog roles even though `setup apply` accepts both fields. Exporting and reapplying a configuration therefore silently discarded that metadata.

This patch:

- preserves non-empty principal and catalog-role properties during export
- adds an export/YAML/apply regression test for both entity types
- documents the supported fields in the reference configuration and setup guide
- records the user-visible fix in the changelog

Fixes #5264

## Validation

- `.venv/bin/pytest tests/test_setup_command.py -q` — 19 passed, 3 subtests passed
- `make client-unit-test` — 173 passed
- `make client-lint`
- `make client-build`
- `./gradlew format compileAll` with Java 21
- `./gradlew :polaris-runtime-spark-tests:catalogFederationIntTest --rerun-tasks --max-workers=1`
- `./gradlew check --max-workers=1` with Java 21 and Colima — 1,409 tasks, build successful
- `site/bin/check-release-doc-links.sh`

## Checklist

- [x] 🛡️ No security issue is disclosed
- [x] 🔗 The need is explained and linked: Fixes #5264
- [x] 🧪 Added export/YAML/apply round-trip coverage and ran the full repository check
- [x] 💡 No complex logic was introduced
- [x] 🧾 Updated `CHANGELOG.md`
- [x] 📚 Updated `site/content/in-dev/unreleased`

## AI assistance

AI assistance was used to investigate the issue and prepare the patch. I reviewed the complete diff and validated the implementation end to end.