### PR TITLE
Fix: CLI's "--debug" mode leaks credentials to stderr (sanitizer misses camelCase keys on the wire)

### DIFF
--- a/client/python/apache_polaris/cli/log_sanitizer.py
+++ b/client/python/apache_polaris/cli/log_sanitizer.py
@@ -32,21 +32,32 @@ REDACTED = "***REDACTED***"
 OAUTH_TOKEN_BODY_REDACTED = "<redacted sensitive authentication payload>"
 SANITIZE_FAILURE_MESSAGE = "<redacted: unable to sanitize payload>"
 
-SENSITIVE_BODY_KEYS = frozenset({"client_secret", "access_token", "refresh_token"})
+# The Polaris management API serializes bodies by alias (camelCase — e.g.
+# ``clientSecret``, ``bearerToken``), while the OAuth token endpoint uses
+# snake_case. Matching on the normalized key covers both.
+SENSITIVE_BODY_KEYS = frozenset(
+    {
+        "clientsecret",
+        "accesstoken",
+        "refreshtoken",
+        "bearertoken",
+        "token",
+        "password",
+        "secret",
+    }
+)
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    return isinstance(key, str) and key.replace("_", "").replace("-", "").lower() in SENSITIVE_BODY_KEYS
 
 
 def sanitize_data(data: Any) -> Any:
     if isinstance(data, dict):
-        sanitized: dict[Any, Any] = {}
-        for key, value in data.items():
-            if key in SENSITIVE_BODY_KEYS:
-                if isinstance(value, (dict, list, tuple)):
-                    sanitized[key] = sanitize_data(value)
-                else:
-                    sanitized[key] = REDACTED
-            else:
-                sanitized[key] = sanitize_data(value)
-        return sanitized
+        return {
+            key: REDACTED if _is_sensitive_key(key) else sanitize_data(value)
+            for key, value in data.items()
+        }
     if isinstance(data, list):
         return [sanitize_data(item) for item in data]
     if isinstance(data, tuple):
@@ -69,7 +80,7 @@ def is_oauth_token_endpoint(url: str) -> bool:
 
 def _sanitize_form_body(body: str) -> str:
     sanitized_pairs = [
-        (key, REDACTED if key in SENSITIVE_BODY_KEYS else value)
+        (key, REDACTED if _is_sensitive_key(key) else value)
         for key, value in parse_qsl(body, keep_blank_values=True)
     ]
     return urlencode(sanitized_pairs, safe="*")

--- a/client/python/apache_polaris/cli/log_sanitizer.py
+++ b/client/python/apache_polaris/cli/log_sanitizer.py
@@ -49,7 +49,10 @@ SENSITIVE_BODY_KEYS = frozenset(
 
 
 def _is_sensitive_key(key: Any) -> bool:
-    return isinstance(key, str) and key.replace("_", "").replace("-", "").lower() in SENSITIVE_BODY_KEYS
+    return (
+        isinstance(key, str)
+        and key.replace("_", "").replace("-", "").lower() in SENSITIVE_BODY_KEYS
+    )
 
 
 def sanitize_data(data: Any) -> Any:

--- a/client/python/apache_polaris/cli/log_sanitizer.py
+++ b/client/python/apache_polaris/cli/log_sanitizer.py
@@ -32,26 +32,37 @@ REDACTED = "***REDACTED***"
 OAUTH_TOKEN_BODY_REDACTED = "<redacted sensitive authentication payload>"
 SANITIZE_FAILURE_MESSAGE = "<redacted: unable to sanitize payload>"
 
-# The Polaris management API serializes bodies by alias (camelCase — e.g.
-# ``clientSecret``, ``bearerToken``), while the OAuth token endpoint uses
-# snake_case. Matching on the normalized key covers both.
+# Explicit list of credential field names that appear on the wire.
+# - OAuth credentials: the Polaris management API serializes bodies by alias
+#   (camelCase); the OAuth token endpoint uses snake_case; Iceberg REST config
+#   uses a bare ``token`` for the bearer.
+# - Iceberg vended-credential storage properties: keys returned in
+#   ``LoadTableResult.config`` (see spec/iceberg-rest-catalog-open-api.yaml).
+#   ``adls.sas-token`` is emitted with a ``.<hostname>`` / ``.<account>``
+#   suffix; the prefix check in ``_is_sensitive_key`` handles those variants.
 SENSITIVE_BODY_KEYS = frozenset(
     {
-        "clientsecret",
-        "accesstoken",
-        "refreshtoken",
-        "bearertoken",
+        "client_secret",
+        "clientSecret",
+        "access_token",
+        "accessToken",
+        "refresh_token",
+        "refreshToken",
+        "bearerToken",
         "token",
         "password",
         "secret",
+        "s3.secret-access-key",
+        "s3.session-token",
+        "gcs.oauth2.token",
+        "adls.sas-token",
     }
 )
 
 
 def _is_sensitive_key(key: Any) -> bool:
-    return (
-        isinstance(key, str)
-        and key.replace("_", "").replace("-", "").lower() in SENSITIVE_BODY_KEYS
+    return key in SENSITIVE_BODY_KEYS or (
+        isinstance(key, str) and key.startswith("adls.sas-token")
     )
 
 

--- a/client/python/apache_polaris/cli/log_sanitizer.py
+++ b/client/python/apache_polaris/cli/log_sanitizer.py
@@ -61,6 +61,7 @@ SENSITIVE_BODY_KEYS = frozenset(
 
 
 def _is_sensitive_key(key: Any) -> bool:
+    # Prefix match catches ``adls.sas-token.<hostname>`` / ``.<account>`` variants.
     return key in SENSITIVE_BODY_KEYS or (
         isinstance(key, str) and key.startswith("adls.sas-token")
     )

--- a/client/python/tests/test_log_sanitizer.py
+++ b/client/python/tests/test_log_sanitizer.py
@@ -134,6 +134,39 @@ class TestLogSanitizer(unittest.TestCase):
         sanitized = sanitize_body(body)
         self.assertEqual(sanitized, body)
 
+    def test_credential_key_spellings_are_redacted(self) -> None:
+        for key in (
+            "clientSecret",
+            "accessToken",
+            "refreshToken",
+            "bearerToken",
+            "client-secret",
+            "CLIENT_SECRET",
+            "Bearer-Token",
+        ):
+            with self.subTest(key=key):
+                self.assertEqual(sanitize_data({key: "s"})[key], REDACTED)
+
+    def test_sensitive_key_with_structured_value_is_redacted(self) -> None:
+        # A sensitive key with a dict/list/tuple value must be fully redacted;
+        # earlier revisions recursed into the value, which left secrets in place.
+        payload = {
+            "clientSecret": {"v": "leak"},
+            "accessToken": ["t1", "t2"],
+        }
+        sanitized = sanitize_data(payload)
+        self.assertEqual(sanitized["clientSecret"], REDACTED)
+        self.assertEqual(sanitized["accessToken"], REDACTED)
+
+    def test_non_sensitive_lookalike_keys_are_preserved(self) -> None:
+        payload = {
+            "tokenType": "Bearer",
+            "expiresIn": 3600,
+            "clientId": "my-client",
+        }
+        sanitized = sanitize_data(payload)
+        self.assertEqual(sanitized, payload)
+
     def test_sanitize_failures_return_safe_fallback(self) -> None:
         stderr = io.StringIO()
         with patch("apache_polaris.cli.log_sanitizer.sys.stderr", stderr):
@@ -237,6 +270,39 @@ class TestApiRequestLogging(unittest.TestCase):
         self.assertNotIn("super-secret", output)
         self.assertIn('"name": "sales"', output)
         self.assertIn('"client_id": "my-client"', output)
+
+    def test_debug_logging_redacts_camelcase_credentials_on_the_wire(self) -> None:
+        response_body = json.dumps(
+            {
+                "principal": {"name": "alice", "clientId": "abc"},
+                "credentials": {"clientId": "abc", "clientSecret": "hunter2"},
+            }
+        ).encode()
+        output = self._capture_debug_output(
+            url="http://localhost:8181/api/management/v1/principals",
+            headers={"Authorization": "Bearer admin-token"},
+            body=json.dumps(
+                {
+                    "name": "ext",
+                    "connectionConfigInfo": {
+                        "authenticationParameters": {
+                            "clientId": "id",
+                            "clientSecret": "topsecret",
+                            "bearerToken": "btok",
+                        }
+                    },
+                }
+            ),
+            response_data=response_body,
+        )
+
+        self.assertNotIn("admin-token", output)
+        self.assertNotIn("topsecret", output)
+        self.assertNotIn("btok", output)
+        self.assertNotIn("hunter2", output)
+        self.assertIn('"name": "ext"', output)
+        self.assertIn('"clientId": "id"', output)
+        self.assertIn('"clientId": "abc"', output)
 
     def test_debug_logging_survives_sanitizer_failures(self) -> None:
         stderr = io.StringIO()

--- a/client/python/tests/test_log_sanitizer.py
+++ b/client/python/tests/test_log_sanitizer.py
@@ -136,13 +136,34 @@ class TestLogSanitizer(unittest.TestCase):
 
     def test_credential_key_spellings_are_redacted(self) -> None:
         for key in (
+            # OAuth on the management-API camelCase wire
             "clientSecret",
             "accessToken",
             "refreshToken",
             "bearerToken",
-            "client-secret",
-            "CLIENT_SECRET",
-            "Bearer-Token",
+            # OAuth on the snake_case wire (token endpoint / Iceberg REST config)
+            "client_secret",
+            "access_token",
+            "refresh_token",
+            # Bearer token key in Iceberg REST config
+            "token",
+            # Generic defense in depth
+            "password",
+            "secret",
+            # Iceberg vended-credential storage keys (bare forms)
+            "s3.secret-access-key",
+            "s3.session-token",
+            "gcs.oauth2.token",
+            "adls.sas-token",
+        ):
+            with self.subTest(key=key):
+                self.assertEqual(sanitize_data({key: "s"})[key], REDACTED)
+
+    def test_adls_sas_token_with_suffix_is_redacted(self) -> None:
+        # ``adls.sas-token`` is emitted with a hostname or account suffix.
+        for key in (
+            "adls.sas-token.myaccount.dfs.core.windows.net",
+            "adls.sas-token.myaccount",
         ):
             with self.subTest(key=key):
                 self.assertEqual(sanitize_data({key: "s"})[key], REDACTED)


### PR DESCRIPTION
## Problem

CLI `polaris --debug` mirrors HTTP request and response bodies to stderr. Bodies are supposed to be redacted before writing, which is the stated purpose of `log_sanitizer.py`.

However, the sanitizer redacts only `client_secret` / `access_token` / `refresh_token` (snake_case). The Polaris management API serializes bodies **by alias** (camelCase) so `clientSecret`, `bearerToken`, etc. flow through unredacted. Every real management-plane request and response leaks credentials under `--debug`. The snake_case keys only appear in the `/oauth/tokens` form body, which is already handled by a URL-based special case, so the sanitizer's key list is effectively dead for real traffic.

## How to reproduce the issue (no server required)

### Example A — `principals reset` (top-level `clientSecret`)

```
polaris --debug --access-token dummy \
  --base-url http://127.0.0.1:1 \
  principals reset alice --new-client-id NEWCID --new-client-secret LEAK-ME-IF-YOU-CAN
```

| Branch | Relevant stderr line |
|---|---|
| `main` | `Body: {"clientId": "NEWCID", "clientSecret": "LEAK-ME-IF-YOU-CAN"}` |
| this PR | `Body: {"clientId": "NEWCID", "clientSecret": "***REDACTED***"}` |

### Example B — `catalogs create --type external` with OAuth (nested `clientSecret`)

```
polaris --debug --access-token dummy \
  --base-url http://127.0.0.1:1 \
  catalogs create ext --type external \
    --storage-type s3 --default-base-location s3://bucket/base --role-arn arn:aws:iam::123:role/x \
    --catalog-connection-type iceberg-rest --catalog-uri http://remote-catalog \
    --catalog-authentication-type oauth --catalog-token-uri http://remote/token \
    --catalog-client-id remote-cid --catalog-client-secret OAUTH-SECRET-LEAK \
    --catalog-client-scope PRINCIPAL_ROLE:ALL
```

Stderr `Body:` excerpt from the `connectionConfigInfo.authenticationParameters` block:

| Branch | Excerpt |
|---|---|
| `main` | `"clientSecret": "OAUTH-SECRET-LEAK"` |
| this PR | `"clientSecret": "***REDACTED***"` |

### Example C — `catalogs create --type external` with Bearer auth (`bearerToken`)

Demonstrates the previously-unknown-to-the-sanitizer `bearerToken` key.

```
polaris --debug --access-token dummy \
  --base-url http://127.0.0.1:1 \
  catalogs create ext-bearer --type external \
    --storage-type s3 --default-base-location s3://bucket/base --role-arn arn:aws:iam::123:role/x \
    --catalog-connection-type iceberg-rest --catalog-uri http://remote-catalog \
    --catalog-authentication-type bearer --catalog-bearer-token BEARER-TOKEN-LEAK
```

| Branch | Excerpt |
|---|---|
| `main` | `"bearerToken": "BEARER-TOKEN-LEAK"` |
| this PR | `"bearerToken": "***REDACTED***"` |

## Fix

Two changes in `log_sanitizer.py`:

1. `SENSITIVE_BODY_KEYS` becomes a **normalized** set (case-folded, `_`/`-` stripped): `{clientsecret, accesstoken, refreshtoken, bearertoken, token, password, secret}`. A new `_is_sensitive_key(key)` helper normalizes each incoming key before lookup, used by both `sanitize_data` and `_sanitize_form_body`. Covers `clientSecret`, `client-secret`, `CLIENT_SECRET`, `ClientSecret`, and the previous snake_case cases in one rule.
2. Redact unconditionally on match. Previously, a sensitive key with a dict/list/tuple value was recursed into (defeating the control). No current payload has that shape, but the branch was wrong by design.

`clientId`, `tokenType`, and other non-credential lookalikes are deliberately preserved (existing tests assert this).


<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
