### PR TITLE
Reject unknown policyType filter values in the Policy API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Internal JWTs are bound to principal secret generation via `polaris-cv` (no secret material in the
   token). Credential-generation is enforced on token exchange; bearer verify is signature and claims
   only. Secrets-load failures during exchange return service unavailable.
-
+- The Policy API now rejects an unknown `policyType` query parameter on `listPolicies` and `getApplicablePolicies` with HTTP 400. Previously an unrecognized value (for example a misspelled `system.data-compaction`) was silently treated as "no filter", so the request returned policies of every type with HTTP 200, and clients could not tell a filtered result from an unfiltered one. An absent or empty `policyType` still means "no filter", as the API specification allows.
 
 ### Commits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Internal JWTs are bound to principal secret generation via `polaris-cv` (no secret material in the
   token). Credential-generation is enforced on token exchange; bearer verify is signature and claims
   only. Secrets-load failures during exchange return service unavailable.
-- The Policy API now rejects an unknown `policyType` query parameter on `listPolicies` and `getApplicablePolicies` with HTTP 400. Previously an unrecognized value (for example a misspelled `system.data-compaction`) was silently treated as "no filter", so the request returned policies of every type with HTTP 200, and clients could not tell a filtered result from an unfiltered one. An absent or empty `policyType` still means "no filter", as the API specification allows.
+- The Policy API now rejects an unknown `policyType` query parameter on `listPolicies` and `getApplicablePolicies` with HTTP 400. Previously an unrecognized value (for example `system.data_compaction`, misspelling `system.data-compaction` with an underscore) was silently treated as "no filter", so the request returned policies of every type with HTTP 200, and clients could not tell a filtered result from an unfiltered one. An absent or empty `policyType` still means "no filter", as the API specification allows.
 
 ### Commits
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
@@ -112,6 +112,7 @@ public class PolarisPolicyServiceIntegrationTest {
   private static final String NS1_NAME = NS1.level(0);
   private static final String INVALID_NAMESPACE = "INVALID_NAMESPACE";
   private static final String INVALID_POLICY = "INVALID_POLICY";
+  private static final String INVALID_POLICY_TYPE = "system.no-such-policy-type";
   private static final String INVALID_TABLE = "INVALID_TABLE";
   private static final String INVALID_NAMESPACE_MSG =
       "Namespace does not exist: " + INVALID_NAMESPACE;
@@ -565,6 +566,56 @@ public class PolarisPolicyServiceIntegrationTest {
 
     policyApi.dropPolicy(currentCatalogName, NS1_P1);
     policyApi.dropPolicy(currentCatalogName, NS1_P2);
+  }
+
+  @Test
+  public void testListPoliciesWithUnknownPolicyType() {
+    restCatalog.createNamespace(NS1);
+    policyApi.createPolicy(
+        currentCatalogName,
+        NS1_P1,
+        PredefinedPolicyTypes.DATA_COMPACTION,
+        EXAMPLE_TABLE_MAINTENANCE_POLICY_CONTENT,
+        "test policy");
+
+    // An unknown policy type must be rejected instead of being silently dropped, which would
+    // return every policy in the namespace as if the filter had matched them.
+    try (Response res =
+        policyApi
+            .request(
+                "polaris/v1/{cat}/namespaces/{ns}/policies",
+                Map.of("cat", currentCatalogName, "ns", NS1_NAME),
+                Map.of("policyType", INVALID_POLICY_TYPE))
+            .get()) {
+      Assertions.assertThat(res.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+      Assertions.assertThat(res.readEntity(String.class)).contains(INVALID_POLICY_TYPE);
+    }
+
+    policyApi.dropPolicy(currentCatalogName, NS1_P1);
+  }
+
+  @Test
+  public void testGetApplicablePoliciesWithUnknownPolicyType() {
+    restCatalog.createNamespace(NS1);
+    policyApi.createPolicy(
+        currentCatalogName,
+        NS1_P1,
+        PredefinedPolicyTypes.DATA_COMPACTION,
+        EXAMPLE_TABLE_MAINTENANCE_POLICY_CONTENT,
+        "test policy");
+
+    try (Response res =
+        policyApi
+            .request(
+                "polaris/v1/{cat}/applicable-policies",
+                Map.of("cat", currentCatalogName),
+                Map.of("namespace", NS1_NAME, "policyType", INVALID_POLICY_TYPE))
+            .get()) {
+      Assertions.assertThat(res.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+      Assertions.assertThat(res.readEntity(String.class)).contains(INVALID_POLICY_TYPE);
+    }
+
+    policyApi.dropPolicy(currentCatalogName, NS1_P1);
   }
 
   @Test

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisPolicyServiceIntegrationTest.java
@@ -571,51 +571,68 @@ public class PolarisPolicyServiceIntegrationTest {
   @Test
   public void testListPoliciesWithUnknownPolicyType() {
     restCatalog.createNamespace(NS1);
-    policyApi.createPolicy(
-        currentCatalogName,
-        NS1_P1,
-        PredefinedPolicyTypes.DATA_COMPACTION,
-        EXAMPLE_TABLE_MAINTENANCE_POLICY_CONTENT,
-        "test policy");
+    try {
+      policyApi.createPolicy(
+          currentCatalogName,
+          NS1_P1,
+          PredefinedPolicyTypes.DATA_COMPACTION,
+          EXAMPLE_TABLE_MAINTENANCE_POLICY_CONTENT,
+          "test policy");
 
-    // An unknown policy type must be rejected instead of being silently dropped, which would
-    // return every policy in the namespace as if the filter had matched them.
-    try (Response res =
-        policyApi
-            .request(
-                "polaris/v1/{cat}/namespaces/{ns}/policies",
-                Map.of("cat", currentCatalogName, "ns", NS1_NAME),
-                Map.of("policyType", INVALID_POLICY_TYPE))
-            .get()) {
-      Assertions.assertThat(res.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
-      Assertions.assertThat(res.readEntity(String.class)).contains(INVALID_POLICY_TYPE);
+      // An unknown policy type must be rejected instead of being silently dropped, which would
+      // return every policy in the namespace as if the filter had matched them.
+      try (Response res =
+          policyApi
+              .request(
+                  "polaris/v1/{cat}/namespaces/{ns}/policies",
+                  Map.of("cat", currentCatalogName, "ns", NS1_NAME),
+                  Map.of("policyType", INVALID_POLICY_TYPE))
+              .get()) {
+        Assertions.assertThat(res.getStatus())
+            .isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        Assertions.assertThat(res.readEntity(String.class)).contains(INVALID_POLICY_TYPE);
+      }
+    } finally {
+      policyApi.purge(currentCatalogName, NS1);
     }
-
-    policyApi.dropPolicy(currentCatalogName, NS1_P1);
   }
 
   @Test
   public void testGetApplicablePoliciesWithUnknownPolicyType() {
     restCatalog.createNamespace(NS1);
-    policyApi.createPolicy(
-        currentCatalogName,
-        NS1_P1,
-        PredefinedPolicyTypes.DATA_COMPACTION,
-        EXAMPLE_TABLE_MAINTENANCE_POLICY_CONTENT,
-        "test policy");
+    try {
+      policyApi.createPolicy(
+          currentCatalogName,
+          NS1_P1,
+          PredefinedPolicyTypes.DATA_COMPACTION,
+          EXAMPLE_TABLE_MAINTENANCE_POLICY_CONTENT,
+          "test policy");
+      // Attach the policy so that it is applicable to the namespace. Without this the endpoint
+      // returns an empty list regardless of the filter, and the test could not tell a rejected
+      // request from one that matched nothing.
+      PolicyAttachmentTarget namespaceTarget =
+          PolicyAttachmentTarget.builder()
+              .setType(PolicyAttachmentTarget.TypeEnum.NAMESPACE)
+              .setPath(Arrays.asList(NS1.levels()))
+              .build();
+      policyApi.attachPolicy(currentCatalogName, NS1_P1, namespaceTarget, Map.of());
 
-    try (Response res =
-        policyApi
-            .request(
-                "polaris/v1/{cat}/applicable-policies",
-                Map.of("cat", currentCatalogName),
-                Map.of("namespace", NS1_NAME, "policyType", INVALID_POLICY_TYPE))
-            .get()) {
-      Assertions.assertThat(res.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
-      Assertions.assertThat(res.readEntity(String.class)).contains(INVALID_POLICY_TYPE);
+      try (Response res =
+          policyApi
+              .request(
+                  "polaris/v1/{cat}/applicable-policies",
+                  Map.of("cat", currentCatalogName),
+                  Map.of("namespace", NS1_NAME, "policyType", INVALID_POLICY_TYPE))
+              .get()) {
+        Assertions.assertThat(res.getStatus())
+            .isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        Assertions.assertThat(res.readEntity(String.class)).contains(INVALID_POLICY_TYPE);
+      }
+    } finally {
+      // The policy is attached, so purge cannot remove it: purge drops without detach-all and the
+      // policy comes back as in-use. Drop it with detach-all, as the attach tests above do.
+      policyApi.dropPolicy(currentCatalogName, NS1_P1, true);
     }
-
-    policyApi.dropPolicy(currentCatalogName, NS1_P1);
   }
 
   @Test

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
@@ -38,7 +38,6 @@ import java.util.stream.Stream;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
-import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.polaris.core.context.CallContext;
 import org.apache.polaris.core.entity.CatalogEntity;
 import org.apache.polaris.core.entity.PolarisEntity;
@@ -116,10 +115,7 @@ public class PolicyCatalog {
       throw new AlreadyExistsException("Policy already exists %s", policyIdentifier);
     }
 
-    PolicyType policyType = PolicyType.fromName(type);
-    if (policyType == null) {
-      throw new BadRequestException("Unknown policy type: %s", type);
-    }
+    PolicyType policyType = PolicyCatalogUtils.resolveRequiredPolicyType(type);
 
     entity =
         new PolicyEntity.Builder(policyIdentifier.namespace(), policyIdentifier.name(), policyType)

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogAdapter.java
@@ -92,7 +92,7 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
       SecurityContext securityContext) {
     Namespace ns =
         NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR);
-    PolicyType type = policyType != null ? PolicyType.fromName(policyType) : null;
+    PolicyType type = PolicyCatalogUtils.resolvePolicyTypeFilter(policyType);
     PolicyCatalogHandler handler = newHandler(securityContext, prefix);
     ListPoliciesResponse response = handler.listPolicies(ns, type);
     return Response.ok(response).build();
@@ -191,7 +191,7 @@ public class PolicyCatalogAdapter implements PolarisCatalogPolicyApiService, Cat
         namespace != null
             ? NamespaceUtils.splitNamespace(namespace, NamespaceUtils.DEFAULT_NAMESPACE_SEPARATOR)
             : null;
-    PolicyType type = policyType != null ? PolicyType.fromName(policyType) : null;
+    PolicyType type = PolicyCatalogUtils.resolvePolicyTypeFilter(policyType);
     PolicyCatalogHandler handler = newHandler(securityContext, prefix);
     GetApplicablePoliciesResponse response = handler.getApplicablePolicies(ns, targetName, type);
     return Response.ok(response).build();

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtils.java
@@ -21,6 +21,8 @@ package org.apache.polaris.service.catalog.policy;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.noSuchNamespaceException;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.notFoundExceptionForTableLikeEntity;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.BadRequestException;
@@ -29,11 +31,22 @@ import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifestCatalogView;
 import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
 import org.apache.polaris.core.policy.PolicyType;
+import org.apache.polaris.core.policy.PredefinedPolicyTypes;
 import org.apache.polaris.service.types.PolicyAttachmentTarget;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 public class PolicyCatalogUtils {
+
+  /**
+   * The accepted {@code policyType} names, listed in rejection messages. Derived from the same
+   * registry {@link PolicyType#fromName(String)} resolves against, so the message cannot advertise
+   * a set that differs from the one actually accepted.
+   */
+  private static final String KNOWN_POLICY_TYPE_NAMES =
+      Arrays.stream(PredefinedPolicyTypes.values())
+          .map(PolicyType::getName)
+          .collect(Collectors.joining(", "));
 
   /**
    * Resolves the optional {@code policyType} query parameter of the policy listing APIs into a
@@ -54,7 +67,8 @@ public class PolicyCatalogUtils {
     }
     PolicyType resolved = PolicyType.fromName(policyType);
     if (resolved == null) {
-      throw new BadRequestException("Unknown policy type: %s", policyType);
+      throw new BadRequestException(
+          "Unknown policy type: '%s'. Valid values are: %s", policyType, KNOWN_POLICY_TYPE_NAMES);
     }
     return resolved;
   }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtils.java
@@ -23,14 +23,41 @@ import static org.apache.polaris.service.catalog.common.ExceptionUtils.notFoundE
 
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifestCatalogView;
 import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
+import org.apache.polaris.core.policy.PolicyType;
 import org.apache.polaris.service.types.PolicyAttachmentTarget;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public class PolicyCatalogUtils {
+
+  /**
+   * Resolves the optional {@code policyType} query parameter of the policy listing APIs into a
+   * {@link PolicyType} filter.
+   *
+   * <p>The parameter is declared with {@code allowEmptyValue: true}, so both {@code null} and the
+   * empty string mean "do not filter". Any other value must name a known policy type: an unknown
+   * name is rejected rather than silently treated as "no filter", which would return policies of
+   * every type and make a typo look like a successful, but wrong, filtered listing.
+   *
+   * @param policyType the raw {@code policyType} query parameter, may be {@code null} or empty
+   * @return the resolved policy type, or {@code null} if no filter was requested
+   * @throws BadRequestException if a non-empty value does not name a known policy type
+   */
+  public static @Nullable PolicyType resolvePolicyTypeFilter(@Nullable String policyType) {
+    if (policyType == null || policyType.isEmpty()) {
+      return null;
+    }
+    PolicyType resolved = PolicyType.fromName(policyType);
+    if (resolved == null) {
+      throw new BadRequestException("Unknown policy type: %s", policyType);
+    }
+    return resolved;
+  }
 
   public static PolarisResolvedPathWrapper getResolvedPathWrapper(
       @NonNull PolarisResolutionManifestCatalogView resolutionManifest,

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtils.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtils.java
@@ -39,14 +39,30 @@ import org.jspecify.annotations.Nullable;
 public class PolicyCatalogUtils {
 
   /**
-   * The accepted {@code policyType} names, listed in rejection messages. Derived from the same
-   * registry {@link PolicyType#fromName(String)} resolves against, so the message cannot advertise
-   * a set that differs from the one actually accepted.
+   * The single point at which a client-supplied policy type name is turned into a {@link
+   * PolicyType}. Both the lookup and the list of names quoted back on rejection live here, so the
+   * message cannot advertise a set that differs from the one actually accepted.
+   *
+   * <p>{@link PolicyType#fromName(String)} resolves against the predefined types today, but its
+   * contract allows it to resolve registered custom types later. When that happens, only this
+   * method needs to learn about them.
+   *
+   * @param policyType a non-null, non-empty policy type name
+   * @return the resolved policy type
+   * @throws BadRequestException if the value does not name a known policy type
    */
-  private static final String KNOWN_POLICY_TYPE_NAMES =
-      Arrays.stream(PredefinedPolicyTypes.values())
-          .map(PolicyType::getName)
-          .collect(Collectors.joining(", "));
+  private static PolicyType lookUpPolicyType(String policyType) {
+    PolicyType resolved = PolicyType.fromName(policyType);
+    if (resolved == null) {
+      throw new BadRequestException(
+          "Unknown policy type: '%s'. Valid values are: %s",
+          policyType,
+          Arrays.stream(PredefinedPolicyTypes.values())
+              .map(PolicyType::getName)
+              .collect(Collectors.joining(", ")));
+    }
+    return resolved;
+  }
 
   /**
    * Resolves the optional {@code policyType} query parameter of the policy listing APIs into a
@@ -65,12 +81,24 @@ public class PolicyCatalogUtils {
     if (policyType == null || policyType.isEmpty()) {
       return null;
     }
-    PolicyType resolved = PolicyType.fromName(policyType);
-    if (resolved == null) {
-      throw new BadRequestException(
-          "Unknown policy type: '%s'. Valid values are: %s", policyType, KNOWN_POLICY_TYPE_NAMES);
+    return lookUpPolicyType(policyType);
+  }
+
+  /**
+   * Resolves a required policy type, as supplied in a create-policy request body.
+   *
+   * <p>Unlike {@link #resolvePolicyTypeFilter(String)}, no value here means "unspecified" and is
+   * rejected: a policy cannot be created without a type.
+   *
+   * @param policyType the requested policy type name
+   * @return the resolved policy type, never {@code null}
+   * @throws BadRequestException if the value is absent, empty, or does not name a known policy type
+   */
+  public static PolicyType resolveRequiredPolicyType(@Nullable String policyType) {
+    if (policyType == null || policyType.isEmpty()) {
+      throw new BadRequestException("Policy type is required");
     }
-    return resolved;
+    return lookUpPolicyType(policyType);
   }
 
   public static PolarisResolvedPathWrapper getResolvedPathWrapper(

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtilsTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtilsTest.java
@@ -64,6 +64,36 @@ class PolicyCatalogUtilsTest {
         .hasMessageContaining(policyType);
   }
 
+  @ParameterizedTest
+  @EnumSource(PredefinedPolicyTypes.class)
+  void testResolveRequiredPolicyTypeAcceptsKnownTypes(PredefinedPolicyTypes policyType) {
+    assertThat(PolicyCatalogUtils.resolveRequiredPolicyType(policyType.getName()))
+        .isEqualTo(policyType);
+  }
+
+  @Test
+  void testResolveRequiredPolicyTypeRejectsNull() {
+    // Unlike the listing filter, a create-policy request has no "unspecified" case.
+    assertThatThrownBy(() -> PolicyCatalogUtils.resolveRequiredPolicyType(null))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("Policy type is required");
+  }
+
+  @Test
+  void testResolveRequiredPolicyTypeRejectsEmptyValue() {
+    assertThatThrownBy(() -> PolicyCatalogUtils.resolveRequiredPolicyType(""))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("Policy type is required");
+  }
+
+  @Test
+  void testResolveRequiredPolicyTypeRejectsUnknownType() {
+    assertThatThrownBy(() -> PolicyCatalogUtils.resolveRequiredPolicyType("not-a-policy-type"))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("Unknown policy type")
+        .hasMessageContaining("not-a-policy-type");
+  }
+
   @Test
   void testResolvePolicyTypeFilterRejectionListsEveryValidType() {
     assertThatThrownBy(() -> PolicyCatalogUtils.resolvePolicyTypeFilter("not-a-policy-type"))

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtilsTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtilsTest.java
@@ -60,6 +60,19 @@ class PolicyCatalogUtilsTest {
   void testResolvePolicyTypeFilterRejectsUnknownTypes(String policyType) {
     assertThatThrownBy(() -> PolicyCatalogUtils.resolvePolicyTypeFilter(policyType))
         .isInstanceOf(BadRequestException.class)
-        .hasMessageContaining("Unknown policy type");
+        .hasMessageContaining("Unknown policy type")
+        .hasMessageContaining(policyType);
+  }
+
+  @Test
+  void testResolvePolicyTypeFilterRejectionListsEveryValidType() {
+    assertThatThrownBy(() -> PolicyCatalogUtils.resolvePolicyTypeFilter("not-a-policy-type"))
+        .isInstanceOf(BadRequestException.class)
+        .satisfies(
+            e -> {
+              for (PredefinedPolicyTypes policyType : PredefinedPolicyTypes.values()) {
+                assertThat(e).hasMessageContaining(policyType.getName());
+              }
+            });
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtilsTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/PolicyCatalogUtilsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.polaris.core.policy.PredefinedPolicyTypes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PolicyCatalogUtilsTest {
+
+  @ParameterizedTest
+  @EnumSource(PredefinedPolicyTypes.class)
+  void testResolvePolicyTypeFilterAcceptsKnownTypes(PredefinedPolicyTypes policyType) {
+    assertThat(PolicyCatalogUtils.resolvePolicyTypeFilter(policyType.getName()))
+        .isEqualTo(policyType);
+  }
+
+  @Test
+  void testResolvePolicyTypeFilterWithNullReturnsNoFilter() {
+    assertThat(PolicyCatalogUtils.resolvePolicyTypeFilter(null)).isNull();
+  }
+
+  @Test
+  void testResolvePolicyTypeFilterWithEmptyValueReturnsNoFilter() {
+    // The policyType query parameter is declared with allowEmptyValue: true.
+    assertThat(PolicyCatalogUtils.resolvePolicyTypeFilter("")).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "not-a-policy-type",
+        "system.data_compaction",
+        "SYSTEM.DATA-COMPACTION",
+        "system.data-compaction ",
+        " "
+      })
+  void testResolvePolicyTypeFilterRejectsUnknownTypes(String policyType) {
+    assertThatThrownBy(() -> PolicyCatalogUtils.resolvePolicyTypeFilter(policyType))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("Unknown policy type");
+  }
+}

--- a/spec/generated/bundled-polaris-catalog-service.yaml
+++ b/spec/generated/bundled-polaris-catalog-service.yaml
@@ -1617,7 +1617,7 @@ paths:
         User provides the following inputs when creating a policy
         - `name` (REQUIRED): The name of the policy.
         - `type` (REQUIRED): The type of the policy.
-          - **Predefined Policies:** policies have a `system.*` prefix in their type, such as `system.data_compaction`
+          - **Predefined Policies:** policies have a `system.*` prefix in their type, such as `system.data-compaction`
         - `description` (OPTIONAL): Provides details about the policy's purpose and functionality
         - `content` (OPTIONAL): Defines the rules that control actions and access conditions on resources. The format can be JSON, SQL, or any other format.
 

--- a/spec/polaris-catalog-apis/policy-apis.yaml
+++ b/spec/polaris-catalog-apis/policy-apis.yaml
@@ -39,7 +39,7 @@ paths:
         User provides the following inputs when creating a policy
         - `name` (REQUIRED): The name of the policy.
         - `type` (REQUIRED): The type of the policy.
-          - **Predefined Policies:** policies have a `system.*` prefix in their type, such as `system.data_compaction`
+          - **Predefined Policies:** policies have a `system.*` prefix in their type, such as `system.data-compaction`
         - `description` (OPTIONAL): Provides details about the policy's purpose and functionality
         - `content` (OPTIONAL): Defines the rules that control actions and access conditions on resources. The format can be JSON, SQL, or any other format.
 


### PR DESCRIPTION
The Policy API resolves the optional `policyType` query parameter with
`PolicyType.fromName(...)`, which returns `null` for any name it does not
recognize. `null` is also the sentinel that means "no filter", so an
unrecognized value silently degrades into an unfiltered listing:

- `GET /polaris/v1/{prefix}/namespaces/{namespace}/policies?policyType=...`
- `GET /polaris/v1/{prefix}/applicable-policies?policyType=...`

A misspelled type such as `system.data_compaction` (underscore instead of
hyphen) therefore returns HTTP 200 together with policies of *every* type,
and the client has no way to tell a filtered result from an unfiltered one.
For `getApplicablePolicies` this is the more damaging case: a caller asking
which snapshot-expiry policy applies to a table receives policies of all
types and may act on the wrong one.

`createPolicy` already rejects unknown type names with a `BadRequestException`
(`PolicyCatalog#createPolicy`), so the two listing endpoints were also
inconsistent with the rest of the same API, and with their own specification,
which documents a 400 response.

## Changes

`PolicyCatalogUtils#resolvePolicyTypeFilter` now resolves the raw query
parameter, and both call sites in `PolicyCatalogAdapter` use it:

- an absent (`null`) or empty value still means "no filter" — the parameter is
  declared `allowEmptyValue: true` in `spec/polaris-catalog-apis/policy-apis.yaml`,
  so empty must keep working;
- any other value must name a known policy type; an unknown name is rejected
  with `BadRequestException`, which maps to HTTP 400.

No public interface or extension point is changed: `PolicyCatalogUtils` is an
internal helper in the service module, and `PolicyType` is untouched.

## Testing

- `PolicyCatalogUtilsTest` (new): parameterized over every `PredefinedPolicyTypes`
  value for the accepted cases, plus `null` / empty for "no filter", plus unknown
  names, wrong separators, wrong case and surrounding whitespace for the rejected
  cases.
- `PolarisPolicyServiceIntegrationTest`: two new end-to-end tests assert HTTP 400
  from `listPolicies` and `getApplicablePolicies` when an unknown `policyType` is
  supplied while a real policy exists in the namespace.

Both integration tests were confirmed to fail against the unpatched resolver
(`expected: 400 but was: 200`) and to pass with the fix. `PolicyServiceIntegrationTest`
runs 48 tests with 0 failures, and `spotlessCheck` / `checkstyleMain` /
`checkstyleTest` pass for `:polaris-runtime-service` and `:polaris-tests`.

## Notes

While reading this area I noticed that `listPolicies` accepts `pageToken` and
`pageSize` and declares `next-page-token` in its response schema, but the
implementation ignores all three and always lists everything. That is a
separate change with design questions of its own (result ordering, the
`Set<PolicyIdentifier>` response shape), so it is deliberately not bundled here;
I plan to raise it as its own issue.

AI assistance was used while preparing this change. I have reviewed the
implementation and the tests, and I am responsible for the contribution.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed) — no user-facing
      documentation covers the `policyType` parameter, so no update was required
