### PR TITLE
Do not use MemorySizeConverter

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/config/PolarisIcebergObjectMapperCustomizer.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/PolarisIcebergObjectMapperCustomizer.java
@@ -26,8 +26,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import io.quarkus.jackson.ObjectMapperCustomizer;
 import io.quarkus.runtime.configuration.MemorySize;
-import io.quarkus.runtime.configuration.MemorySizeConverter;
-import io.smallrye.config.WithConverter;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.apache.iceberg.rest.RESTSerializers;
@@ -45,10 +43,8 @@ public class PolarisIcebergObjectMapperCustomizer implements ObjectMapperCustomi
 
   @Inject
   public PolarisIcebergObjectMapperCustomizer(
-      @ConfigProperty(name = "quarkus.http.limits.max-body-size")
-          @WithConverter(MemorySizeConverter.class)
-          MemorySize maxBodySize) {
-    this.maxBodySize = maxBodySize.asLongValue();
+      @ConfigProperty(name = "quarkus.http.limits.max-body-size") String maxBodySize) {
+    this.maxBodySize = MemorySize.of(maxBodySize).asLongValue();
   }
 
   @Override

--- a/runtime/service/src/test/java/org/apache/polaris/service/events/jsonEventListener/aws/cloudwatch/AwsCloudWatchEventListenerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/events/jsonEventListener/aws/cloudwatch/AwsCloudWatchEventListenerTest.java
@@ -23,8 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.quarkus.runtime.configuration.MemorySize;
-import java.math.BigInteger;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Map;
@@ -71,8 +69,7 @@ class AwsCloudWatchEventListenerTest {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   static {
-    new PolarisIcebergObjectMapperCustomizer(new MemorySize(BigInteger.valueOf(1024 * 1024)))
-        .customize(OBJECT_MAPPER);
+    new PolarisIcebergObjectMapperCustomizer("1M").customize(OBJECT_MAPPER);
   }
 
   @Mock private AwsCloudWatchConfiguration config;


### PR DESCRIPTION
MemorySizeConverter has been deprecated for removal.

Use `MemorySize.of()` directly, as suggested by Quarkus javadoc.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
