### PR TITLE
Remove "default base location" arg from `CatalogEntity.setStorageConfigurationInfo()`

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -279,6 +279,9 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
   }
 
   public static class Builder extends PolarisEntity.BaseBuilder<CatalogEntity, Builder> {
+    private RealmConfig realmConfig;
+    private StorageConfigInfo storageConfigModel;
+
     public Builder() {
       super();
       setType(PolarisEntityType.CATALOG);
@@ -324,6 +327,14 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
 
     public Builder setStorageConfigurationInfo(
         RealmConfig realmConfig, StorageConfigInfo storageConfigModel) {
+      Preconditions.checkNotNull(
+          realmConfig, "realmConfig must be provided when setting StorageConfigInfo");
+      this.realmConfig = realmConfig;
+      this.storageConfigModel = storageConfigModel;
+      return this;
+    }
+
+    private void processStorageConfigurationInfo() {
       if (storageConfigModel != null) {
         String defaultBaseLocation = properties.get(DEFAULT_BASE_LOCATION_KEY);
         if (defaultBaseLocation == null) {
@@ -395,7 +406,6 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
         internalProperties.put(
             PolarisEntityConstants.getStorageConfigInfoPropertyName(), config.serialize());
       }
-      return this;
     }
 
     /** Validate the number of allowed locations not exceeding the max value. */
@@ -436,6 +446,7 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
 
     @Override
     public CatalogEntity build() {
+      processStorageConfigurationInfo();
       validateDefaultBaseLocation();
       return new CatalogEntity(buildBase());
     }

--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/CatalogEntity.java
@@ -92,8 +92,7 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
     Map<String, String> internalProperties = new HashMap<>();
     internalProperties.put(CATALOG_TYPE_PROPERTY, catalog.getType().name());
     builder.setInternalProperties(internalProperties);
-    builder.setStorageConfigurationInfo(
-        realmConfig, catalog.getStorageConfigInfo(), getBaseLocation(catalog));
+    builder.setStorageConfigurationInfo(realmConfig, catalog.getStorageConfigInfo());
     return builder.build();
   }
 
@@ -324,8 +323,9 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
     }
 
     public Builder setStorageConfigurationInfo(
-        RealmConfig realmConfig, StorageConfigInfo storageConfigModel, String defaultBaseLocation) {
+        RealmConfig realmConfig, StorageConfigInfo storageConfigModel) {
       if (storageConfigModel != null) {
+        String defaultBaseLocation = properties.get(DEFAULT_BASE_LOCATION_KEY);
         if (defaultBaseLocation == null) {
           throw new BadRequestException("Must specify default base location");
         }
@@ -439,9 +439,5 @@ public class CatalogEntity extends PolarisEntity implements LocationBasedEntity 
       validateDefaultBaseLocation();
       return new CatalogEntity(buildBase());
     }
-  }
-
-  protected static @NonNull String getBaseLocation(Catalog catalog) {
-    return catalog.getProperties().getDefaultBaseLocation();
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java
@@ -1030,8 +1030,7 @@ public class PolarisAdminService {
     }
 
     if (updateRequest.getStorageConfigInfo() != null) {
-      updateBuilder.setStorageConfigurationInfo(
-          realmConfig, updateRequest.getStorageConfigInfo(), defaultBaseLocation);
+      updateBuilder.setStorageConfigurationInfo(realmConfig, updateRequest.getStorageConfigInfo());
     }
     CatalogEntity updatedEntity = updateBuilder.build();
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -272,10 +272,7 @@ public abstract class PolarisAuthzTestBase {
             .setName(FEDERATED_CATALOG_NAME)
             .setCatalogType("EXTERNAL")
             .setDefaultBaseLocation(storageLocationForFederatedCatalog)
-            .setStorageConfigurationInfo(
-                realmConfig,
-                storageConfigModelForFederatedCatalog,
-                storageLocationForFederatedCatalog)
+            .setStorageConfigurationInfo(realmConfig, storageConfigModelForFederatedCatalog)
             .addProperty("polaris.config.enable-sub-catalog-rbac-for-federated-catalogs", "true")
             .build();
     ExternalCatalog externalCatalog =
@@ -302,8 +299,7 @@ public abstract class PolarisAuthzTestBase {
                         .setName(CATALOG_NAME)
                         .setCatalogType("INTERNAL")
                         .setDefaultBaseLocation(storageLocation)
-                        .setStorageConfigurationInfo(
-                            realmConfig, storageConfigModel, storageLocation)
+                        .setStorageConfigurationInfo(realmConfig, storageConfigModel)
                         .build()
                         .asCatalog(serviceIdentityProvider)));
     federatedCatalogEntity =

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
@@ -199,7 +199,7 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
                         "true")
                     .addProperty(
                         FeatureConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfig(), "true")
-                    .setStorageConfigurationInfo(realmConfig, storageConfigModel, storageLocation)
+                    .setStorageConfigurationInfo(realmConfig, storageConfigModel)
                     .build()
                     .asCatalog(serviceIdentityProvider)));
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
@@ -2083,7 +2083,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
                 new CatalogEntity.Builder()
                     .setName(externalCatalog)
                     .setDefaultBaseLocation(storageLocation)
-                    .setStorageConfigurationInfo(realmConfig, storageConfigModel, storageLocation)
+                    .setStorageConfigurationInfo(realmConfig, storageConfigModel)
                     .setCatalogType("EXTERNAL")
                     .build()
                     .asCatalog(serviceIdentityProvider)));

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogOverlapTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogOverlapTest.java
@@ -172,7 +172,7 @@ public abstract class AbstractLocalIcebergCatalogOverlapTest {
                         "true")
                     .addProperty(
                         FeatureConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfig(), "true")
-                    .setStorageConfigurationInfo(realmConfig, storageConfigModel, STORAGE_LOCATION)
+                    .setStorageConfigurationInfo(realmConfig, storageConfigModel)
                     .build()
                     .asCatalog(serviceIdentityProvider)));
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -341,8 +341,7 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
                         .addProperty(
                             FeatureConfiguration.PURGE_VIEW_METADATA_ON_DROP.catalogConfig(),
                             "true")
-                        .setStorageConfigurationInfo(
-                            realmConfig, storageConfigModel, STORAGE_LOCATION)
+                        .setStorageConfigurationInfo(realmConfig, storageConfigModel)
                         .build()
                         .asCatalog(serviceIdentityProvider)));
 
@@ -2063,8 +2062,7 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
                         "true")
                     .addProperty(
                         FeatureConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfig(), "false")
-                    .setStorageConfigurationInfo(
-                        realmConfig, noPurgeStorageConfigModel, storageLocation)
+                    .setStorageConfigurationInfo(realmConfig, noPurgeStorageConfigModel)
                     .build()
                     .asCatalog(serviceIdentityProvider)));
     LocalIcebergCatalog noPurgeCatalog =

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogViewTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogViewTest.java
@@ -199,8 +199,7 @@ public abstract class AbstractLocalIcebergCatalogViewTest
                         new FileStorageConfigInfo(
                             StorageConfigInfo.StorageTypeEnum.FILE,
                             List.of("file://tmp", "*"),
-                            null),
-                        "file://tmp")
+                            null))
                     .build()
                     .asCatalog(serviceIdentityProvider)));
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
@@ -219,7 +219,7 @@ public abstract class AbstractPolicyCatalogTest {
                     .addProperty(
                         FeatureConfiguration.ALLOW_UNSTRUCTURED_TABLE_LOCATION.catalogConfig(),
                         "true")
-                    .setStorageConfigurationInfo(realmConfig, storageConfigModel, storageLocation)
+                    .setStorageConfigurationInfo(realmConfig, storageConfigModel)
                     .build()
                     .asCatalog(serviceIdentityProvider)));
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/entity/CatalogEntityTest.java
@@ -399,7 +399,7 @@ public class CatalogEntityTest {
         new CatalogEntity.Builder()
             .setName("test-catalog")
             .setDefaultBaseLocation(baseLocation)
-            .setStorageConfigurationInfo(realmConfig, storageConfigModel, baseLocation)
+            .setStorageConfigurationInfo(realmConfig, storageConfigModel)
             .build();
 
     Catalog catalog = catalogEntity.asCatalog(serviceIdentityProvider);
@@ -425,7 +425,7 @@ public class CatalogEntityTest {
             .setName("test-external-catalog")
             .setDefaultBaseLocation(baseLocation)
             .setCatalogType(Catalog.TypeEnum.EXTERNAL.name())
-            .setStorageConfigurationInfo(realmConfig, storageConfigModel, baseLocation)
+            .setStorageConfigurationInfo(realmConfig, storageConfigModel)
             .build();
 
     Catalog catalog = catalogEntity.asCatalog(serviceIdentityProvider);
@@ -450,7 +450,7 @@ public class CatalogEntityTest {
             .setName("test-internal-catalog")
             .setDefaultBaseLocation(baseLocation)
             .setCatalogType(Catalog.TypeEnum.INTERNAL.name())
-            .setStorageConfigurationInfo(realmConfig, storageConfigModel, baseLocation)
+            .setStorageConfigurationInfo(realmConfig, storageConfigModel)
             .build();
 
     Catalog catalog = catalogEntity.asCatalog(serviceIdentityProvider);
@@ -486,9 +486,7 @@ public class CatalogEntityTest {
             .setDefaultBaseLocation(config.getAllowedLocations().getFirst())
             .setCatalogType(Catalog.TypeEnum.INTERNAL.name())
             .setStorageConfigurationInfo(
-                realmConfig,
-                MAPPER.readValue(configStr, StorageConfigInfo.class),
-                config.getAllowedLocations().getFirst())
+                realmConfig, MAPPER.readValue(configStr, StorageConfigInfo.class))
             .build();
 
     Catalog catalog = catalogEntity.asCatalog(serviceIdentityProvider);
@@ -524,7 +522,7 @@ public class CatalogEntityTest {
             .setName("test-catalog")
             .setCatalogType(Catalog.TypeEnum.EXTERNAL.name())
             .setDefaultBaseLocation(baseLocation)
-            .setStorageConfigurationInfo(realmConfig, storageConfigModel, baseLocation)
+            .setStorageConfigurationInfo(realmConfig, storageConfigModel)
             .setConnectionConfigInfoDpoWithSecrets(
                 icebergRestConnectionConfigInfoModel, null, new AwsIamServiceIdentityInfoDpo(null))
             .build();
@@ -603,8 +601,7 @@ public class CatalogEntityTest {
                             .setRoleArn("arn:aws:iam::012345678901:role/jdoe")
                             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
                             .setAllowedLocations(List.of(allowed))
-                            .build(),
-                        base)
+                            .build())
                     .build())
         .doesNotThrowAnyException();
   }
@@ -623,8 +620,7 @@ public class CatalogEntityTest {
                             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
                             .setAllowedLocations(
                                 List.of("s3://bucket-a/", "s3://bucket-b/warehouse/"))
-                            .build(),
-                        "s3://bucket-b/warehouse/data")
+                            .build())
                     .build())
         .doesNotThrowAnyException();
   }
@@ -642,8 +638,7 @@ public class CatalogEntityTest {
                             .setRoleArn("arn:aws:iam::012345678901:role/jdoe")
                             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
                             .setAllowedLocations(List.of("s3://bucket/"))
-                            .build(),
-                        "s3://other-bucket/data")
+                            .build())
                     .build())
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("s3://other-bucket/data")
@@ -663,8 +658,7 @@ public class CatalogEntityTest {
                             .setRoleArn("arn:aws:iam::012345678901:role/jdoe")
                             .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
                             .setAllowedLocations(List.of("s3://bucket/"))
-                            .build(),
-                        "gs://bucket/data")
+                            .build())
                     .build())
         .isInstanceOf(BadRequestException.class);
   }


### PR DESCRIPTION
* The old `defaultBaseLocation` argument of the "set" method was NOT actually used to set the default base location in the Catalog object builder.

* The old `defaultBaseLocation` argument was used for validation, but nothing guaranteed that the caller passed in the right value.

* Remove the `defaultBaseLocation` argument

* Get the default base location value from current `properties` (which is the source of truth for this value).

* Note: most callers on this builder method already set the default base location before invoking `setStorageConfigurationInfo()`

* Keep the exception if `setStorageConfigurationInfo()` is invoked without first setting the default base location.

This is a follow-up to #4422
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
