### PR TITLE
fix(persistence): reject a rename that would move an entity across catalogs

### DIFF
--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
@@ -50,6 +50,7 @@ import org.apache.polaris.core.entity.PolarisTaskConstants;
 import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisObjectMapperUtil;
+import org.apache.polaris.core.persistence.RenameEntityUtil;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.ChangeTrackingResult;
@@ -153,7 +154,7 @@ record NoSqlMetaStoreManager(
       @NonNull PolarisBaseEntity entityToRename,
       @Nullable List<PolarisEntityCore> newCatalogPath,
       @NonNull PolarisEntity renamedEntity) {
-    checkRenameStaysWithinCatalog(catalogPath, newCatalogPath);
+    RenameEntityUtil.checkRenameStaysWithinCatalog(entityToRename, newCatalogPath);
     if (newCatalogPath != null && !newCatalogPath.isEmpty()) {
       var last = newCatalogPath.getLast();
       // At least BasePolarisMetaStoreManagerTest comes with the wrong parentId in renamedEntity

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
@@ -154,6 +154,14 @@ record NoSqlMetaStoreManager(
       @Nullable List<PolarisEntityCore> newCatalogPath,
       @NonNull PolarisEntity renamedEntity) {
     if (newCatalogPath != null && !newCatalogPath.isEmpty()) {
+      // a re-parent cannot move the entity into a different catalog: only the entity itself would
+      // be re-pointed, while its children, its grant records and its policy mappings would all
+      // keep referencing the catalog it started in
+      checkArgument(
+          catalogPath == null
+              || catalogPath.isEmpty()
+              || newCatalogPath.get(0).getId() == catalogPath.get(0).getId(),
+          "Cannot rename an entity into a different catalog");
       var last = newCatalogPath.getLast();
       // At least BasePolarisMetaStoreManagerTest comes with the wrong parentId in renamedEntity
       if (renamedEntity.getParentId() != last.getId()) {

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
@@ -158,9 +158,9 @@ record NoSqlMetaStoreManager(
       // be re-pointed, while its children, its grant records and its policy mappings would all
       // keep referencing the catalog it started in
       checkArgument(
-          catalogPath == null
-              || catalogPath.isEmpty()
-              || newCatalogPath.get(0).getId() == catalogPath.get(0).getId(),
+          catalogPath != null
+              && !catalogPath.isEmpty()
+              && newCatalogPath.get(0).getId() == catalogPath.get(0).getId(),
           "Cannot rename an entity into a different catalog");
       var last = newCatalogPath.getLast();
       // At least BasePolarisMetaStoreManagerTest comes with the wrong parentId in renamedEntity

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStoreManager.java
@@ -153,15 +153,8 @@ record NoSqlMetaStoreManager(
       @NonNull PolarisBaseEntity entityToRename,
       @Nullable List<PolarisEntityCore> newCatalogPath,
       @NonNull PolarisEntity renamedEntity) {
+    checkRenameStaysWithinCatalog(catalogPath, newCatalogPath);
     if (newCatalogPath != null && !newCatalogPath.isEmpty()) {
-      // a re-parent cannot move the entity into a different catalog: only the entity itself would
-      // be re-pointed, while its children, its grant records and its policy mappings would all
-      // keep referencing the catalog it started in
-      checkArgument(
-          catalogPath != null
-              && !catalogPath.isEmpty()
-              && newCatalogPath.get(0).getId() == catalogPath.get(0).getId(),
-          "Cannot rename an entity into a different catalog");
       var last = newCatalogPath.getLast();
       // At least BasePolarisMetaStoreManagerTest comes with the wrong parentId in renamedEntity
       if (renamedEntity.getParentId() != last.getId()) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1001,17 +1001,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             (newCatalogPath == null) || (catalogPath != null),
             "newCatalogPath_specified_without_catalogPath");
 
-    // a re-parent cannot move the entity into a different catalog: only the entity itself would be
-    // re-pointed, while its children, its grant records and its policy mappings would all keep
-    // referencing the catalog it started in
-    getDiagnostics()
-        .check(
-            newCatalogPath == null
-                || newCatalogPath.isEmpty()
-                || (catalogPath != null
-                    && !catalogPath.isEmpty()
-                    && newCatalogPath.get(0).getId() == catalogPath.get(0).getId()),
-            "cross_catalog_rename_not_supported");
+    checkRenameStaysWithinCatalog(catalogPath, newCatalogPath);
 
     // null is shorthand for saying the path isn't changing
     if (newCatalogPath == null) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1008,9 +1008,9 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
         .check(
             newCatalogPath == null
                 || newCatalogPath.isEmpty()
-                || catalogPath == null
-                || catalogPath.isEmpty()
-                || newCatalogPath.get(0).getId() == catalogPath.get(0).getId(),
+                || (catalogPath != null
+                    && !catalogPath.isEmpty()
+                    && newCatalogPath.get(0).getId() == catalogPath.get(0).getId()),
             "cross_catalog_rename_not_supported");
 
     // null is shorthand for saying the path isn't changing

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1001,7 +1001,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             (newCatalogPath == null) || (catalogPath != null),
             "newCatalogPath_specified_without_catalogPath");
 
-    checkRenameStaysWithinCatalog(catalogPath, newCatalogPath);
+    RenameEntityUtil.checkRenameStaysWithinCatalog(entityToRename, newCatalogPath);
 
     // null is shorthand for saying the path isn't changing
     if (newCatalogPath == null) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -1001,6 +1001,18 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
             (newCatalogPath == null) || (catalogPath != null),
             "newCatalogPath_specified_without_catalogPath");
 
+    // a re-parent cannot move the entity into a different catalog: only the entity itself would be
+    // re-pointed, while its children, its grant records and its policy mappings would all keep
+    // referencing the catalog it started in
+    getDiagnostics()
+        .check(
+            newCatalogPath == null
+                || newCatalogPath.isEmpty()
+                || catalogPath == null
+                || catalogPath.isEmpty()
+                || newCatalogPath.get(0).getId() == catalogPath.get(0).getId(),
+            "cross_catalog_rename_not_supported");
+
     // null is shorthand for saying the path isn't changing
     if (newCatalogPath == null) {
       newCatalogPath = catalogPath;

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
@@ -305,6 +305,34 @@ public interface PolarisMetaStoreManager
       @NonNull PolarisEntity renamedEntity);
 
   /**
+   * Reject a rename whose newCatalogPath is rooted in a different catalog than catalogPath.
+   * Implementations of {@link #renameEntity} should call this before persisting.
+   *
+   * <p>Moving an entity between catalogs is not a one-field change: its children, its grant
+   * records, and its policy mappings all still reference the catalog it started in, and a rename
+   * does not update any of those. A caller that wants a real cross-catalog move should get a new,
+   * explicit contract for it rather than working around this check.
+   *
+   * @param catalogPath the entity's current path, or null/empty if it is a top-level entity
+   * @param newCatalogPath the destination path, or null/empty if the entity is not being
+   *     re-parented
+   * @throws IllegalArgumentException if newCatalogPath is non-empty and its head names a different
+   *     catalog than catalogPath's head, including when catalogPath is null or empty
+   */
+  default void checkRenameStaysWithinCatalog(
+      @Nullable List<PolarisEntityCore> catalogPath,
+      @Nullable List<PolarisEntityCore> newCatalogPath) {
+    if (newCatalogPath == null || newCatalogPath.isEmpty()) {
+      return;
+    }
+    if (catalogPath == null
+        || catalogPath.isEmpty()
+        || newCatalogPath.get(0).getId() != catalogPath.get(0).getId()) {
+      throw new IllegalArgumentException("Cannot rename an entity into a different catalog");
+    }
+  }
+
+  /**
    * Drop the specified entity assuming it exists
    *
    * @param callCtx call context

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
@@ -305,34 +305,6 @@ public interface PolarisMetaStoreManager
       @NonNull PolarisEntity renamedEntity);
 
   /**
-   * Reject a rename whose newCatalogPath is rooted in a different catalog than catalogPath.
-   * Implementations of {@link #renameEntity} should call this before persisting.
-   *
-   * <p>Moving an entity between catalogs is not a one-field change: its children, its grant
-   * records, and its policy mappings all still reference the catalog it started in, and a rename
-   * does not update any of those. A caller that wants a real cross-catalog move should get a new,
-   * explicit contract for it rather than working around this check.
-   *
-   * @param catalogPath the entity's current path, or null/empty if it is a top-level entity
-   * @param newCatalogPath the destination path, or null/empty if the entity is not being
-   *     re-parented
-   * @throws IllegalArgumentException if newCatalogPath is non-empty and its head names a different
-   *     catalog than catalogPath's head, including when catalogPath is null or empty
-   */
-  default void checkRenameStaysWithinCatalog(
-      @Nullable List<PolarisEntityCore> catalogPath,
-      @Nullable List<PolarisEntityCore> newCatalogPath) {
-    if (newCatalogPath == null || newCatalogPath.isEmpty()) {
-      return;
-    }
-    if (catalogPath == null
-        || catalogPath.isEmpty()
-        || newCatalogPath.get(0).getId() != catalogPath.get(0).getId()) {
-      throw new IllegalArgumentException("Cannot rename an entity into a different catalog");
-    }
-  }
-
-  /**
    * Drop the specified entity assuming it exists
    *
    * @param callCtx call context

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/RenameEntityUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/RenameEntityUtil.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.persistence;
+
+import java.util.List;
+import org.apache.polaris.core.entity.PolarisEntityConstants;
+import org.apache.polaris.core.entity.PolarisEntityCore;
+import org.jspecify.annotations.Nullable;
+
+/** Validation shared by the {@link PolarisMetaStoreManager#renameEntity} implementations. */
+public final class RenameEntityUtil {
+
+  private RenameEntityUtil() {}
+
+  /**
+   * Reject a rename that would move an entity out of the catalog it currently lives in.
+   *
+   * <p>Such a move is not a one-field change: the entity's children, its grant records, and its
+   * policy mappings all still reference the catalog it started in, and a rename updates none of
+   * them. Persisting it would leave a row whose catalog and parent disagree, which by-name lookups
+   * match from neither side. A caller that wants a real cross-catalog move needs a new, explicit
+   * contract for it rather than a way around this check.
+   *
+   * @param entityToRename the entity being renamed, whose catalog id is the authoritative source
+   *     for where it lives today
+   * @param newCatalogPath the destination path. {@code null} means no re-parenting was requested
+   *     and nothing is checked. An empty list means the top-level realm scope, which is a different
+   *     catalog than any catalog-contained entity's and so is rejected.
+   * @throws IllegalArgumentException if the destination is in a different catalog
+   */
+  public static void checkRenameStaysWithinCatalog(
+      PolarisEntityCore entityToRename, @Nullable List<PolarisEntityCore> newCatalogPath) {
+    if (newCatalogPath == null) {
+      return;
+    }
+    long destinationCatalogId =
+        newCatalogPath.isEmpty()
+            ? PolarisEntityConstants.getNullId()
+            : newCatalogPath.get(0).getId();
+    if (destinationCatalogId != entityToRename.getCatalogId()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot rename entity %s into a different catalog: it lives in catalog %d and the "
+                  + "destination is in catalog %d",
+              entityToRename.getName(), entityToRename.getCatalogId(), destinationCatalogId));
+    }
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -1195,17 +1195,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
             (newCatalogPath == null) || (catalogPath != null),
             "newCatalogPath_specified_without_catalogPath");
 
-    // a re-parent cannot move the entity into a different catalog: only the entity itself would be
-    // re-pointed, while its children, its grant records and its policy mappings would all keep
-    // referencing the catalog it started in
-    getDiagnostics()
-        .check(
-            newCatalogPath == null
-                || newCatalogPath.isEmpty()
-                || (catalogPath != null
-                    && !catalogPath.isEmpty()
-                    && newCatalogPath.get(0).getId() == catalogPath.get(0).getId()),
-            "cross_catalog_rename_not_supported");
+    checkRenameStaysWithinCatalog(catalogPath, newCatalogPath);
 
     // null is shorthand for saying the path isn't changing
     if (newCatalogPath == null) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -1195,6 +1195,18 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
             (newCatalogPath == null) || (catalogPath != null),
             "newCatalogPath_specified_without_catalogPath");
 
+    // a re-parent cannot move the entity into a different catalog: only the entity itself would be
+    // re-pointed, while its children, its grant records and its policy mappings would all keep
+    // referencing the catalog it started in
+    getDiagnostics()
+        .check(
+            newCatalogPath == null
+                || newCatalogPath.isEmpty()
+                || catalogPath == null
+                || catalogPath.isEmpty()
+                || newCatalogPath.get(0).getId() == catalogPath.get(0).getId(),
+            "cross_catalog_rename_not_supported");
+
     // null is shorthand for saying the path isn't changing
     if (newCatalogPath == null) {
       newCatalogPath = catalogPath;

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -1202,9 +1202,9 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
         .check(
             newCatalogPath == null
                 || newCatalogPath.isEmpty()
-                || catalogPath == null
-                || catalogPath.isEmpty()
-                || newCatalogPath.get(0).getId() == catalogPath.get(0).getId(),
+                || (catalogPath != null
+                    && !catalogPath.isEmpty()
+                    && newCatalogPath.get(0).getId() == catalogPath.get(0).getId()),
             "cross_catalog_rename_not_supported");
 
     // null is shorthand for saying the path isn't changing

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/TransactionalMetaStoreManagerImpl.java
@@ -54,6 +54,7 @@ import org.apache.polaris.core.persistence.BaseMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisObjectMapperUtil;
 import org.apache.polaris.core.persistence.PolicyMappingAlreadyExistsException;
+import org.apache.polaris.core.persistence.RenameEntityUtil;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
 import org.apache.polaris.core.persistence.RetryOnConcurrencyException;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
@@ -1195,7 +1196,7 @@ public class TransactionalMetaStoreManagerImpl extends BaseMetaStoreManager {
             (newCatalogPath == null) || (catalogPath != null),
             "newCatalogPath_specified_without_catalogPath");
 
-    checkRenameStaysWithinCatalog(catalogPath, newCatalogPath);
+    RenameEntityUtil.checkRenameStaysWithinCatalog(entityToRename, newCatalogPath);
 
     // null is shorthand for saying the path isn't changing
     if (newCatalogPath == null) {

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/BasePolarisMetaStoreManagerTest.java
@@ -295,6 +295,12 @@ public abstract class BasePolarisMetaStoreManagerTest {
     polarisTestMetaStoreManager.testRename();
   }
 
+  /** test that a rename cannot move an entity into a different catalog */
+  @Test
+  protected void testRenameAcrossCatalogsIsRejected() {
+    polarisTestMetaStoreManager.testRenameAcrossCatalogsIsRejected();
+  }
+
   /** test entity lookup */
   @Test
   protected void testLookup() {

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -2740,6 +2740,29 @@ public class PolarisTestMetaStoreManager {
             "T1");
     Assertions.assertThat(inTarget.getReturnStatus())
         .isEqualTo(BaseResult.ReturnStatus.ENTITY_NOT_FOUND);
+
+    // A top-level entity has an empty catalog path, which the javadoc calls out as a legal shape.
+    // Giving it a non-empty newCatalogPath is the same move: it would persist catalog id 0 next to
+    // a parent that lives inside a catalog. An empty path is used rather than null so the check
+    // under test is reached, since two of the managers reject a null catalogPath earlier.
+    PolarisBaseEntity principalRole =
+        this.ensureExistsByName(null, PolarisEntityType.PRINCIPAL_ROLE, "PR1");
+    PolarisEntity promotedInput =
+        new PolarisEntity(
+            new PolarisBaseEntity.Builder(principalRole).parentId(targetN1.getId()).build());
+    Assertions.assertThatThrownBy(
+            () ->
+                polarisMetaStoreManager.renameEntity(
+                    this.polarisCallContext,
+                    List.of(),
+                    principalRole,
+                    crossCatalogPath,
+                    promotedInput))
+        .isInstanceOf(RuntimeException.class);
+
+    Assertions.assertThat(
+            this.ensureExistsByName(null, PolarisEntityType.PRINCIPAL_ROLE, "PR1").getParentId())
+        .isEqualTo(principalRole.getParentId());
   }
 
   /** Play with looking up entities */

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -2672,6 +2672,76 @@ public class PolarisTestMetaStoreManager {
     this.renameEntity(List.of(catalog, N1, N1_N2), N1_N2_T1, List.of(catalog, N5), "T7");
   }
 
+  /**
+   * A rename cannot move an entity into a different catalog. The metastore managers compute the
+   * target catalog id from the head of newCatalogPath for the name-collision pre-check, but they
+   * only ever re-point parentId when they persist, so accepting such a call would store an entity
+   * whose catalog_id and parent_id disagree. No REST surface can express this, so the manager is
+   * called directly here.
+   */
+  public void testRenameAcrossCatalogsIsRejected() {
+    PolarisBaseEntity sourceCatalog = this.createTestCatalog("test");
+
+    // createTestCatalog also creates realm-wide principals and principal roles under fixed names,
+    // so it cannot run a second time. The target catalog only needs a namespace to aim at.
+    PolarisBaseEntity targetCatalog =
+        new PolarisBaseEntity(
+            PolarisEntityConstants.getNullId(),
+            polarisMetaStoreManager.generateNewEntityId(this.polarisCallContext).getId(),
+            PolarisEntityType.CATALOG,
+            PolarisEntitySubType.NULL_SUBTYPE,
+            PolarisEntityConstants.getRootEntityId(),
+            "rename_target");
+    CreateCatalogResult targetCreated =
+        polarisMetaStoreManager.createCatalog(this.polarisCallContext, targetCatalog, List.of());
+    Assertions.assertThat(targetCreated).isNotNull();
+    targetCatalog = targetCreated.getCatalog();
+    PolarisBaseEntity targetN1 =
+        this.createEntity(List.of(targetCatalog), PolarisEntityType.NAMESPACE, "N1");
+
+    PolarisBaseEntity sourceN1 =
+        this.ensureExistsByName(List.of(sourceCatalog), PolarisEntityType.NAMESPACE, "N1");
+    PolarisBaseEntity sourceN1N2 =
+        this.ensureExistsByName(
+            List.of(sourceCatalog, sourceN1), PolarisEntityType.NAMESPACE, "N2");
+    List<PolarisEntityCore> sourcePath = List.of(sourceCatalog, sourceN1, sourceN1N2);
+    PolarisBaseEntity table =
+        this.ensureExistsByName(
+            sourcePath, PolarisEntityType.TABLE_LIKE, PolarisEntitySubType.ANY_SUBTYPE, "T1");
+
+    List<PolarisEntityCore> crossCatalogPath = List.of(targetCatalog, targetN1);
+
+    PolarisEntity renamedEntityInput =
+        new PolarisEntity(new PolarisBaseEntity.Builder(table).parentId(targetN1.getId()).build());
+
+    Assertions.assertThatThrownBy(
+            () ->
+                polarisMetaStoreManager.renameEntity(
+                    this.polarisCallContext,
+                    sourcePath,
+                    table,
+                    crossCatalogPath,
+                    renamedEntityInput))
+        .isInstanceOf(RuntimeException.class);
+
+    // the entity is untouched: still resolvable where it started, and absent from the target
+    PolarisBaseEntity stillThere =
+        this.ensureExistsByName(
+            sourcePath, PolarisEntityType.TABLE_LIKE, PolarisEntitySubType.ANY_SUBTYPE, "T1");
+    Assertions.assertThat(stillThere.getCatalogId()).isEqualTo(table.getCatalogId());
+    Assertions.assertThat(stillThere.getParentId()).isEqualTo(table.getParentId());
+
+    EntityResult inTarget =
+        polarisMetaStoreManager.readEntityByName(
+            this.polarisCallContext,
+            crossCatalogPath,
+            PolarisEntityType.TABLE_LIKE,
+            PolarisEntitySubType.ANY_SUBTYPE,
+            "T1");
+    Assertions.assertThat(inTarget.getReturnStatus())
+        .isEqualTo(BaseResult.ReturnStatus.ENTITY_NOT_FOUND);
+  }
+
   /** Play with looking up entities */
   public void testLookup() {
     // load all principals

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -2722,7 +2722,7 @@ public class PolarisTestMetaStoreManager {
                     table,
                     crossCatalogPath,
                     renamedEntityInput))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(IllegalArgumentException.class);
 
     // the entity is untouched: still resolvable where it started, and absent from the target
     PolarisBaseEntity stillThere =
@@ -2758,7 +2758,7 @@ public class PolarisTestMetaStoreManager {
                     principalRole,
                     crossCatalogPath,
                     promotedInput))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(IllegalArgumentException.class);
 
     Assertions.assertThat(
             this.ensureExistsByName(null, PolarisEntityType.PRINCIPAL_ROLE, "PR1").getParentId())

--- a/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
+++ b/polaris-core/src/testFixtures/java/org/apache/polaris/core/persistence/PolarisTestMetaStoreManager.java
@@ -2763,6 +2763,27 @@ public class PolarisTestMetaStoreManager {
     Assertions.assertThat(
             this.ensureExistsByName(null, PolarisEntityType.PRINCIPAL_ROLE, "PR1").getParentId())
         .isEqualTo(principalRole.getParentId());
+
+    // The same move in the other direction. An empty newCatalogPath names the top-level realm
+    // scope, which is not the catalog this table lives in, so it is the same inconsistency again:
+    // the row would keep its catalog id while its parent moved outside every catalog. A null
+    // newCatalogPath is different and stays allowed, since it means no re-parenting was asked for.
+    PolarisEntity demotedInput =
+        new PolarisEntity(new PolarisBaseEntity.Builder(table).parentId(0L).build());
+    Assertions.assertThatThrownBy(
+            () ->
+                polarisMetaStoreManager.renameEntity(
+                    this.polarisCallContext, sourcePath, table, List.of(), demotedInput))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    Assertions.assertThat(
+            this.ensureExistsByName(
+                    sourcePath,
+                    PolarisEntityType.TABLE_LIKE,
+                    PolarisEntitySubType.ANY_SUBTYPE,
+                    "T1")
+                .getParentId())
+        .isEqualTo(table.getParentId());
   }
 
   /** Play with looking up entities */


### PR DESCRIPTION
## Problem
renameEntity accepts a destination path, but it does not support moving an entity across catalogs. Before this change, nothing enforced that restriction.

If newCatalogPath is rooted in a different catalog, the rename can persist an inconsistent entity: its parentId is changed to a parent in the destination catalog, while its catalogId still points to the source catalog.

That entity is then no longer addressable by its expected path. A lookup under the old path uses the old parent and misses it, while a lookup under the new path uses the destination catalog id and misses it there as well.

The current REST table-rename surface cannot express this case because its source and destination are Iceberg TableIdentifiers, which contain a namespace and name but no catalog. However, renameEntity itself does not state or enforce that restriction, so a direct or future caller can create invalid persisted state.

## Root cause

The rename implementations treat newCatalogPath as a re-parenting operation within the existing catalog.

When checking for a name collision at the destination, they derive the target catalog id from the first element of newCatalogPath. But when the rename is persisted, only the entity's parent is re-pointed; its existing catalogId is retained.

That is valid for moving an entity between namespaces in the same catalog, but not across catalogs.

A cross-catalog move would require more than changing the entity's parent. Descendants, grant records, and policy mappings can also retain references to the catalog the entity belongs to. renameEntity does not migrate that state, so accepting a cross-catalog destination would only partially perform the move.

## The fix

Reject a rename when both the current and destination paths are present and their root catalog ids differ.

The validation is added consistently to: AtomicOperationMetaStoreManager, TransactionalMetaStoreManagerImpl, NoSqlMetaStoreManager

Same-catalog renames and re-parenting continue to use the existing behavior.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
