### PR TITLE
Return a retryable 409 instead of 500 when a policy update loses a concurrent write

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
@@ -250,12 +250,10 @@ public class PolicyCatalog {
                         newPolicyEntity)
                     .getEntity())
             .map(PolicyEntity::of)
-            .orElse(null);
-
-    if (newPolicyEntity == null) {
-      throw new CommitConflictException(
-          "Concurrent modification on policy '%s'; retry later", policyIdentifier);
-    }
+            .orElseThrow(
+                () ->
+                    new CommitConflictException(
+                        "Concurrent modification on policy '%s'; retry later", policyIdentifier));
 
     return constructPolicy(newPolicyEntity);
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
@@ -45,6 +45,7 @@ import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.PolicyMappingAlreadyExistsException;
@@ -252,8 +253,8 @@ public class PolicyCatalog {
             .orElse(null);
 
     if (newPolicyEntity == null) {
-      throw new IllegalStateException(
-          String.format("Failed to update policy %s", policyIdentifier));
+      throw new CommitConflictException(
+          "Concurrent modification on policy '%s'; retry later", policyIdentifier);
     }
 
     return constructPolicy(newPolicyEntity);

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
@@ -58,9 +58,12 @@ import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PrincipalEntity;
+import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolicyMappingAlreadyExistsException;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.policy.PredefinedPolicyTypes;
@@ -418,6 +421,31 @@ public abstract class AbstractPolicyCatalogTest {
     assertThatThrownBy(
             () -> policyCatalog.updatePolicy(POLICY1, "updated", "{\"enable\": true}", 1))
         .isInstanceOf(PolicyVersionMismatchException.class);
+  }
+
+  @Test
+  public void testUpdatePolicyLosingConcurrentUpdateIsRetryableConflict() {
+    icebergCatalog.createNamespace(NS);
+    policyCatalog.createPolicy(
+        POLICY1, PredefinedPolicyTypes.DATA_COMPACTION.getName(), "test", "{\"enable\": false}");
+
+    // Simulate another writer winning the compare-and-swap on the policy entity.
+    PolarisMetaStoreManager concurrentlyModified = Mockito.spy(metaStoreManager);
+    Mockito.doReturn(
+            new EntityResult(
+                BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED, "simulated"))
+        .when(concurrentlyModified)
+        .updateEntityPropertiesIfNotChanged(Mockito.any(), Mockito.any(), Mockito.any());
+
+    PolicyCatalog catalog =
+        new PolicyCatalog(
+            concurrentlyModified,
+            polarisContext,
+            new PolarisPassthroughResolutionView(
+                resolutionManifestFactory, authenticatedRoot, CATALOG_NAME));
+
+    assertThatThrownBy(() -> catalog.updatePolicy(POLICY1, "updated", "{\"enable\": true}", 0))
+        .isInstanceOf(CommitConflictException.class);
   }
 
   @Test

--- a/spec/generated/bundled-polaris-catalog-service.yaml
+++ b/spec/generated/bundled-polaris-catalog-service.yaml
@@ -1766,7 +1766,7 @@ paths:
                 PolicyToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchPolicyError'
         '409':
-          description: The policy version doesn't match the current-policy-version; retry after fetching latest version
+          description: The policy version doesn't match the current-policy-version, or the policy was concurrently modified; retry after fetching latest version
           content:
             application/json:
               schema:

--- a/spec/polaris-catalog-apis/policy-apis.yaml
+++ b/spec/polaris-catalog-apis/policy-apis.yaml
@@ -195,7 +195,7 @@ paths:
                 PolicyToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchPolicyError'
         409:
-          description: "The policy version doesn't match the current-policy-version; retry after fetching latest version"
+          description: "The policy version doesn't match the current-policy-version, or the policy was concurrently modified; retry after fetching latest version"
           content:
             application/json:
               schema:


### PR DESCRIPTION
`PolicyCatalog.updatePolicy` calls `updateEntityPropertiesIfNotChanged`, which returns no entity when another writer has already modified the policy since it was read. That outcome is currently turned into an `IllegalStateException("Failed to update policy …")`, which reaches the client as `HTTP 500`.
Two clients updating the same policy at the same time is ordinary optimistic-concurrency behaviour rather than a server fault: the losing request is safe to retry, and a `500` tells the client the opposite — that something went wrong server-side and retrying is inadvisable.
It also leaves no way to distinguish a lost race from a genuine failure. Every comparable path in the codebase already treats this as a conflict and throws `CommitConflictException`, which maps to `HTTP 409`: `PolarisAdminService.updateCatalog`, `updatePrincipal` and `updatePrincipalRole` for the same compare-and-swap outcome, and `LocalIcebergCatalog.setProperties` and `removeProperties` for concurrent namespace modification.
This change makes policy updates behave the same way, so a client that loses the race receives a retryable `409` naming the policy.

example ref:
https://github.com/apache/polaris/blob/ffa69775ec832a2e8308e3f75ffbc9b2d556c472/runtime/service/src/main/java/org/apache/polaris/service/admin/PolarisAdminService.java#L1047-L1055

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
