### PR TITLE
Preserve setup principal-role properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   `{name, namespace, ...}` entries instead of the previous name-keyed mapping, preserving policies
   with the same name in different namespaces. The new export format cannot be applied by older CLI
   versions; use the exporting CLI version or newer for `setup apply`.
+- Python CLI `setup export` now preserves user-defined properties on principal roles,
+  so exported configurations restore that metadata during `setup apply`.
 - Python CLI `setup export` now preserves user-defined properties on principals and catalog roles,
   so exported configurations restore that metadata during `setup apply`.
 - Python CLI `setup apply` no longer double-encodes policy content emitted by `setup export`, so

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -188,10 +188,16 @@ class SetupCommand(Command):
             self._record_failure("Failed to export principals")
         return principals_map
 
-    def _export_principal_roles(self, api: PolarisDefaultApi) -> List[str]:
-        """Export all principal role names."""
+    def _export_principal_roles(self, api: PolarisDefaultApi) -> List[Any]:
+        """Export all principal roles."""
         try:
-            return sorted([role.name for role in api.list_principal_roles().roles])
+            roles = sorted(api.list_principal_roles().roles, key=lambda role: role.name)
+            return [
+                {"name": role.name, "properties": role.properties}
+                if role.properties
+                else role.name
+                for role in roles
+            ]
         except Exception:
             self._record_failure("Failed to export principal roles")
             return []
@@ -734,7 +740,7 @@ class SetupCommand(Command):
     def _create_principal_roles(
         self,
         api: PolarisDefaultApi,
-        principal_roles_config: List[str],
+        principal_roles_config: List[Any],
         dry_run: bool = False,
     ) -> None:
         """Create principal roles."""
@@ -744,7 +750,21 @@ class SetupCommand(Command):
             return
         self._get_existing_principal_roles(api)
 
-        for role_name in principal_roles_config:
+        for role_item in principal_roles_config:
+            role_name: Optional[str]
+            role_data: Dict[str, Any]
+            if isinstance(role_item, str):
+                role_name = role_item
+                role_data = {}
+            elif isinstance(role_item, dict):
+                role_name = role_item.get("name")
+                role_data = role_item
+            else:
+                logger.warning(f"Skipping invalid principal role entry: {role_item}")
+                continue
+            if not role_name:
+                logger.warning("Skipping principal role with no name")
+                continue
             if (
                 self._existing_principal_roles is not None
                 and role_name in self._existing_principal_roles
@@ -754,7 +774,12 @@ class SetupCommand(Command):
                 )
                 continue
             if dry_run:
-                self._log_dry_run("create", "principal role", role_name)
+                self._log_dry_run(
+                    "create",
+                    "principal role",
+                    role_name,
+                    {"properties": role_data.get("properties")},
+                )
                 if self._existing_principal_roles is not None:
                     self._existing_principal_roles.add(role_name)
             else:
@@ -763,6 +788,7 @@ class SetupCommand(Command):
                     cmd = PrincipalRolesCommand(
                         principal_roles_subcommand=Subcommands.CREATE,
                         principal_role_name=role_name,
+                        properties=role_data.get("properties"),
                     )
                     cmd.validate()
                     cmd.execute(api)

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -188,7 +188,9 @@ class SetupCommand(Command):
             self._record_failure("Failed to export principals")
         return principals_map
 
-    def _export_principal_roles(self, api: PolarisDefaultApi) -> List[Any]:
+    def _export_principal_roles(
+        self, api: PolarisDefaultApi
+    ) -> List[Union[str, Dict[str, Any]]]:
         """Export all principal roles."""
         try:
             roles = sorted(api.list_principal_roles().roles, key=lambda role: role.name)
@@ -740,7 +742,7 @@ class SetupCommand(Command):
     def _create_principal_roles(
         self,
         api: PolarisDefaultApi,
-        principal_roles_config: List[Any],
+        principal_roles_config: List[Union[str, Dict[str, Any]]],
         dry_run: bool = False,
     ) -> None:
         """Create principal roles."""

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -325,6 +325,10 @@ class TestSetupCommand(CLITestBase):
         export_client.list_principal_roles.return_value = SimpleNamespace(
             roles=[
                 SimpleNamespace(
+                    name="viewer-role",
+                    properties=None,
+                ),
+                SimpleNamespace(
                     name="analytics-role",
                     properties=principal_role_properties,
                 )
@@ -360,8 +364,14 @@ class TestSetupCommand(CLITestBase):
             principal_properties,
         )
         self.assertEqual(
-            loaded["principal_roles"][0]["properties"],
-            principal_role_properties,
+            loaded["principal_roles"],
+            [
+                {
+                    "name": "analytics-role",
+                    "properties": principal_role_properties,
+                },
+                "viewer-role",
+            ],
         )
         self.assertEqual(
             loaded["catalog_roles"]["catalog-reader"]["properties"],
@@ -393,16 +403,20 @@ class TestSetupCommand(CLITestBase):
         )
 
         principal_request = apply_client.create_principal.call_args.args[0]
-        principal_role_request = apply_client.create_principal_role.call_args.args[0]
+        principal_role_requests = [
+            call.args[0] for call in apply_client.create_principal_role.call_args_list
+        ]
         catalog_role_request = apply_client.create_catalog_role.call_args.args[1]
         self.assertEqual(
             principal_request.principal.properties,
             principal_properties,
         )
         self.assertEqual(
-            principal_role_request.principal_role.properties,
+            principal_role_requests[0].principal_role.properties,
             principal_role_properties,
         )
+        self.assertEqual(principal_role_requests[1].principal_role.name, "viewer-role")
+        self.assertEqual(principal_role_requests[1].principal_role.properties, {})
         self.assertEqual(
             catalog_role_request.catalog_role.properties,
             catalog_role_properties,

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -308,6 +308,7 @@ class TestSetupCommand(CLITestBase):
 
     def test_setup_exported_entity_properties_round_trip_through_apply(self) -> None:
         principal_properties = {"owner": "data-platform"}
+        principal_role_properties = {"team": "analytics"}
         catalog_role_properties = {"purpose": "migration"}
         export_client = self.build_mock_client()
         export_client.list_principals.return_value = SimpleNamespace(
@@ -320,6 +321,14 @@ class TestSetupCommand(CLITestBase):
         )
         export_client.list_principal_roles_assigned.return_value = SimpleNamespace(
             roles=[]
+        )
+        export_client.list_principal_roles.return_value = SimpleNamespace(
+            roles=[
+                SimpleNamespace(
+                    name="analytics-role",
+                    properties=principal_role_properties,
+                )
+            ]
         )
         export_client.list_catalog_roles.return_value = SimpleNamespace(
             roles=[
@@ -339,6 +348,7 @@ class TestSetupCommand(CLITestBase):
 
         exported = {
             "principals": export_command._export_principals(export_client),
+            "principal_roles": export_command._export_principal_roles(export_client),
             "catalog_roles": export_command._export_catalog_roles_for_catalog(
                 export_client, "catalog"
             ),
@@ -350,12 +360,17 @@ class TestSetupCommand(CLITestBase):
             principal_properties,
         )
         self.assertEqual(
+            loaded["principal_roles"][0]["properties"],
+            principal_role_properties,
+        )
+        self.assertEqual(
             loaded["catalog_roles"]["catalog-reader"]["properties"],
             catalog_role_properties,
         )
 
         apply_client = self.build_mock_client()
         apply_client.list_principals.return_value = SimpleNamespace(principals=[])
+        apply_client.list_principal_roles.return_value = SimpleNamespace(roles=[])
         apply_client.list_catalog_roles.return_value = SimpleNamespace(roles=[])
         apply_client.create_principal.return_value = SimpleNamespace(
             credentials=SimpleNamespace(
@@ -367,6 +382,10 @@ class TestSetupCommand(CLITestBase):
 
         with patch("sys.stdout", new_callable=io.StringIO):
             apply_command._create_principals(apply_client, loaded["principals"])
+        apply_command._create_principal_roles(
+            apply_client,
+            loaded["principal_roles"],
+        )
         apply_command._create_catalog_roles(
             apply_client,
             "catalog",
@@ -374,10 +393,15 @@ class TestSetupCommand(CLITestBase):
         )
 
         principal_request = apply_client.create_principal.call_args.args[0]
+        principal_role_request = apply_client.create_principal_role.call_args.args[0]
         catalog_role_request = apply_client.create_catalog_role.call_args.args[1]
         self.assertEqual(
             principal_request.principal.properties,
             principal_properties,
+        )
+        self.assertEqual(
+            principal_role_request.principal_role.properties,
+            principal_role_properties,
         )
         self.assertEqual(
             catalog_role_request.catalog_role.properties,
@@ -727,7 +751,8 @@ class TestSetupCommand(CLITestBase):
 
         self.assertEqual(len(exported), 1)
         self.assertEqual(
-            exported[0]["endpoint_internal"], "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com"
+            exported[0]["endpoint_internal"],
+            "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com",
         )
         self.assertEqual(exported[0]["sts_endpoint"], "https://sts.amazonaws.com")
 

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -81,6 +81,21 @@ class TestSetupCommand(CLITestBase):
         self.assertEqual(command._failure_count, 0)
         mock_client.create_principal_role.assert_called_once()
 
+    def test_setup_apply_skips_principal_role_without_name(self) -> None:
+        mock_client = self.build_mock_client()
+        mock_client.list_principal_roles.return_value.roles = []
+        command = SetupCommand(setup_subcommand=Subcommands.APPLY)
+
+        with self.assertLogs(
+            "apache_polaris.cli.command.setup", level="WARNING"
+        ) as logs:
+            command._create_principal_roles(
+                mock_client, [{"properties": {"team": "analytics"}}]
+            )
+
+        mock_client.create_principal_role.assert_not_called()
+        self.assertIn("Skipping principal role with no name", logs.output[0])
+
     @patch("apache_polaris.cli.command.setup.os.path.isfile")
     def test_setup_dry_run_reports_lookup_failures(
         self, mock_isfile: MagicMock
@@ -331,7 +346,7 @@ class TestSetupCommand(CLITestBase):
                 SimpleNamespace(
                     name="analytics-role",
                     properties=principal_role_properties,
-                )
+                ),
             ]
         )
         export_client.list_catalog_roles.return_value = SimpleNamespace(
@@ -765,8 +780,7 @@ class TestSetupCommand(CLITestBase):
 
         self.assertEqual(len(exported), 1)
         self.assertEqual(
-            exported[0]["endpoint_internal"],
-            "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com",
+            exported[0]["endpoint_internal"], "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com"
         )
         self.assertEqual(exported[0]["sts_endpoint"], "https://sts.amazonaws.com")
 

--- a/site/content/guides/assets/polaris/reference-setup-config.yaml
+++ b/site/content/guides/assets/polaris/reference-setup-config.yaml
@@ -51,8 +51,12 @@ principals:
 
 # Principal roles are global roles that group principals.
 principal_roles:
+  # Roles without properties can use the short string form.
   - quickstart_user_role
-  - readonly_user_role
+  # Use the object form to persist optional properties with the role.
+  - name: readonly_user_role
+    properties:
+      owner: security-team
   - dev_user_role
 
 # ==================================

--- a/site/content/in-dev/unreleased/getting-started/setup-tools.md
+++ b/site/content/in-dev/unreleased/getting-started/setup-tools.md
@@ -40,7 +40,7 @@ If you already have an Apache Polaris environment, you can export its current st
 polaris setup export --client-id ${CLIENT_ID} --client-secret ${CLIENT_SECRET} > polaris_bootstrap.yaml
 ```
 
-This generates a readable YAML file containing principals, principal roles, catalogs, and their associated namespaces and catalog roles. User-defined properties on principals and catalog roles are preserved in the exported configuration.
+This generates a readable YAML file containing principals, principal roles, catalogs, and their associated namespaces and catalog roles. User-defined properties on principals, principal roles, and catalog roles are preserved in the exported configuration.
 
 ## Applying a Configuration
 
@@ -61,6 +61,9 @@ principals:
 
 principal_roles:
   - quickstart_user_role
+  - name: analytics_role
+    properties:
+      owner: data-platform
 
 # ==================================
 #     Catalog-Specific Entities
@@ -103,4 +106,3 @@ The current implementation focuses on simplifying initial setup, with a few limi
 - **Non-declarative updates**: The command is create-only. If an entity already exists, it will be skipped rather than updated. There is no state reconciliation yet.
 - **Policy attachment export**: Policy attachments are not included in `setup export` due to performance considerations. However, they can still be defined in YAML and applied during `setup apply`.
 - **External catalog testing**: Support for external catalogs (e.g., Hive Metastore) exists, but full end-to-end testing has not yet been completed. It is recommended to validate configurations in a non-production environment first.
-


### PR DESCRIPTION
## Summary

`polaris setup export` currently serializes principal roles as names only, so applying an exported configuration silently recreates roles without their user-defined properties.

This change:

- exports a principal role as an object with `name` and `properties` when properties are present;
- keeps the existing short string form for roles without properties;
- accepts both forms during `setup apply`, preserving backward compatibility with existing setup files;
- extends the entity-property round-trip regression test, including mixed legacy and object entries, and documents both supported forms.

Fixes #5280

## Validation

- `make client-lint`
- `make client-unit-test` — 184 passed
- `make client-license-check`
- `make client-build` — sdist and wheel built successfully
- `cd site/it && uv run pytest` — 27 passed
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew format compileAll` — BUILD SUCCESSFUL
- Parsed `site/content/guides/assets/polaris/reference-setup-config.yaml` with `yaml.safe_load`
- `git diff --check`

## Checklist

- [x] 🛡️ No security issue is disclosed
- [x] 🔗 The need is explained and the related issue is linked: Fixes #5280
- [x] 🧪 Tests were updated with round-trip and backward-compatibility coverage
- [x] 💡 No comments were added because the compatibility branch follows the existing namespace-entry pattern
- [x] 🧾 Updated `CHANGELOG.md`
- [x] 📚 Updated `site/content/in-dev/unreleased` and the reference setup configuration

## AI assistance

This change was prepared with significant AI assistance. I reviewed the implementation end to end and remain responsible for the contribution.
