### PR TITLE
Deprecate ADD_TRAILING_SLASH_TO_LOCATION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,6 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 ### Breaking changes
 
 - Concurrent table commits that hit a stale sequence number now return a retryable `409` instead of a fatal `400`, for both single-table commits and `commitTransaction`.
-- Removed the `ADD_TRAILING_SLASH_TO_LOCATION` feature flag (catalog config
-  `polaris.config.add-trailing-slash-to-location`). Polaris now always appends a trailing slash to
-  table and namespace base locations. A leftover key in configuration is harmless and ignored; a
-  production-readiness warning is emitted at startup if it is explicitly set to `false`. Locations
-  stored without a trailing slash by older versions continue to be handled correctly by
-  location-overlap checks.
 
 ### New Features
 
@@ -47,6 +41,8 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Python CLI: added `gcp` as an external catalog authentication type for Iceberg REST federation, enabling CLI creation of GCP-authenticated catalogs such as BigLake without passing Google credential secrets through command-line flags.
 
 ### Changes
+
+- Removed the `ADD_TRAILING_SLASH_TO_LOCATION` feature flag (catalog config `polaris.config.add-trailing-slash-to-location`). Polaris now always appends a trailing slash to table and namespace base locations. A leftover config value is ignored, with a startup warning if it is set to `false`.
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Deprecations
 
-- Deprecated the `ADD_TRAILING_SLASH_TO_LOCATION` feature flag (catalog config `polaris.config.add-trailing-slash-to-location`). Polaris now always appends a trailing slash to table and namespace base locations, so the flag no longer has any effect. The key is still accepted for compatibility but ignored, and a startup warning is emitted if it is set to `false`. It will be removed in a future release.
+- Deprecated the `ADD_TRAILING_SLASH_TO_LOCATION` feature flag; Polaris now always appends a trailing slash to table and namespace base locations, so the key is accepted-but-ignored (a startup warning is emitted only when it is `false` in `polaris.features` defaults or realm overrides) and will be removed in a future release.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 ### Breaking changes
 
 - Concurrent table commits that hit a stale sequence number now return a retryable `409` instead of a fatal `400`, for both single-table commits and `commitTransaction`.
+- Removed the `ADD_TRAILING_SLASH_TO_LOCATION` feature flag (catalog config
+  `polaris.config.add-trailing-slash-to-location`). Polaris now always appends a trailing slash to
+  table and namespace base locations. A leftover key in configuration is harmless and ignored; a
+  production-readiness warning is emitted at startup if it is explicitly set to `false`. Locations
+  stored without a trailing slash by older versions continue to be handled correctly by
+  location-overlap checks.
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,9 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Changes
 
-- Removed the `ADD_TRAILING_SLASH_TO_LOCATION` feature flag (catalog config `polaris.config.add-trailing-slash-to-location`). Polaris now always appends a trailing slash to table and namespace base locations. A leftover config value is ignored, with a startup warning if it is set to `false`.
-
 ### Deprecations
+
+- Deprecated the `ADD_TRAILING_SLASH_TO_LOCATION` feature flag (catalog config `polaris.config.add-trailing-slash-to-location`). Polaris now always appends a trailing slash to table and namespace base locations, so the flag no longer has any effect. The key is still accepted for compatibility but ignored, and a startup warning is emitted if it is set to `false`. It will be removed in a future release.
 
 ### Fixes
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -599,8 +599,12 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
    * @deprecated since 1.8.0, for removal. Polaris now always appends a trailing slash to table and
    *     namespace base locations, so this flag no longer changes behavior. The configuration key is
    *     retained only so existing catalog properties and feature-config entries continue to be
-   *     accepted (and ignored) instead of rejected; a production-readiness warning is emitted when
-   *     it is explicitly set to {@code false}. Scheduled for removal in a future release.
+   *     accepted (and ignored) instead of rejected. A production-readiness warning is emitted when
+   *     it is explicitly set to {@code false} in the server feature configuration — the {@code
+   *     polaris.features} defaults or a realm override — since that is the surface {@code
+   *     ProductionReadinessChecks} inspects at startup; the equivalent per-catalog property ({@code
+   *     polaris.config.add-trailing-slash-to-location}) is accepted and ignored without a warning.
+   *     Scheduled for removal in a future release.
    */
   @Deprecated(since = "1.8.0", forRemoval = true)
   public static final FeatureConfiguration<Boolean> ADD_TRAILING_SLASH_TO_LOCATION =

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -595,6 +595,25 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
           .defaultValue(false)
           .buildFeatureConfiguration();
 
+  /**
+   * @deprecated since 1.8.0, for removal. Polaris now always appends a trailing slash to table and
+   *     namespace base locations, so this flag no longer changes behavior. The configuration key is
+   *     retained only so existing catalog properties and feature-config entries continue to be
+   *     accepted (and ignored) instead of rejected; a production-readiness warning is emitted when
+   *     it is explicitly set to {@code false}. Scheduled for removal in a future release.
+   */
+  @Deprecated(since = "1.8.0", forRemoval = true)
+  public static final FeatureConfiguration<Boolean> ADD_TRAILING_SLASH_TO_LOCATION =
+      PolarisConfiguration.<Boolean>builder()
+          .key("ADD_TRAILING_SLASH_TO_LOCATION")
+          .catalogConfig("polaris.config.add-trailing-slash-to-location")
+          .description(
+              "Deprecated and ignored: Polaris always appends a trailing slash to table and "
+                  + "namespace base locations. Retained so existing configuration remains accepted "
+                  + "rather than rejected.")
+          .defaultValue(true)
+          .buildFeatureConfiguration();
+
   public static final FeatureConfiguration<Boolean> ALLOW_OPTIMIZED_SIBLING_CHECK =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_OPTIMIZED_SIBLING_CHECK")

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -595,15 +595,6 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
           .defaultValue(false)
           .buildFeatureConfiguration();
 
-  public static final FeatureConfiguration<Boolean> ADD_TRAILING_SLASH_TO_LOCATION =
-      PolarisConfiguration.<Boolean>builder()
-          .key("ADD_TRAILING_SLASH_TO_LOCATION")
-          .catalogConfig("polaris.config.add-trailing-slash-to-location")
-          .description(
-              "When set, the base location for a table or namespace will have `/` added as a suffix if not present")
-          .defaultValue(true)
-          .buildFeatureConfiguration();
-
   public static final FeatureConfiguration<Boolean> ALLOW_OPTIMIZED_SIBLING_CHECK =
       PolarisConfiguration.<Boolean>builder()
           .key("ALLOW_OPTIMIZED_SIBLING_CHECK")
@@ -625,9 +616,9 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
                   + "views, and namespaces. This is not a bypass mode, but enabling or disabling "
                   + "it can change overlap-detection coverage for non-standard location layouts. "
                   + "Only enable it when the required index and backfill state is known to be "
-                  + "correct. For correct results, locations should end with a slash; see "
-                  + "ADD_TRAILING_SLASH_TO_LOCATION. Supported by the JDBC and NoSQL metastore "
-                  + "implementations.")
+                  + "correct. Locations written by Polaris always end with a slash; locations "
+                  + "stored by older versions without one are still handled. Supported by the "
+                  + "JDBC and NoSQL metastore implementations.")
           .defaultValue(false)
           .buildFeatureConfiguration();
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -671,12 +671,8 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       Namespace namespace,
       Map<String, String> metadata,
       PolarisResolvedPathWrapper resolvedParent) {
-    String baseLocation = resolveNamespaceLocation(namespace, metadata);
-
-    // Set / suffix
-    if (!baseLocation.endsWith("/")) {
-      baseLocation += "/";
-    }
+    String baseLocation =
+        StorageLocation.ensureTrailingSlash(resolveNamespaceLocation(namespace, metadata));
 
     NamespaceEntity entity =
         new NamespaceEntity.Builder(namespace)
@@ -2815,12 +2811,11 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       PolarisResolvedPathWrapper resolvedParent,
       boolean validateMetadataLocation) {
     IcebergTableLikeEntity icebergTableLikeEntity = IcebergTableLikeEntity.of(entity);
-    // Set / suffix
-    if (icebergTableLikeEntity.getBaseLocation() != null
-        && !icebergTableLikeEntity.getBaseLocation().endsWith("/")) {
+    if (icebergTableLikeEntity.getBaseLocation() != null) {
       icebergTableLikeEntity =
           new IcebergTableLikeEntity.Builder(icebergTableLikeEntity)
-              .setBaseLocation(icebergTableLikeEntity.getBaseLocation() + "/")
+              .setBaseLocation(
+                  StorageLocation.ensureTrailingSlash(icebergTableLikeEntity.getBaseLocation()))
               .build();
     }
 
@@ -2881,12 +2876,11 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     }
     IcebergTableLikeEntity icebergTableLikeEntity = new IcebergTableLikeEntity(entity);
 
-    // Set / suffix
-    if (icebergTableLikeEntity.getBaseLocation() != null
-        && !icebergTableLikeEntity.getBaseLocation().endsWith("/")) {
+    if (icebergTableLikeEntity.getBaseLocation() != null) {
       icebergTableLikeEntity =
           new IcebergTableLikeEntity.Builder(icebergTableLikeEntity)
-              .setBaseLocation(icebergTableLikeEntity.getBaseLocation() + "/")
+              .setBaseLocation(
+                  StorageLocation.ensureTrailingSlash(icebergTableLikeEntity.getBaseLocation()))
               .build();
     }
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -869,6 +869,14 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
 
     // Merge new properties into existing map.
     newProperties.putAll(properties);
+    // Keep the namespace base location slash-terminated like createNamespaceInternal, so property
+    // updates stay within the "locations written by Polaris always end with a slash" invariant.
+    String updatedBaseLocation = newProperties.get(PolarisEntityConstants.ENTITY_BASE_LOCATION);
+    if (updatedBaseLocation != null) {
+      newProperties.put(
+          PolarisEntityConstants.ENTITY_BASE_LOCATION,
+          StorageLocation.ensureTrailingSlash(updatedBaseLocation));
+    }
     PolarisEntity updatedEntity =
         new PolarisEntity.Builder(entity).setProperties(newProperties).build();
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -880,10 +880,17 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     PolarisEntity updatedEntity =
         new PolarisEntity.Builder(entity).setProperties(newProperties).build();
 
+    // Compare normalized (slash-terminated) locations so that merely normalizing a legacy
+    // slash-less location does not count as a move. Otherwise an unrelated property update on a
+    // namespace stored before Polaris always appended a slash would flip locationChanged to true
+    // and run the overlap check against the namespace's own still-persisted slash-less row (which
+    // the optimized sibling check does not exclude), wrongly rejecting the update. A genuine move
+    // still differs after normalization and is validated.
     boolean locationChanged =
         !Objects.equal(
-            NamespaceEntity.of(entity).getBaseLocation(),
-            NamespaceEntity.of(updatedEntity).getBaseLocation());
+            StorageLocation.ensureTrailingSlash(NamespaceEntity.of(entity).getBaseLocation()),
+            StorageLocation.ensureTrailingSlash(
+                NamespaceEntity.of(updatedEntity).getBaseLocation()));
 
     if (locationChanged
         && !realmConfig.getConfig(FeatureConfiguration.ALLOW_NAMESPACE_LOCATION_OVERLAP)) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -674,9 +674,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     String baseLocation = resolveNamespaceLocation(namespace, metadata);
 
     // Set / suffix
-    boolean requireTrailingSlash =
-        realmConfig.getConfig(FeatureConfiguration.ADD_TRAILING_SLASH_TO_LOCATION);
-    if (requireTrailingSlash && !baseLocation.endsWith("/")) {
+    if (!baseLocation.endsWith("/")) {
       baseLocation += "/";
     }
 
@@ -2818,10 +2816,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       boolean validateMetadataLocation) {
     IcebergTableLikeEntity icebergTableLikeEntity = IcebergTableLikeEntity.of(entity);
     // Set / suffix
-    boolean requireTrailingSlash =
-        realmConfig.getConfig(FeatureConfiguration.ADD_TRAILING_SLASH_TO_LOCATION);
-    if (requireTrailingSlash
-        && icebergTableLikeEntity.getBaseLocation() != null
+    if (icebergTableLikeEntity.getBaseLocation() != null
         && !icebergTableLikeEntity.getBaseLocation().endsWith("/")) {
       icebergTableLikeEntity =
           new IcebergTableLikeEntity.Builder(icebergTableLikeEntity)
@@ -2887,10 +2882,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     IcebergTableLikeEntity icebergTableLikeEntity = new IcebergTableLikeEntity(entity);
 
     // Set / suffix
-    boolean requireTrailingSlash =
-        realmConfig.getConfig(FeatureConfiguration.ADD_TRAILING_SLASH_TO_LOCATION);
-    if (requireTrailingSlash
-        && icebergTableLikeEntity.getBaseLocation() != null
+    if (icebergTableLikeEntity.getBaseLocation() != null
         && !icebergTableLikeEntity.getBaseLocation().endsWith("/")) {
       icebergTableLikeEntity =
           new IcebergTableLikeEntity.Builder(icebergTableLikeEntity)

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
@@ -62,6 +62,12 @@ public class ProductionReadinessChecks {
       "quarkus.rest.jackson.optimization.enable-reflection-free-serializers";
 
   /**
+   * Key of the removed {@code ADD_TRAILING_SLASH_TO_LOCATION} feature flag, kept only to warn
+   * operators whose configuration still sets it.
+   */
+  private static final String ADD_TRAILING_SLASH_TO_LOCATION_KEY = "ADD_TRAILING_SLASH_TO_LOCATION";
+
+  /**
    * A warning sign ⚠ {@code 26A0} with variant selector {@code FE0F}. The sign is preceded by a
    * null character {@code 0000} to ensure that the warning sign is displayed correctly regardless
    * of the log pattern (some log patterns seem to interfere with non-ASCII characters).
@@ -364,6 +370,39 @@ public class ProductionReadinessChecks {
                         format(
                             "polaris.features.realm-overrides.\"%s\".overrides.\"%s\"",
                             realmId, optimizedSiblingCheck.key())));
+              }
+            });
+    return errors.isEmpty()
+        ? ProductionReadinessCheck.OK
+        : ProductionReadinessCheck.of(errors.toArray(new Error[0]));
+  }
+
+  @Produces
+  public ProductionReadinessCheck checkAddTrailingSlashToLocation(
+      FeaturesConfiguration featureConfiguration) {
+    var message =
+        "ADD_TRAILING_SLASH_TO_LOCATION was removed and is ignored. Polaris always adds a "
+            + "trailing slash to table and namespace base locations. Remove this setting.";
+    var errors = new ArrayList<Error>();
+    if ("false"
+        .equalsIgnoreCase(
+            featureConfiguration.defaults().get(ADD_TRAILING_SLASH_TO_LOCATION_KEY))) {
+      errors.add(
+          Error.of(message, format("polaris.features.\"%s\"", ADD_TRAILING_SLASH_TO_LOCATION_KEY)));
+    }
+    featureConfiguration
+        .realmOverrides()
+        .forEach(
+            (realmId, overrides) -> {
+              if ("false"
+                  .equalsIgnoreCase(
+                      overrides.overrides().get(ADD_TRAILING_SLASH_TO_LOCATION_KEY))) {
+                errors.add(
+                    Error.of(
+                        message,
+                        format(
+                            "polaris.features.realm-overrides.\"%s\".overrides.\"%s\"",
+                            realmId, ADD_TRAILING_SLASH_TO_LOCATION_KEY)));
               }
             });
     return errors.isEmpty()

--- a/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/config/ProductionReadinessChecks.java
@@ -62,7 +62,7 @@ public class ProductionReadinessChecks {
       "quarkus.rest.jackson.optimization.enable-reflection-free-serializers";
 
   /**
-   * Key of the removed {@code ADD_TRAILING_SLASH_TO_LOCATION} feature flag, kept only to warn
+   * Key of the deprecated {@code ADD_TRAILING_SLASH_TO_LOCATION} feature flag, kept only to warn
    * operators whose configuration still sets it.
    */
   private static final String ADD_TRAILING_SLASH_TO_LOCATION_KEY = "ADD_TRAILING_SLASH_TO_LOCATION";
@@ -381,7 +381,7 @@ public class ProductionReadinessChecks {
   public ProductionReadinessCheck checkAddTrailingSlashToLocation(
       FeaturesConfiguration featureConfiguration) {
     var message =
-        "ADD_TRAILING_SLASH_TO_LOCATION was removed and is ignored. Polaris always adds a "
+        "ADD_TRAILING_SLASH_TO_LOCATION is deprecated and ignored. Polaris always adds a "
             + "trailing slash to table and namespace base locations. Remove this setting.";
     var errors = new ArrayList<Error>();
     if ("false"

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogOverlapTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogOverlapTest.java
@@ -19,7 +19,6 @@
 package org.apache.polaris.service.catalog.iceberg;
 
 import static org.apache.polaris.service.admin.PolarisAuthzTestBase.SCHEMA;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
@@ -49,15 +48,10 @@ import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
-import org.apache.polaris.core.entity.PolarisEntityCore;
-import org.apache.polaris.core.entity.PolarisEntitySubType;
-import org.apache.polaris.core.entity.PolarisEntityType;
-import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
-import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
@@ -126,9 +120,9 @@ public abstract class AbstractLocalIcebergCatalogOverlapTest {
 
   private LocalIcebergCatalog catalog;
   private String realmName;
-  private PolarisCallContext polarisContext;
+  protected PolarisCallContext polarisContext;
   private InMemoryFileIO fileIO;
-  private PolarisEntity catalogEntity;
+  protected PolarisEntity catalogEntity;
 
   @BeforeAll
   public static void setUpMocks() {
@@ -300,98 +294,5 @@ public abstract class AbstractLocalIcebergCatalogOverlapTest {
         .isInstanceOf(ForbiddenException.class)
         .hasMessageContaining("Unable to create entity at location")
         .hasMessageContaining("conflicts with existing table or namespace");
-  }
-
-  @Test
-  public void testParentPrefixOverlapWithTrailingSlashMismatch() {
-    // The catalog now always stores locations with a trailing slash
-    // (ADD_TRAILING_SLASH_TO_LOCATION was removed). Simulate legacy slash-less data
-    // by rewriting the stored parent location directly, then verify the optimized sibling check
-    // still detects overlaps against it: ancestor equality terms used to be slash-terminated only,
-    // so a slash-less location_without_scheme was missed.
-    Namespace ns = Namespace.of("ns-for-trailing-slash-overlap");
-    catalog().createNamespace(ns);
-
-    TableIdentifier parentTable = TableIdentifier.of(ns, "trailing-parent");
-    String parentLoc = STORAGE_LOCATION + "/trailing-overlap/parent";
-    assertThat(parentLoc).doesNotEndWith("/");
-    catalog().buildTable(parentTable, SCHEMA).withLocation(parentLoc).create();
-
-    stripStoredBaseLocationTrailingSlash(ns, parentTable);
-
-    // Guardrail: the stored location must be slash-less so overlap checks exercise the
-    // non-slash-terminated location_without_scheme path that QueryGenerator must handle.
-    assertThat(storedTableBaseLocation(ns, parentTable))
-        .as("parent must remain slash-less so overlap uses non-slash-terminated stored location")
-        .isEqualTo(parentLoc)
-        .doesNotEndWith("/");
-
-    // Creating a child table under the slash-less parent location must be rejected.
-    TableIdentifier childTable = TableIdentifier.of(ns, "trailing-child");
-    String childLoc = STORAGE_LOCATION + "/trailing-overlap/parent/child";
-    assertThatThrownBy(
-            () -> catalog().buildTable(childTable, SCHEMA).withLocation(childLoc).create())
-        .isInstanceOf(ForbiddenException.class)
-        .hasMessageContaining("Unable to create entity at location")
-        .hasMessageContaining("conflicts with existing table or namespace");
-
-    // The same must hold when the slash-terminated form of the same prefix is used.
-    TableIdentifier siblingTable = TableIdentifier.of(ns, "trailing-sibling");
-    String siblingLoc = STORAGE_LOCATION + "/trailing-overlap/parent/";
-    assertThatThrownBy(
-            () -> catalog().buildTable(siblingTable, SCHEMA).withLocation(siblingLoc).create())
-        .isInstanceOf(ForbiddenException.class)
-        .hasMessageContaining("Unable to create entity at location")
-        .hasMessageContaining("conflicts with existing table or namespace");
-  }
-
-  private String storedTableBaseLocation(Namespace ns, TableIdentifier table) {
-    return IcebergTableLikeEntity.of(readStoredTableLike(ns, table)).getBaseLocation();
-  }
-
-  /**
-   * Rewrites the stored base location of {@code table} without its trailing slash, simulating data
-   * written before Polaris always appended one.
-   */
-  private void stripStoredBaseLocationTrailingSlash(Namespace ns, TableIdentifier table) {
-    PolarisEntity tableEntity = readStoredTableLike(ns, table);
-    IcebergTableLikeEntity tableLike = IcebergTableLikeEntity.of(tableEntity);
-    String baseLocation = tableLike.getBaseLocation();
-    assertThat(baseLocation).endsWith("/");
-    IcebergTableLikeEntity stripped =
-        new IcebergTableLikeEntity.Builder(tableLike)
-            .setBaseLocation(baseLocation.substring(0, baseLocation.length() - 1))
-            .build();
-    EntityResult result =
-        metaStoreManager.updateEntityPropertiesIfNotChanged(
-            polarisContext, tableLikeCatalogPath(ns), stripped);
-    assertThat(result.isSuccess()).isTrue();
-  }
-
-  private PolarisEntity readStoredTableLike(Namespace ns, TableIdentifier table) {
-    EntityResult result =
-        metaStoreManager.readEntityByName(
-            polarisContext,
-            tableLikeCatalogPath(ns),
-            PolarisEntityType.TABLE_LIKE,
-            PolarisEntitySubType.ICEBERG_TABLE,
-            table.name());
-    assertThat(result.isSuccess()).isTrue();
-    return PolarisEntity.of(result.getEntity());
-  }
-
-  private List<PolarisEntityCore> tableLikeCatalogPath(Namespace ns) {
-    assertThat(ns.length()).as("test namespaces must be single-level").isEqualTo(1);
-    EntityResult result =
-        metaStoreManager.readEntityByName(
-            polarisContext,
-            List.of(PolarisEntity.toCore(catalogEntity)),
-            PolarisEntityType.NAMESPACE,
-            PolarisEntitySubType.NULL_SUBTYPE,
-            ns.level(0));
-    assertThat(result.isSuccess()).isTrue();
-    return List.of(
-        PolarisEntity.toCore(catalogEntity),
-        PolarisEntity.toCore(PolarisEntity.of(result.getEntity())));
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogOverlapTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogOverlapTest.java
@@ -49,10 +49,15 @@ import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityCore;
+import org.apache.polaris.core.entity.PolarisEntitySubType;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
+import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
@@ -299,9 +304,11 @@ public abstract class AbstractLocalIcebergCatalogOverlapTest {
 
   @Test
   public void testParentPrefixOverlapWithTrailingSlashMismatch() {
-    // Profiles disable ADD_TRAILING_SLASH_TO_LOCATION so the parent is stored without a trailing
-    // slash. That is the OPTIMIZED_SIBLING_CHECK false-negative for JDBC: ancestor equality terms
-    // used to be slash-terminated only, so location_without_scheme without '/' was missed.
+    // The catalog now always stores locations with a trailing slash
+    // (ADD_TRAILING_SLASH_TO_LOCATION was removed). Simulate legacy slash-less data
+    // by rewriting the stored parent location directly, then verify the optimized sibling check
+    // still detects overlaps against it: ancestor equality terms used to be slash-terminated only,
+    // so a slash-less location_without_scheme was missed.
     Namespace ns = Namespace.of("ns-for-trailing-slash-overlap");
     catalog().createNamespace(ns);
 
@@ -310,9 +317,11 @@ public abstract class AbstractLocalIcebergCatalogOverlapTest {
     assertThat(parentLoc).doesNotEndWith("/");
     catalog().buildTable(parentTable, SCHEMA).withLocation(parentLoc).create();
 
-    // Guardrail: if trailing-slash normalization were still on, this test would not exercise the
-    // slash-less location_without_scheme path that QueryGenerator must handle.
-    assertThat(catalog().loadTable(parentTable).location())
+    stripStoredBaseLocationTrailingSlash(ns, parentTable);
+
+    // Guardrail: the stored location must be slash-less so overlap checks exercise the
+    // non-slash-terminated location_without_scheme path that QueryGenerator must handle.
+    assertThat(storedTableBaseLocation(ns, parentTable))
         .as("parent must remain slash-less so overlap uses non-slash-terminated stored location")
         .isEqualTo(parentLoc)
         .doesNotEndWith("/");
@@ -334,5 +343,55 @@ public abstract class AbstractLocalIcebergCatalogOverlapTest {
         .isInstanceOf(ForbiddenException.class)
         .hasMessageContaining("Unable to create entity at location")
         .hasMessageContaining("conflicts with existing table or namespace");
+  }
+
+  private String storedTableBaseLocation(Namespace ns, TableIdentifier table) {
+    return IcebergTableLikeEntity.of(readStoredTableLike(ns, table)).getBaseLocation();
+  }
+
+  /**
+   * Rewrites the stored base location of {@code table} without its trailing slash, simulating data
+   * written before Polaris always appended one.
+   */
+  private void stripStoredBaseLocationTrailingSlash(Namespace ns, TableIdentifier table) {
+    PolarisEntity tableEntity = readStoredTableLike(ns, table);
+    IcebergTableLikeEntity tableLike = IcebergTableLikeEntity.of(tableEntity);
+    String baseLocation = tableLike.getBaseLocation();
+    assertThat(baseLocation).endsWith("/");
+    IcebergTableLikeEntity stripped =
+        new IcebergTableLikeEntity.Builder(tableLike)
+            .setBaseLocation(baseLocation.substring(0, baseLocation.length() - 1))
+            .build();
+    EntityResult result =
+        metaStoreManager.updateEntityPropertiesIfNotChanged(
+            polarisContext, tableLikeCatalogPath(ns), stripped);
+    assertThat(result.isSuccess()).isTrue();
+  }
+
+  private PolarisEntity readStoredTableLike(Namespace ns, TableIdentifier table) {
+    EntityResult result =
+        metaStoreManager.readEntityByName(
+            polarisContext,
+            tableLikeCatalogPath(ns),
+            PolarisEntityType.TABLE_LIKE,
+            PolarisEntitySubType.ICEBERG_TABLE,
+            table.name());
+    assertThat(result.isSuccess()).isTrue();
+    return PolarisEntity.of(result.getEntity());
+  }
+
+  private List<PolarisEntityCore> tableLikeCatalogPath(Namespace ns) {
+    assertThat(ns.length()).as("test namespaces must be single-level").isEqualTo(1);
+    EntityResult result =
+        metaStoreManager.readEntityByName(
+            polarisContext,
+            List.of(PolarisEntity.toCore(catalogEntity)),
+            PolarisEntityType.NAMESPACE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            ns.level(0));
+    assertThat(result.isSuccess()).isTrue();
+    return List.of(
+        PolarisEntity.toCore(catalogEntity),
+        PolarisEntity.toCore(PolarisEntity.of(result.getEntity())));
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogNoSqlOverlapTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogNoSqlOverlapTest.java
@@ -46,8 +46,6 @@ public class LocalIcebergCatalogNoSqlOverlapTest extends AbstractLocalIcebergCat
       overrides.put("polaris.features.\"ALLOW_TABLE_LOCATION_OVERLAP\"", "false");
       overrides.put("polaris.features.\"OPTIMIZED_SIBLING_CHECK\"", "true");
       overrides.put("polaris.features.\"ALLOW_OPTIMIZED_SIBLING_CHECK\"", "true");
-      // Keep locations as written so slash-less base locations are stored as-is.
-      overrides.put("polaris.features.\"ADD_TRAILING_SLASH_TO_LOCATION\"", "false");
       return overrides;
     }
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogOverlapTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogOverlapTest.java
@@ -44,8 +44,6 @@ public class LocalIcebergCatalogOverlapTest extends AbstractLocalIcebergCatalogO
       overrides.put("polaris.features.\"ALLOW_TABLE_LOCATION_OVERLAP\"", "false");
       overrides.put("polaris.features.\"OPTIMIZED_SIBLING_CHECK\"", "true");
       overrides.put("polaris.features.\"ALLOW_OPTIMIZED_SIBLING_CHECK\"", "true");
-      // Keep locations as written so slash-less base locations are stored as-is.
-      overrides.put("polaris.features.\"ADD_TRAILING_SLASH_TO_LOCATION\"", "false");
       return overrides;
     }
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogRelationalOverlapTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogRelationalOverlapTest.java
@@ -45,9 +45,6 @@ public class LocalIcebergCatalogRelationalOverlapTest
       overrides.put("polaris.features.\"ALLOW_TABLE_LOCATION_OVERLAP\"", "false");
       overrides.put("polaris.features.\"OPTIMIZED_SIBLING_CHECK\"", "true");
       overrides.put("polaris.features.\"ALLOW_OPTIMIZED_SIBLING_CHECK\"", "true");
-      // Keep locations as written so JDBC optimized sibling checks exercise slash-less
-      // location_without_scheme values (the false-negative fixed in QueryGenerator).
-      overrides.put("polaris.features.\"ADD_TRAILING_SLASH_TO_LOCATION\"", "false");
       overrides.put("polaris.persistence.type", "relational-jdbc");
       overrides.put("polaris.persistence.auto-bootstrap-types", "relational-jdbc");
       overrides.put("quarkus.datasource.db-kind", "h2");

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogRelationalOverlapTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogRelationalOverlapTest.java
@@ -20,6 +20,7 @@ package org.apache.polaris.service.catalog.iceberg;
 
 import static org.apache.polaris.service.admin.PolarisAuthzTestBase.SCHEMA;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -30,7 +31,9 @@ import java.util.Map;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.polaris.core.entity.NamespaceEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
 import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
@@ -120,8 +123,76 @@ public class LocalIcebergCatalogRelationalOverlapTest
         .hasMessageContaining("conflicts with existing table or namespace");
   }
 
+  /**
+   * Regression for the {@code setProperties} normalization path. A namespace stored before Polaris
+   * always appended a trailing slash keeps a slash-less location. Updating an unrelated property
+   * must not be rejected: previously the slash-only normalization flipped {@code locationChanged}
+   * to true and ran the overlap check, which under the optimized sibling check matched the
+   * namespace's own still-persisted slash-less row (it does not exclude the current entity). The
+   * update must succeed and the stored location must be re-normalized to end with a slash. Kept
+   * JDBC-specific because it depends on the optimized sibling check backed by {@code
+   * QueryGenerator}.
+   */
+  @Test
+  public void testNamespacePropertyUpdateNormalizesLegacySlashlessLocation() {
+    Namespace ns = Namespace.of("ns-legacy-slashless");
+    // Let Polaris derive the location (custom namespace locations are disabled in this profile).
+    catalog().createNamespace(ns);
+
+    // On create Polaris stores the location slash-terminated.
+    String created = storedNamespaceBaseLocation(ns);
+    assertThat(created).endsWith("/");
+
+    // Simulate a row written before that normalization existed.
+    stripStoredNamespaceBaseLocationTrailingSlash(ns);
+    String legacy = storedNamespaceBaseLocation(ns);
+    assertThat(legacy).doesNotEndWith("/");
+    assertThat(created).isEqualTo(legacy + "/");
+
+    // Updating a non-location property must succeed (not be flagged as a self-overlap) and must
+    // re-normalize the stored location.
+    assertThatCode(() -> catalog().setProperties(ns, Map.of("some-key", "some-value")))
+        .doesNotThrowAnyException();
+    assertThat(storedNamespaceBaseLocation(ns)).endsWith("/");
+  }
+
   private String storedTableBaseLocation(Namespace ns, TableIdentifier table) {
     return IcebergTableLikeEntity.of(readStoredTableLike(ns, table)).getBaseLocation();
+  }
+
+  private String storedNamespaceBaseLocation(Namespace ns) {
+    return NamespaceEntity.of(readStoredNamespace(ns)).getBaseLocation();
+  }
+
+  private PolarisEntity readStoredNamespace(Namespace ns) {
+    EntityResult result =
+        metaStoreManager.readEntityByName(
+            polarisContext,
+            List.of(PolarisEntity.toCore(catalogEntity)),
+            PolarisEntityType.NAMESPACE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            ns.level(0));
+    assertThat(result.isSuccess()).isTrue();
+    return PolarisEntity.of(result.getEntity());
+  }
+
+  /**
+   * Rewrites the stored base location of {@code ns} without its trailing slash, simulating a
+   * namespace written before Polaris always appended one.
+   */
+  private void stripStoredNamespaceBaseLocationTrailingSlash(Namespace ns) {
+    PolarisEntity nsEntity = readStoredNamespace(ns);
+    Map<String, String> properties = new HashMap<>(nsEntity.getPropertiesAsMap());
+    String baseLocation = properties.get(PolarisEntityConstants.ENTITY_BASE_LOCATION);
+    assertThat(baseLocation).endsWith("/");
+    properties.put(
+        PolarisEntityConstants.ENTITY_BASE_LOCATION,
+        baseLocation.substring(0, baseLocation.length() - 1));
+    PolarisEntity stripped = new PolarisEntity.Builder(nsEntity).setProperties(properties).build();
+    EntityResult result =
+        metaStoreManager.updateEntityPropertiesIfNotChanged(
+            polarisContext, List.of(PolarisEntity.toCore(catalogEntity)), stripped);
+    assertThat(result.isSuccess()).isTrue();
   }
 
   /**

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogRelationalOverlapTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogRelationalOverlapTest.java
@@ -18,11 +18,26 @@
  */
 package org.apache.polaris.service.catalog.iceberg;
 
+import static org.apache.polaris.service.admin.PolarisAuthzTestBase.SCHEMA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.polaris.core.entity.PolarisEntity;
+import org.apache.polaris.core.entity.PolarisEntityCore;
+import org.apache.polaris.core.entity.PolarisEntitySubType;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
+import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.service.Profiles;
+import org.junit.jupiter.api.Test;
 
 /**
  * JDBC/relational-backed overlap test. Inherits the assertions from {@link
@@ -53,5 +68,105 @@ public class LocalIcebergCatalogRelationalOverlapTest
           "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE");
       return overrides;
     }
+  }
+
+  /**
+   * Regression guard for the QueryGenerator trailing-slash false-negative. It is kept JDBC-specific
+   * on purpose: the failure mode lives in {@code QueryGenerator}'s ancestor-equality terms, which
+   * only the relational-jdbc optimized sibling check exercises. The in-memory and NoSQL profiles
+   * use different overlap paths, so running this there would pass regardless and give false
+   * confidence.
+   */
+  @Test
+  public void testParentPrefixOverlapWithTrailingSlashMismatch() {
+    // The catalog now always stores locations with a trailing slash
+    // (ADD_TRAILING_SLASH_TO_LOCATION was removed). Simulate legacy slash-less data
+    // by rewriting the stored parent location directly, then verify the optimized sibling check
+    // still detects overlaps against it: ancestor equality terms used to be slash-terminated only,
+    // so a slash-less location_without_scheme was missed.
+    Namespace ns = Namespace.of("ns-for-trailing-slash-overlap");
+    catalog().createNamespace(ns);
+
+    TableIdentifier parentTable = TableIdentifier.of(ns, "trailing-parent");
+    String parentLoc = STORAGE_LOCATION + "/trailing-overlap/parent";
+    assertThat(parentLoc).doesNotEndWith("/");
+    catalog().buildTable(parentTable, SCHEMA).withLocation(parentLoc).create();
+
+    stripStoredBaseLocationTrailingSlash(ns, parentTable);
+
+    // Guardrail: the stored location must be slash-less so overlap checks exercise the
+    // non-slash-terminated location_without_scheme path that QueryGenerator must handle.
+    assertThat(storedTableBaseLocation(ns, parentTable))
+        .as("parent must remain slash-less so overlap uses non-slash-terminated stored location")
+        .isEqualTo(parentLoc)
+        .doesNotEndWith("/");
+
+    // Creating a child table under the slash-less parent location must be rejected.
+    TableIdentifier childTable = TableIdentifier.of(ns, "trailing-child");
+    String childLoc = STORAGE_LOCATION + "/trailing-overlap/parent/child";
+    assertThatThrownBy(
+            () -> catalog().buildTable(childTable, SCHEMA).withLocation(childLoc).create())
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("Unable to create entity at location")
+        .hasMessageContaining("conflicts with existing table or namespace");
+
+    // The same must hold when the slash-terminated form of the same prefix is used.
+    TableIdentifier siblingTable = TableIdentifier.of(ns, "trailing-sibling");
+    String siblingLoc = STORAGE_LOCATION + "/trailing-overlap/parent/";
+    assertThatThrownBy(
+            () -> catalog().buildTable(siblingTable, SCHEMA).withLocation(siblingLoc).create())
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("Unable to create entity at location")
+        .hasMessageContaining("conflicts with existing table or namespace");
+  }
+
+  private String storedTableBaseLocation(Namespace ns, TableIdentifier table) {
+    return IcebergTableLikeEntity.of(readStoredTableLike(ns, table)).getBaseLocation();
+  }
+
+  /**
+   * Rewrites the stored base location of {@code table} without its trailing slash, simulating data
+   * written before Polaris always appended one.
+   */
+  private void stripStoredBaseLocationTrailingSlash(Namespace ns, TableIdentifier table) {
+    PolarisEntity tableEntity = readStoredTableLike(ns, table);
+    IcebergTableLikeEntity tableLike = IcebergTableLikeEntity.of(tableEntity);
+    String baseLocation = tableLike.getBaseLocation();
+    assertThat(baseLocation).endsWith("/");
+    IcebergTableLikeEntity stripped =
+        new IcebergTableLikeEntity.Builder(tableLike)
+            .setBaseLocation(baseLocation.substring(0, baseLocation.length() - 1))
+            .build();
+    EntityResult result =
+        metaStoreManager.updateEntityPropertiesIfNotChanged(
+            polarisContext, tableLikeCatalogPath(ns), stripped);
+    assertThat(result.isSuccess()).isTrue();
+  }
+
+  private PolarisEntity readStoredTableLike(Namespace ns, TableIdentifier table) {
+    EntityResult result =
+        metaStoreManager.readEntityByName(
+            polarisContext,
+            tableLikeCatalogPath(ns),
+            PolarisEntityType.TABLE_LIKE,
+            PolarisEntitySubType.ICEBERG_TABLE,
+            table.name());
+    assertThat(result.isSuccess()).isTrue();
+    return PolarisEntity.of(result.getEntity());
+  }
+
+  private List<PolarisEntityCore> tableLikeCatalogPath(Namespace ns) {
+    assertThat(ns.length()).as("test namespaces must be single-level").isEqualTo(1);
+    EntityResult result =
+        metaStoreManager.readEntityByName(
+            polarisContext,
+            List.of(PolarisEntity.toCore(catalogEntity)),
+            PolarisEntityType.NAMESPACE,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            ns.level(0));
+    assertThat(result.isSuccess()).isTrue();
+    return List.of(
+        PolarisEntity.toCore(catalogEntity),
+        PolarisEntity.toCore(PolarisEntity.of(result.getEntity())));
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/config/ProductionReadinessChecksAddTrailingSlashTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/config/ProductionReadinessChecksAddTrailingSlashTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.apache.polaris.core.config.ProductionReadinessCheck;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductionReadinessChecksAddTrailingSlashTest {
+
+  private static final String FLAG_KEY = "ADD_TRAILING_SLASH_TO_LOCATION";
+
+  private ProductionReadinessChecks checks;
+
+  @BeforeEach
+  void setUp() {
+    checks = new ProductionReadinessChecks();
+  }
+
+  @Test
+  void flagUnsetReturnsOk() {
+    FeaturesConfiguration config = mockConfig(Map.of(), Map.of());
+
+    ProductionReadinessCheck result = checks.checkAddTrailingSlashToLocation(config);
+
+    assertThat(result.ready()).isTrue();
+  }
+
+  @Test
+  void flagExplicitlyTrueReturnsOk() {
+    FeaturesConfiguration config = mockConfig(Map.of(FLAG_KEY, "true"), Map.of());
+
+    ProductionReadinessCheck result = checks.checkAddTrailingSlashToLocation(config);
+
+    assertThat(result.ready()).isTrue();
+  }
+
+  @Test
+  void flagExplicitlyFalseReturnsWarning() {
+    FeaturesConfiguration config = mockConfig(Map.of(FLAG_KEY, "false"), Map.of());
+
+    ProductionReadinessCheck result = checks.checkAddTrailingSlashToLocation(config);
+
+    assertThat(result.ready()).isFalse();
+    assertThat(result.getErrors())
+        .singleElement()
+        .satisfies(
+            error -> {
+              assertThat(error.offendingProperty()).contains(FLAG_KEY);
+              assertThat(error.severe()).isFalse();
+            });
+  }
+
+  @Test
+  void realmOverrideFalseReturnsWarning() {
+    FeaturesConfiguration config =
+        mockConfig(Map.of(), Map.of("test-realm", mockRealmOverrides(Map.of(FLAG_KEY, "false"))));
+
+    ProductionReadinessCheck result = checks.checkAddTrailingSlashToLocation(config);
+
+    assertThat(result.ready()).isFalse();
+    assertThat(result.getErrors())
+        .singleElement()
+        .satisfies(
+            error -> {
+              assertThat(error.offendingProperty()).contains("test-realm").contains(FLAG_KEY);
+              assertThat(error.severe()).isFalse();
+            });
+  }
+
+  private static FeaturesConfiguration mockConfig(
+      Map<String, String> defaults, Map<String, RealmOverridable.RealmOverrides> realmOverrides) {
+    FeaturesConfiguration config = mock(FeaturesConfiguration.class);
+    when(config.defaults()).thenReturn(defaults);
+    when(config.realmOverrides()).thenReturn(realmOverrides);
+    return config;
+  }
+
+  private static RealmOverridable.RealmOverrides mockRealmOverrides(Map<String, String> overrides) {
+    RealmOverridable.RealmOverrides realmOverrides = mock(RealmOverridable.RealmOverrides.class);
+    when(realmOverrides.overrides()).thenReturn(overrides);
+    return realmOverrides;
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/config/ReservedPropertiesTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/config/ReservedPropertiesTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.polaris.core.config.FeatureConfiguration;
 import org.junit.jupiter.api.Test;
 
 class ReservedPropertiesTest {
@@ -91,5 +92,32 @@ class ReservedPropertiesTest {
 
     assertThat(reservedProperties.removeReservedProperties(List.of("polaris.test", "user.test")))
         .containsExactly("user.test");
+  }
+
+  @Test
+  @SuppressWarnings({"deprecation", "removal"}) // exercises the deprecated flag's compat contract
+  void testDeprecatedAddTrailingSlashConfigStaysAcceptedButIgnored() {
+    // Regression for the accepted-but-ignored compatibility contract of the deprecated
+    // ADD_TRAILING_SLASH_TO_LOCATION flag. The catalog-config key stays on the allowlist only
+    // because the deprecated feature config still declares it. If that declaration is removed, this
+    // key falls through to the reserved "polaris." prefix check and catalog create/update starts
+    // returning 400 again -- including a plain read-modify-write of an existing catalog that still
+    // carries the key. Referencing the constant here also forces the feature-config registry to
+    // load and turns a future removal into a compile-time failure on this test.
+    String key = FeatureConfiguration.ADD_TRAILING_SLASH_TO_LOCATION.catalogConfig();
+    assertThat(key).isEqualTo("polaris.config.add-trailing-slash-to-location");
+    ReservedProperties reservedProperties = new ReservedProperties() {};
+
+    assertThat(reservedProperties.allowlist()).contains(key);
+
+    // Create path: the property is accepted rather than rejected or stripped.
+    assertThat(reservedProperties.removeReservedProperties(Map.of(key, "false")))
+        .containsEntry(key, "false");
+
+    // Read-modify-write path: GET returns the key, PUT it back unchanged must not be rejected.
+    assertThat(
+            reservedProperties.removeReservedPropertiesFromUpdate(
+                Map.of(key, "false"), Map.of(key, "false")))
+        .containsEntry(key, "false");
   }
 }

--- a/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
@@ -25,16 +25,6 @@ build:
 
 Feature configurations for Polaris. These are stable, user-facing settings.
 
-##### `polaris.features."ADD_TRAILING_SLASH_TO_LOCATION"`
-
-When set, the base location for a table or namespace will have `/` added as a suffix if not present
-
-- **Type:** `Boolean`
-- **Default:** `true`
-- **Catalog Config:** `polaris.config.add-trailing-slash-to-location`
-
----
-
 ##### `polaris.features."ALLOW_CLIENT_SPECIFIED_TABLE_LOCATION"`
 
 If set to true (the default), Polaris honors a `location` (and the `write.data.path` / `write.metadata.path` properties) explicitly supplied in a create or update request, subject to the usual structured-location, allowed-location, metadata-location, and overlap validation. If set to false, such requests are rejected, regardless of the other location compatibility flags. This setting does not apply to federated catalogs.
@@ -460,7 +450,7 @@ How many times to retry refreshing metadata when the previous error was retryabl
 
 ##### `polaris.features."OPTIMIZED_SIBLING_CHECK"`
 
-When set, Polaris uses an index to perform sibling overlap checks between tables, views, and namespaces. This is not a bypass mode, but enabling or disabling it can change overlap-detection coverage for non-standard location layouts. Only enable it when the required index and backfill state is known to be correct. For correct results, locations should end with a slash; see ADD_TRAILING_SLASH_TO_LOCATION. Supported by the JDBC and NoSQL metastore implementations.
+When set, Polaris uses an index to perform sibling overlap checks between tables, views, and namespaces. This is not a bypass mode, but enabling or disabling it can change overlap-detection coverage for non-standard location layouts. Only enable it when the required index and backfill state is known to be correct. Locations written by Polaris always end with a slash; locations stored by older versions without one are still handled. Supported by the JDBC and NoSQL metastore implementations.
 
 - **Type:** `Boolean`
 - **Default:** `false`

--- a/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
@@ -25,6 +25,16 @@ build:
 
 Feature configurations for Polaris. These are stable, user-facing settings.
 
+##### `polaris.features."ADD_TRAILING_SLASH_TO_LOCATION"`
+
+Deprecated and ignored: Polaris always appends a trailing slash to table and namespace base locations. Retained so existing configuration remains accepted rather than rejected.
+
+- **Type:** `Boolean`
+- **Default:** `true`
+- **Catalog Config:** `polaris.config.add-trailing-slash-to-location`
+
+---
+
 ##### `polaris.features."ALLOW_CLIENT_SPECIFIED_TABLE_LOCATION"`
 
 If set to true (the default), Polaris honors a `location` (and the `write.data.path` / `write.metadata.path` properties) explicitly supplied in a create or update request, subject to the usual structured-location, allowed-location, metadata-location, and overlap validation. If set to false, such requests are rejected, regardless of the other location compatibility flags. This setting does not apply to federated catalogs.


### PR DESCRIPTION
Fixes #5269 & follow-up to the discussion on #5003.

`ADD_TRAILING_SLASH_TO_LOCATION` is **deprecated**, not removed. Polaris now always
appends a trailing slash to table and namespace base locations, so the flag no longer
changes behavior.

- The flag stays registered as `@Deprecated(since = "1.8.0", forRemoval = true)`,
  unread at runtime. Keeping the declaration keeps its catalog-config key
  (`polaris.config.add-trailing-slash-to-location`) on the `ReservedProperties`
  allowlist, so existing catalog properties and `polaris.features` entries remain
  accepted-but-ignored instead of being rejected with a 400 on create/update.
- A non-severe production-readiness warning is emitted at startup if the flag is
  explicitly set to `false` (in `polaris.features` defaults or realm overrides),
  naming the exact config key.
- The `OPTIMIZED_SIBLING_CHECK` description no longer references the flag: locations
  written by Polaris always end with a slash, and slash-less locations stored by older
  versions remain handled by the overlap check.

### Why deprecate instead of remove

`ADD_TRAILING_SLASH_TO_LOCATION` is a user-facing feature flag. Hard-removing the
declaration would reject a normal read-modify-write of an existing catalog that still
carries the key (GET returns it, PUT then 400s). The deprecation path avoids that,
gives downstream users a heads-up, and can be followed by a hard removal in a future
release.

Operators who explicitly set `ADD_TRAILING_SLASH_TO_LOCATION=false` will now get
trailing slashes on new table/namespace locations regardless. Setting it to `false`
only weakened location-overlap detection (the trailing slash is what lets prefix
matching distinguish `ns/tA/child` from `ns/tA_backup`). 

### Follow-ups

This PR does not simplify the dual-form ancestor terms in `QueryGenerator` (added in
#5003). Slash-less rows written by older versions may still exist, so both forms must
be queried until stored data is migrated. A migration to normalize stored locations
(candidate for the migration framework from #4981) and the subsequent query
simplification are left as follow-ups.