### PR TITLE
Improve homepage visual consistency

### DIFF
--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -135,7 +135,12 @@ h6:hover .heading-anchor {
     z-index: -1;
     inset: 0;
     background:
-      linear-gradient(to bottom, #30638e 0, rgba(48, 99, 142, 0.5) 4rem, rgba(48, 99, 142, 0) 12rem),
+      linear-gradient(
+        to bottom,
+        $td-navbar-bg-color 0,
+        rgba($td-navbar-bg-color, 0.5) 4rem,
+        rgba($td-navbar-bg-color, 0) 12rem
+      ),
       linear-gradient(to bottom, rgba(1, 19, 25, 0.22), rgba(1, 19, 25, 0.02) 45%, rgba(1, 19, 25, 0.18)),
       radial-gradient(circle at center 35%, rgba(0, 0, 0, 0.06), rgba(0, 18, 24, 0.2));
     content: "";
@@ -243,16 +248,18 @@ h6:hover .heading-anchor {
   }
 }
 
-@media (min-width: 768px) {
-  .polaris-landing-hero__content hr {
-    max-width: 16rem;
-    margin: 1.5rem auto;
-  }
+@include media-breakpoint-up(md) {
+  .polaris-landing {
+    .polaris-landing-hero__content hr {
+      max-width: 16rem;
+      margin: 1.5rem auto;
+    }
 
-  .polaris-landing-button {
-    min-height: 3rem;
-    padding: 0.7rem 1rem;
-    font-size: 0.9rem;
+    .polaris-landing-button {
+      min-height: 3rem;
+      padding: 0.7rem 1rem;
+      font-size: 0.9rem;
+    }
   }
 }
 
@@ -285,7 +292,7 @@ h6:hover .heading-anchor {
   padding: 3.75rem 0;
   border-top: 1px solid rgba(114, 232, 221, 0.08);
   background:
-    radial-gradient(circle at 50% 45%, rgba(48, 99, 142, 0.12), rgba(48, 99, 142, 0) 58%),
+    radial-gradient(circle at 50% 45%, rgba($td-navbar-bg-color, 0.12), rgba($td-navbar-bg-color, 0) 58%),
     #073b47;
 }
 
@@ -397,7 +404,7 @@ h6:hover .heading-anchor {
   }
 }
 
-@media (max-width: 767.98px) {
+@include media-breakpoint-down(md) {
   .polaris-landing-hero {
     min-height: 43rem;
     background-position: center bottom;

--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -89,9 +89,7 @@ h6:hover .heading-anchor {
   background: #f6f8f7;
 
   .td-navbar {
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-    background: rgba(3, 36, 45, 0.96);
-    backdrop-filter: blur(14px);
+    border-bottom-color: transparent;
   }
 
   .td-outer {
@@ -137,6 +135,7 @@ h6:hover .heading-anchor {
     z-index: -1;
     inset: 0;
     background:
+      linear-gradient(to bottom, #30638e 0, rgba(48, 99, 142, 0.5) 4rem, rgba(48, 99, 142, 0) 12rem),
       linear-gradient(to bottom, rgba(1, 19, 25, 0.22), rgba(1, 19, 25, 0.02) 45%, rgba(1, 19, 25, 0.18)),
       radial-gradient(circle at center 35%, rgba(0, 0, 0, 0.06), rgba(0, 18, 24, 0.2));
     content: "";
@@ -158,14 +157,14 @@ h6:hover .heading-anchor {
     justify-content: center;
     margin: 0;
     color: #fff;
-    font-size: clamp(4rem, 8vw, 7.8rem);
+    font-size: clamp(4rem, 5.75vw, 5.75rem);
     font-weight: 400;
     letter-spacing: 0;
     line-height: 1;
 
     > img {
-      width: 0.9em;
-      height: 0.9em;
+      width: 0.82em;
+      height: 0.82em;
       flex: 0 0 auto;
       filter: drop-shadow(0 0.2rem 1rem rgba(0, 0, 0, 0.25));
     }
@@ -178,7 +177,7 @@ h6:hover .heading-anchor {
   > p {
     margin: 1.5rem 0 0;
     color: rgba(255, 255, 255, 0.92);
-    font-size: clamp(1.25rem, 2.2vw, 1.75rem);
+    font-size: clamp(1.25rem, 1.8vw, 1.5rem);
     font-weight: 400;
     letter-spacing: 0.01em;
   }
@@ -244,9 +243,24 @@ h6:hover .heading-anchor {
   }
 }
 
+@media (min-width: 768px) {
+  .polaris-landing-hero__content hr {
+    max-width: 16rem;
+    margin: 1.5rem auto;
+  }
+
+  .polaris-landing-button {
+    min-height: 3rem;
+    padding: 0.7rem 1rem;
+    font-size: 0.9rem;
+  }
+}
+
 .polaris-landing-about {
-  padding: 7rem 0;
-  background: #0b333d;
+  padding: 5.5rem 0;
+  background:
+    radial-gradient(circle at 50% 0, rgba(114, 232, 221, 0.1), rgba(114, 232, 221, 0) 48%),
+    #073b47;
   text-align: center;
 
   h2 {
@@ -261,7 +275,7 @@ h6:hover .heading-anchor {
   p {
     max-width: 53rem;
     margin: 0 auto 1.2rem;
-    color: rgba(255, 255, 255, 0.72);
+    color: rgba(255, 255, 255, 0.76);
     font-size: clamp(1.05rem, 1.5vw, 1.2rem);
     line-height: 1.75;
   }
@@ -269,7 +283,10 @@ h6:hover .heading-anchor {
 
 .polaris-landing .polaris-landing-community {
   padding: 3.75rem 0;
-  background: #073b47;
+  border-top: 1px solid rgba(114, 232, 221, 0.08);
+  background:
+    radial-gradient(circle at 50% 45%, rgba(48, 99, 142, 0.12), rgba(48, 99, 142, 0) 58%),
+    #073b47;
 }
 
 .polaris-landing-community__grid {
@@ -317,7 +334,7 @@ h6:hover .heading-anchor {
     }
 
     small {
-      color: rgba(255, 255, 255, 0.68);
+      color: rgba(255, 255, 255, 0.76);
       font-size: 0.92rem;
       line-height: 1.6;
     }
@@ -352,7 +369,7 @@ h6:hover .heading-anchor {
 
   p {
     margin: 0;
-    color: rgba(255, 255, 255, 0.68);
+    color: rgba(255, 255, 255, 0.76);
     font-size: 0.92rem;
     line-height: 1.6;
   }
@@ -369,7 +386,7 @@ h6:hover .heading-anchor {
 .polaris-landing .polaris-landing-trademarks {
   padding: 1rem 0;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
-  background: #052f39;
+  background: linear-gradient(to bottom, #073b47, #212529);
 
   p {
     margin: 0;

--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -135,12 +135,6 @@ h6:hover .heading-anchor {
     z-index: -1;
     inset: 0;
     background:
-      linear-gradient(
-        to bottom,
-        $td-navbar-bg-color 0,
-        rgba($td-navbar-bg-color, 0.5) 4rem,
-        rgba($td-navbar-bg-color, 0) 12rem
-      ),
       linear-gradient(to bottom, rgba(1, 19, 25, 0.22), rgba(1, 19, 25, 0.02) 45%, rgba(1, 19, 25, 0.18)),
       radial-gradient(circle at center 35%, rgba(0, 0, 0, 0.06), rgba(0, 18, 24, 0.2));
     content: "";

--- a/site/assets/scss/_variables_project.scss
+++ b/site/assets/scss/_variables_project.scss
@@ -23,8 +23,8 @@
  */
 $td-enable-google-fonts: false;
 
-// Keep the layout on the Polaris site as it was with Docsy 0.10.0
-$td-navbar-bg-color: #30638e !default;
+// Use the dark Polaris palette for shared site navigation.
+$td-navbar-bg-color: #03242d !default;
 
 // Dark mode disabled - see hugo.yaml.
 // https://www.docsy.dev/docs/content/lookandfeel/#how-to-disable-dark-mode


### PR DESCRIPTION
## Summary

- restore the homepage navbar to the shared site color while blending it smoothly into the hero
- rebalance the hero headline, logo, tagline, divider, and desktop action buttons
- unify the lower-page palette and add subtle depth without reintroducing card containers
- improve lower-page text contrast and reduce excess vertical space

## screenshot

<img width="1001" height="722" alt="Screenshot 2026-08-17 at 11 53 43 PM" src="https://github.com/user-attachments/assets/af99d3fc-83b6-43fe-95e7-8ddc72461455" />


## Checklist

- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic, where needed
- [x] 🧾 Updated `CHANGELOG.md` (not needed for this visual-only site refinement)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (not needed)
