### PR TITLE
hardening: null-safe list handling in 'catalogs update --allowed-location'

### DIFF
--- a/client/python/apache_polaris/cli/command/catalogs.py
+++ b/client/python/apache_polaris/cli/command/catalogs.py
@@ -511,9 +511,9 @@ class CatalogsCommand(Command):
                 # in option_tree.py should be applied individually against the existing
                 # storage_config_info here.
                 if self.allowed_locations:
-                    updated_storage_info.allowed_locations.extend(
-                        self.allowed_locations
-                    )
+                    updated_storage_info.allowed_locations = (
+                        updated_storage_info.allowed_locations or []
+                    ) + self.allowed_locations
 
                 if self.region:
                     self._require_s3(updated_storage_info, "--region")

--- a/client/python/tests/test_catalogs_command.py
+++ b/client/python/tests/test_catalogs_command.py
@@ -567,42 +567,6 @@ class TestCatalogsCommand(CLITestBase):
             "--no-kms requires S3 storage_type",
         )
 
-    def test_catalog_update_allowed_locations(self) -> None:
-        # ``--allowed-location`` on update must produce
-        # ``(existing or []) + new_flags`` — including the ``None`` case
-        # (regression for the crash when the catalog was created without any).
-        cases = [
-            (None, ["s3://bucket/new"], ["s3://bucket/new"]),
-            (
-                ["s3://bucket/a"],
-                ["s3://bucket/b", "s3://bucket/c"],
-                ["s3://bucket/a", "s3://bucket/b", "s3://bucket/c"],
-            ),
-        ]
-        for existing, new_flags, expected in cases:
-            with self.subTest(existing=existing):
-                mock_client = self.build_mock_client()
-                mock_client.get_catalog.return_value = PolarisCatalog(
-                    type="INTERNAL",
-                    name="s3-catalog",
-                    entity_version=1,
-                    properties=CatalogProperties(
-                        default_base_location="s3://bucket/path",
-                        additional_properties={},
-                    ),
-                    storage_config_info=AwsStorageConfigInfo(
-                        storage_type="S3", allowed_locations=existing
-                    ),
-                )
-                args = ["catalogs", "update", "s3-catalog"]
-                for loc in new_flags:
-                    args += ["--allowed-location", loc]
-                self.mock_execute(mock_client, args)
-                call_args = mock_client.update_catalog.call_args[0][1]
-                self.assertEqual(
-                    call_args.storage_config_info.allowed_locations, expected
-                )
-
     def test_catalog_list(self) -> None:
         mock_client = self.build_mock_client()
         mock_client.list_catalogs.return_values.catalogs = []

--- a/client/python/tests/test_catalogs_command.py
+++ b/client/python/tests/test_catalogs_command.py
@@ -567,6 +567,42 @@ class TestCatalogsCommand(CLITestBase):
             "--no-kms requires S3 storage_type",
         )
 
+    def test_catalog_update_allowed_locations(self) -> None:
+        # ``--allowed-location`` on update must produce
+        # ``(existing or []) + new_flags`` — including the ``None`` case
+        # (regression for the crash when the catalog was created without any).
+        cases = [
+            (None, ["s3://bucket/new"], ["s3://bucket/new"]),
+            (
+                ["s3://bucket/a"],
+                ["s3://bucket/b", "s3://bucket/c"],
+                ["s3://bucket/a", "s3://bucket/b", "s3://bucket/c"],
+            ),
+        ]
+        for existing, new_flags, expected in cases:
+            with self.subTest(existing=existing):
+                mock_client = self.build_mock_client()
+                mock_client.get_catalog.return_value = PolarisCatalog(
+                    type="INTERNAL",
+                    name="s3-catalog",
+                    entity_version=1,
+                    properties=CatalogProperties(
+                        default_base_location="s3://bucket/path",
+                        additional_properties={},
+                    ),
+                    storage_config_info=AwsStorageConfigInfo(
+                        storage_type="S3", allowed_locations=existing
+                    ),
+                )
+                args = ["catalogs", "update", "s3-catalog"]
+                for loc in new_flags:
+                    args += ["--allowed-location", loc]
+                self.mock_execute(mock_client, args)
+                call_args = mock_client.update_catalog.call_args[0][1]
+                self.assertEqual(
+                    call_args.storage_config_info.allowed_locations, expected
+                )
+
     def test_catalog_list(self) -> None:
         mock_client = self.build_mock_client()
         mock_client.list_catalogs.return_values.catalogs = []


### PR DESCRIPTION
**(The PR was created with assumption that this is causing a bug, but turns out it's not really a bug and doesn't result in any issue. This PR now is updated into a work for hardening)**

## Summary

Defensive hardening for the Python CLI: `catalogs update --allowed-location` called `list.extend()` on `updated_storage_info.allowed_locations`, which the SDK types as `Optional[List[StrictStr]] = None`. Coalesce to `[]` before appending.

## Context

Per discussion in this PR, the Polaris server auto-populates `allowedLocations` with the default base location (`CatalogEntity.java:343-359`), so this null state is not reachable via a real server response. The change is kept purely as hardening around a code path that shouldn't rely on a server-side invariant. Tests removed to avoid implying a reachable failure.
