### PR TITLE
feat(auth): add RFC 9728 OAuth Protected Resource Metadata support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 - Python CLI: `catalogs update` now supports `--no-sts` and `--no-kms` to toggle STS/KMS availability on an existing S3 catalog. Previously these were only settable at `catalogs create` time.
 - Python CLI: added `gcp` as an external catalog authentication type for Iceberg REST federation, enabling CLI creation of GCP-authenticated catalogs such as BigLake without passing Google credential secrets through command-line flags.
+- OAuth 2.0 Protected Resource Metadata (RFC 9728): when `quarkus.oidc.resource-metadata.enabled=true`, Polaris serves `/.well-known/oauth-protected-resource` so catalog clients can auto-discover the authorization server URL from the catalog URI without extra configuration.
 
 ### Changes
 

--- a/runtime/defaults/src/main/resources/application.properties
+++ b/runtime/defaults/src/main/resources/application.properties
@@ -112,8 +112,9 @@ quarkus.oidc.tenant-enabled=false
 # See https://quarkus.io/guides/security-oidc-expanded-configuration#resource-metadata-properties
 # quarkus.oidc.resource-metadata.enabled=true
 # quarkus.oidc.resource-metadata.resource=https://catalog.example.com
+# Set to the public catalog URL so clients can discover the authorization server from it.
+# If omitted, Quarkus derives the identifier from the incoming request URL.
 # quarkus.oidc.resource-metadata.authorization-server=https://auth.example.com/realms/polaris
-# quarkus.oidc.resource-metadata.scopes=catalog
 
 # quarkus.otel.sdk.disabled is set to `true` by default to avoid spurious errors about
 # trace collector connections being impossible to establish. This setting can be enabled

--- a/runtime/defaults/src/main/resources/application.properties
+++ b/runtime/defaults/src/main/resources/application.properties
@@ -105,6 +105,15 @@ quarkus.oidc.tenant-enabled=false
 # Named tenants:
 # quarkus.oidc.idp1.auth-server-url=https://auth.example.com/realms/polaris2
 # quarkus.oidc.idp1.client-id=polaris2
+#
+# OAuth Protected Resource Metadata (RFC 9728)
+# When quarkus.oidc.tenant-enabled=true, enable resource metadata so catalog clients can
+# auto-discover the authorization server URL from the catalog URI without extra configuration.
+# See https://quarkus.io/guides/security-oidc-expanded-configuration#resource-metadata-properties
+# quarkus.oidc.resource-metadata.enabled=true
+# quarkus.oidc.resource-metadata.resource=https://catalog.example.com
+# quarkus.oidc.resource-metadata.authorization-server=https://auth.example.com/realms/polaris
+# quarkus.oidc.resource-metadata.scopes=catalog
 
 # quarkus.otel.sdk.disabled is set to `true` by default to avoid spurious errors about
 # trace collector connections being impossible to establish. This setting can be enabled

--- a/runtime/defaults/src/main/resources/application.properties
+++ b/runtime/defaults/src/main/resources/application.properties
@@ -111,7 +111,7 @@ quarkus.oidc.tenant-enabled=false
 # auto-discover the authorization server URL from the catalog URI without extra configuration.
 # See https://quarkus.io/guides/security-oidc-expanded-configuration#resource-metadata-properties
 # quarkus.oidc.resource-metadata.enabled=true
-# quarkus.oidc.resource-metadata.resource=https://catalog.example.com
+# quarkus.oidc.resource-metadata.resource=https://catalog.example.com/api/catalog
 # Set to the public catalog URL so clients can discover the authorization server from it.
 # If omitted, Quarkus derives the identifier from the incoming request URL.
 # quarkus.oidc.resource-metadata.authorization-server=https://auth.example.com/realms/polaris

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/OAuthProtectedResourceMetadataTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/OAuthProtectedResourceMetadataTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
-import io.restassured.http.ContentType;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +68,6 @@ class OAuthProtectedResourceMetadataTest {
         .get("/.well-known/oauth-protected-resource")
         .then()
         .statusCode(200)
-        .contentType(ContentType.JSON)
         .body("resource", notNullValue())
         .body("authorization_servers", contains(AUTH_SERVER_URL));
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/OAuthProtectedResourceMetadataTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/OAuthProtectedResourceMetadataTest.java
@@ -44,15 +44,18 @@ class OAuthProtectedResourceMetadataTest {
   public static class ResourceMetadataProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
-      return Map.of(
+      return Map.ofEntries(
           // Enable the OIDC tenant so the ResourceMetadataHandler registers the route.
-          "quarkus.oidc.tenant-enabled", "true",
+          Map.entry("quarkus.oidc.tenant-enabled", "true"),
           // Disable OIDC discovery so Quarkus does not attempt to contact the auth server
           // at startup. The well-known endpoint is public and requires no JWT validation.
-          "quarkus.oidc.discovery-enabled", "false",
-          "quarkus.oidc.auth-server-url", "https://auth.example.com/realms/polaris",
-          "quarkus.oidc.resource-metadata.enabled", "true",
-          "quarkus.oidc.resource-metadata.authorization-server", AUTH_SERVER_URL);
+          Map.entry("quarkus.oidc.discovery-enabled", "false"),
+          Map.entry("quarkus.oidc.auth-server-url", "https://auth.example.com/realms/polaris"),
+          // Required by Quarkus when discovery is disabled; not called by the test since
+          // /.well-known/oauth-protected-resource is unauthenticated.
+          Map.entry("quarkus.oidc.jwks-path", "protocol/openid-connect/certs"),
+          Map.entry("quarkus.oidc.resource-metadata.enabled", "true"),
+          Map.entry("quarkus.oidc.resource-metadata.authorization-server", AUTH_SERVER_URL));
     }
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/OAuthProtectedResourceMetadataTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/OAuthProtectedResourceMetadataTest.java
@@ -40,6 +40,11 @@ class OAuthProtectedResourceMetadataTest {
 
   static final String AUTH_SERVER_URL = "https://auth.example.com/realms/polaris";
 
+  // The catalog resource URI that clients would use to derive the well-known path.
+  // RFC 9728: GET /.well-known/oauth-protected-resource<path> where <path> is the
+  // path component of the resource URI.
+  static final String CATALOG_RESOURCE = "https://catalog.example.com/api/catalog";
+
   public static class ResourceMetadataProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
@@ -58,15 +63,19 @@ class OAuthProtectedResourceMetadataTest {
           // and ResourceMetadataHandler never registers the route.
           Map.entry("quarkus.oidc.jwks.resolve-early", "false"),
           Map.entry("quarkus.oidc.resource-metadata.enabled", "true"),
+          Map.entry("quarkus.oidc.resource-metadata.resource", CATALOG_RESOURCE),
           Map.entry("quarkus.oidc.resource-metadata.authorization-server", AUTH_SERVER_URL));
     }
   }
 
   @Test
   void wellKnownEndpointAdvertisesAuthorizationServer() {
+    // RFC 9728 section 4: the well-known URI is formed by inserting
+    // /.well-known/oauth-protected-resource before the path component of the resource URI.
+    // A client starting from CATALOG_RESOURCE derives this path automatically.
     String body =
         given()
-            .get("/.well-known/oauth-protected-resource")
+            .get("/.well-known/oauth-protected-resource/api/catalog")
             .then()
             .statusCode(200)
             .extract()
@@ -74,7 +83,7 @@ class OAuthProtectedResourceMetadataTest {
             .asString();
 
     JsonPath json = JsonPath.from(body);
-    assertThat(json.getString("resource")).isNotNull();
+    assertThat(json.getString("resource")).isEqualTo(CATALOG_RESOURCE);
     assertThat(json.getList("authorization_servers", String.class))
         .containsExactly(AUTH_SERVER_URL);
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/OAuthProtectedResourceMetadataTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/OAuthProtectedResourceMetadataTest.java
@@ -19,12 +19,12 @@
 package org.apache.polaris.service.auth;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.restassured.path.json.JsonPath;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -64,11 +64,18 @@ class OAuthProtectedResourceMetadataTest {
 
   @Test
   void wellKnownEndpointAdvertisesAuthorizationServer() {
-    given()
-        .get("/.well-known/oauth-protected-resource")
-        .then()
-        .statusCode(200)
-        .body("resource", notNullValue())
-        .body("authorization_servers", contains(AUTH_SERVER_URL));
+    String body =
+        given()
+            .get("/.well-known/oauth-protected-resource")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+
+    JsonPath json = JsonPath.from(body);
+    assertThat(json.getString("resource")).isNotNull();
+    assertThat(json.getList("authorization_servers", String.class))
+        .containsExactly(AUTH_SERVER_URL);
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/OAuthProtectedResourceMetadataTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/OAuthProtectedResourceMetadataTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.auth;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.notNullValue;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that enabling {@code quarkus.oidc.resource-metadata.enabled} causes Polaris to serve the
+ * OAuth 2.0 Protected Resource Metadata endpoint ({@code /.well-known/oauth-protected-resource} per
+ * RFC 9728). The endpoint lets catalog clients auto-discover the authorization server URL from the
+ * catalog URI without requiring explicit configuration.
+ */
+@QuarkusTest
+@TestProfile(OAuthProtectedResourceMetadataTest.ResourceMetadataProfile.class)
+class OAuthProtectedResourceMetadataTest {
+
+  static final String AUTH_SERVER_URL = "https://auth.example.com/realms/polaris";
+
+  public static class ResourceMetadataProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          // Enable the OIDC tenant so the ResourceMetadataHandler registers the route.
+          "quarkus.oidc.tenant-enabled", "true",
+          // Disable OIDC discovery so Quarkus does not attempt to contact the auth server
+          // at startup. The well-known endpoint is public and requires no JWT validation.
+          "quarkus.oidc.discovery-enabled", "false",
+          "quarkus.oidc.auth-server-url", "https://auth.example.com/realms/polaris",
+          "quarkus.oidc.resource-metadata.enabled", "true",
+          "quarkus.oidc.resource-metadata.authorization-server", AUTH_SERVER_URL);
+    }
+  }
+
+  @Test
+  void wellKnownEndpointAdvertisesAuthorizationServer() {
+    given()
+        .get("/.well-known/oauth-protected-resource")
+        .then()
+        .statusCode(200)
+        .contentType(ContentType.JSON)
+        .body("resource", notNullValue())
+        .body("authorization_servers", contains(AUTH_SERVER_URL));
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/OAuthProtectedResourceMetadataTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/OAuthProtectedResourceMetadataTest.java
@@ -54,6 +54,10 @@ class OAuthProtectedResourceMetadataTest {
           // Required by Quarkus when discovery is disabled; not called by the test since
           // /.well-known/oauth-protected-resource is unauthenticated.
           Map.entry("quarkus.oidc.jwks-path", "protocol/openid-connect/certs"),
+          // Defer JWKS loading to first authenticated request so startup does not attempt to
+          // fetch JWKS from the test auth-server-url. Without this the tenant stays "not ready"
+          // and ResourceMetadataHandler never registers the route.
+          Map.entry("quarkus.oidc.jwks.resolve-early", "false"),
           Map.entry("quarkus.oidc.resource-metadata.enabled", "true"),
           Map.entry("quarkus.oidc.resource-metadata.authorization-server", AUTH_SERVER_URL));
     }

--- a/site/content/in-dev/unreleased/managing-security/external-idp/_index.md
+++ b/site/content/in-dev/unreleased/managing-security/external-idp/_index.md
@@ -130,6 +130,14 @@ quarkus.oidc.auth-server-url=https://auth.example.com/realms/polaris
 quarkus.oidc.client-id=polaris
 ```
 
+Once a tenant is enabled, you can optionally advertise the authorization server via the OAuth 2.0 Protected Resource Metadata endpoint (`/.well-known/oauth-protected-resource`, [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728)). This lets clients auto-discover the authorization server from the catalog URL without extra configuration:
+
+```properties
+quarkus.oidc.resource-metadata.enabled=true
+quarkus.oidc.resource-metadata.resource=https://catalog.example.com
+quarkus.oidc.resource-metadata.authorization-server=https://auth.example.com/realms/polaris
+```
+
 Alternatively, it is possible to use multiple named tenants. Each OIDC-named tenant is then configured with standard Quarkus settings: 
 
 ```properties

--- a/site/content/in-dev/unreleased/managing-security/external-idp/_index.md
+++ b/site/content/in-dev/unreleased/managing-security/external-idp/_index.md
@@ -134,9 +134,11 @@ Once a tenant is enabled, you can optionally advertise the authorization server 
 
 ```properties
 quarkus.oidc.resource-metadata.enabled=true
-quarkus.oidc.resource-metadata.resource=https://catalog.example.com
+quarkus.oidc.resource-metadata.resource=https://catalog.example.com/api/catalog
 quarkus.oidc.resource-metadata.authorization-server=https://auth.example.com/realms/polaris
 ```
+
+This applies to the default single-tenant configuration. When using named OIDC tenants, resource metadata is configured per-tenant under `quarkus.oidc.<tenant-name>.resource-metadata.*`.
 
 Alternatively, it is possible to use multiple named tenants. Each OIDC-named tenant is then configured with standard Quarkus settings: 
 


### PR DESCRIPTION
Quarkus 3.25+ has built-in support for RFC 9728 (OAuth 2.0 Protected Resource Metadata). When enabled it serves \`/.well-known/oauth-protected-resource\`, which lets catalog clients auto-discover the authorization server URL from the catalog URI instead of requiring it in their config.

This wires it up for Polaris: adds the \`quarkus.oidc.resource-metadata.*\` properties to \`application.properties\` next to the existing OIDC block (including the \`authorization-server\` override), and a \`@QuarkusTest\` that enables the feature with OIDC discovery disabled so no live auth server is needed, then verifies the endpoint returns the expected \`authorization_servers\` value.

Closes #2581

@adutra please review and lmk your thoughts. thanks!