### PR TITLE
Fix scope of DROP_WITH_PURGE_ENABLED to tables so views can be dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   fetch principal entity`. The failing lookup is still named in the server log at `ERROR`, which
   operators can match to the client error through the request id, returned by default as
   `X-Request-ID` and printed by the default log format as `requestId`.
+- `DROP_WITH_PURGE_ENABLED` now applies to Iceberg tables only. It previously also gated the
+  metadata purge that a view drop performs internally, so with its default of `false` and
+  `PURGE_VIEW_METADATA_ON_DROP` defaulting to `true`, dropping any view failed with HTTP 403 under
+  the default configuration. A view drop is now governed by `PURGE_VIEW_METADATA_ON_DROP` alone,
+  while the guard continues to protect a client-requested Iceberg table purge.
 
 ### Deprecations
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
@@ -1903,10 +1903,26 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
     catalogProps.put(FeatureConfiguration.PURGE_VIEW_METADATA_ON_DROP.catalogConfig(), "true");
     managementApi.updateCatalog(catalog, catalogProps);
 
-    assertThatThrownBy(() -> restCatalog.dropView(id)).isInstanceOf(ForbiddenException.class);
+    // DROP_WITH_PURGE_ENABLED guards client-requested table purges, not view drops.
+    assertThatCode(() -> restCatalog.dropView(id)).doesNotThrowAnyException();
+  }
 
-    catalog = managementApi.getCatalog(currentCatalogName);
-    catalogProps.put(FeatureConfiguration.PURGE_VIEW_METADATA_ON_DROP.catalogConfig(), "false");
+  @Test
+  public void testDropViewWithDefaultPurgeViewMetadataOnDrop() {
+    restCatalog.createNamespace(Namespace.of("ns1"));
+    TableIdentifier id = TableIdentifier.of(Namespace.of("ns1"), "view1");
+    restCatalog
+        .buildView(id)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(Namespace.of("ns1"))
+        .withQuery("spark", VIEW_QUERY)
+        .create();
+
+    Catalog catalog = managementApi.getCatalog(currentCatalogName);
+    Map<String, String> catalogProps = new HashMap<>(catalog.getProperties().toMap());
+    // Remove the purge related configs so defaults are used.
+    catalogProps.remove(FeatureConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfig());
+    catalogProps.remove(FeatureConfiguration.PURGE_VIEW_METADATA_ON_DROP.catalogConfig());
     managementApi.updateCatalog(catalog, catalogProps);
 
     assertThatCode(() -> restCatalog.dropView(id)).doesNotThrowAnyException();

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -82,6 +83,7 @@ import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.view.BaseView;
 import org.apache.polaris.core.admin.model.Catalog;
 import org.apache.polaris.core.admin.model.CatalogGrant;
 import org.apache.polaris.core.admin.model.CatalogPrivilege;
@@ -118,6 +120,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Assumptions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.configuration.PreferredAssumptionException;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -129,6 +132,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Import the full core Iceberg catalog tests by hitting the REST service via the RESTCatalog
@@ -209,6 +213,26 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   protected <T extends FileIO> T initializeClientFileIO(T fileIO) {
     fileIO.initialize(clientFileIOProperties().build());
     return fileIO;
+  }
+
+  private void assertViewMetadataFileExists(String metadataLocation, boolean shouldBeDeleted) {
+    try (ResolvingFileIO fileIO = new ResolvingFileIO()) {
+      initializeClientFileIO(fileIO);
+      fileIO.setConf(new Configuration());
+      if (shouldBeDeleted) {
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(20))
+            .untilAsserted(
+                () ->
+                    assertThat(fileIO.newInputFile(metadataLocation).exists())
+                        .as("View metadata file should be deleted when purge is enabled")
+                        .isFalse());
+      } else {
+        assertThat(fileIO.newInputFile(metadataLocation).exists())
+            .as("View metadata file should remain when purge is disabled")
+            .isTrue();
+      }
+    }
   }
 
   /**
@@ -1886,8 +1910,9 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
     }
   }
 
-  @Test
-  public void testDropViewWithPurge() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testDropViewWithPurge(boolean purgeViewMetadataOnDrop) {
     restCatalog.createNamespace(Namespace.of("ns1"));
     TableIdentifier id = TableIdentifier.of(Namespace.of("ns1"), "view1");
     restCatalog
@@ -1897,14 +1922,21 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
         .withQuery("spark", VIEW_QUERY)
         .create();
 
+    String metadataLocation =
+        ((BaseView) restCatalog.loadView(id)).operations().current().metadataFileLocation();
+
     Catalog catalog = managementApi.getCatalog(currentCatalogName);
     Map<String, String> catalogProps = new HashMap<>(catalog.getProperties().toMap());
+    // DROP_WITH_PURGE_ENABLED guards client-requested table purges, not view drops.
     catalogProps.put(FeatureConfiguration.DROP_WITH_PURGE_ENABLED.catalogConfig(), "false");
-    catalogProps.put(FeatureConfiguration.PURGE_VIEW_METADATA_ON_DROP.catalogConfig(), "true");
+    catalogProps.put(
+        FeatureConfiguration.PURGE_VIEW_METADATA_ON_DROP.catalogConfig(),
+        Boolean.toString(purgeViewMetadataOnDrop));
     managementApi.updateCatalog(catalog, catalogProps);
 
-    // DROP_WITH_PURGE_ENABLED guards client-requested table purges, not view drops.
     assertThatCode(() -> restCatalog.dropView(id)).doesNotThrowAnyException();
+
+    assertViewMetadataFileExists(metadataLocation, purgeViewMetadataOnDrop);
   }
 
   @Test

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java
@@ -427,7 +427,8 @@ public class FeatureConfiguration<T> extends PolarisConfiguration<T> {
           .catalogConfig("polaris.config.drop-with-purge.enabled")
           .legacyCatalogConfig("drop-with-purge.enabled")
           .description(
-              "If set to true, allows tables to be dropped with the purge parameter set to true.")
+              "If set to true, allows Iceberg tables to be dropped with the purge parameter set to"
+                  + " true.")
           .defaultValue(false)
           .buildFeatureConfiguration();
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -2964,7 +2964,10 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     PolarisEntity leafEntity = resolvedEntities.getRawLeafEntity();
 
     // Check that purge is enabled, if it is set:
-    if (catalogPath != null && !catalogPath.isEmpty() && purge) {
+    if (catalogPath != null
+        && !catalogPath.isEmpty()
+        && purge
+        && subType == PolarisEntitySubType.ICEBERG_TABLE) {
       boolean dropWithPurgeEnabled =
           realmConfig.getConfig(FeatureConfiguration.DROP_WITH_PURGE_ENABLED, catalogEntity);
       if (!dropWithPurgeEnabled) {

--- a/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/flags-polaris_features.md
@@ -274,7 +274,7 @@ When enabled, a managed location generated for a table or view created without a
 
 ##### `polaris.features."DROP_WITH_PURGE_ENABLED"`
 
-If set to true, allows tables to be dropped with the purge parameter set to true.
+If set to true, allows Iceberg tables to be dropped with the purge parameter set to true.
 
 - **Type:** `Boolean`
 - **Default:** `false`


### PR DESCRIPTION
Fixes: https://github.com/apache/polaris/issues/5293

Dropping a view on a catalog with no purge-related configuration set fails with a 403:

```
ForbiddenException: Unable to purge entity: view1. To enable this feature, set the Polaris
configuration DROP_WITH_PURGE_ENABLED or the catalog configuration
polaris.config.drop-with-purge.enabled
```

The cause is the interaction of two defaults:

- `DROP_WITH_PURGE_ENABLED` defaults to `false`
https://github.com/apache/polaris/blob/ffa69775ec832a2e8308e3f75ffbc9b2d556c472/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java#L424-L432


- `PURGE_VIEW_METADATA_ON_DROP` defaults to `true`
https://github.com/apache/polaris/blob/ffa69775ec832a2e8308e3f75ffbc9b2d556c472/polaris-core/src/main/java/org/apache/polaris/core/config/FeatureConfiguration.java#L434-L441


`LocalIcebergCatalog`.`dropView` derives purge from the first and passes it to `dropTableLike`, whose guard rejects purge=true unless the second is enabled. So the shipped defaults are exactly the combination that fails.

`PolarisRestCatalogIntegrationBase.testDropViewWithPurge` explicitly pins the behaviour when both properties are set (`DROP_WITH_PURGE_ENABLED`=`false` + `PURGE_VIEW_METADATA_ON_DROP`=`true` → `ForbiddenException`)

https://github.com/apache/polaris/blob/ffa69775ec832a2e8308e3f75ffbc9b2d556c472/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java#L1902-L1907

In order to fix this scope of `DROP_WITH_PURGE_ENABLED` is changed to tables only so views can be independently dropped

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
