### PR TITLE
Fix NoSQL client-ID index reporting a re-added key as already in use

### DIFF
--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/ImmutableEmptyIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/ImmutableEmptyIndexImpl.java
@@ -83,7 +83,7 @@ final class ImmutableEmptyIndexImpl<V> implements IndexSpi<V> {
   }
 
   @Override
-  public boolean add(@NonNull InternalIndexElement<V> element) {
+  public AddResult add(@NonNull InternalIndexElement<V> element) {
     throw unsupported();
   }
 

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexImpl.java
@@ -453,7 +453,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
   }
 
   @Override
-  public boolean add(@NonNull InternalIndexElement<V> element) {
+  public AddResult add(@NonNull InternalIndexElement<V> element) {
     modified = true;
     var e = elements;
     var serializer = this.serializer;
@@ -467,7 +467,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
       estimatedSerializedSizeDiff += elementSerializedSize - prevSerializedSize;
 
       e.set(idx, element);
-      return false;
+      return prev.hasValue() ? AddResult.UPDATED : AddResult.UPDATED_NO_VALUE;
     }
 
     estimatedSerializedSizeDiff += addElementDiff(element, elementSerializedSize);
@@ -478,7 +478,7 @@ final class IndexImpl<V> implements IndexSpi<V> {
     } else {
       e.add(insertionPoint, element);
     }
-    return true;
+    return AddResult.NEW_KEY;
   }
 
   private static <V> int addElementDiff(

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexSpi.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/IndexSpi.java
@@ -46,9 +46,32 @@ interface IndexSpi<V> extends ModifiableIndex<V> {
    * Adds a new element to the index.
    *
    * @param element element to add
-   * @return {@code true}, if the key did not exist in the index before
+   * @return logical add/update result
    */
-  boolean add(@NonNull InternalIndexElement<V> element);
+  AddResult add(@NonNull InternalIndexElement<V> element);
+
+  enum AddResult {
+    /**
+     * A new element was added. In case the {@link IndexSpi} instance is a layered index, this means
+     * neither the embedded nor the reference indexes contained the key.
+     */
+    NEW_KEY(true),
+    /** An existing element without a value (removal sentinel for embedded indexes) was updated. */
+    UPDATED_NO_VALUE(true),
+    /** An existing element with a value was updated. */
+    UPDATED(false);
+
+    /**
+     * {@code true} if the element's key was not <em>logically</em> present, so either not present
+     * in the embedded and the reference indexes <em>or</em> present in the embedded index but
+     * without a value (removal sentinel).
+     */
+    final boolean logicallyAdded;
+
+    AddResult(boolean logicallyAdded) {
+      this.logicallyAdded = logicallyAdded;
+    }
+  }
 
   /**
    * Convenience around {@link #add(InternalIndexElement)}.
@@ -61,7 +84,7 @@ interface IndexSpi<V> extends ModifiableIndex<V> {
   default boolean put(@NonNull IndexKey key, @NonNull V value) {
     requireNonNull(key, "key must not be null");
     requireNonNull(value, "value must not be null");
-    return add(indexElement(key, value));
+    return add(indexElement(key, value)).logicallyAdded;
   }
 
   /**

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/LazyIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/LazyIndexImpl.java
@@ -197,7 +197,7 @@ final class LazyIndexImpl<V> implements IndexSpi<V> {
   }
 
   @Override
-  public boolean add(@NonNull InternalIndexElement<V> element) {
+  public AddResult add(@NonNull InternalIndexElement<V> element) {
     return loaded().add(element);
   }
 

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/ReadOnlyLayeredIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/ReadOnlyLayeredIndexImpl.java
@@ -71,7 +71,7 @@ final class ReadOnlyLayeredIndexImpl<V> extends AbstractLayeredIndexImpl<V> {
   }
 
   @Override
-  public boolean add(@NonNull InternalIndexElement<V> element) {
+  public AddResult add(@NonNull InternalIndexElement<V> element) {
     throw unsupported();
   }
 

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/StripedIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/StripedIndexImpl.java
@@ -322,7 +322,7 @@ final class StripedIndexImpl<V> implements IndexSpi<V> {
   }
 
   @Override
-  public boolean add(@NonNull InternalIndexElement<V> element) {
+  public AddResult add(@NonNull InternalIndexElement<V> element) {
     return mutableStripeForKey(element.key()).add(element);
   }
 

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/UpdatableIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/UpdatableIndexImpl.java
@@ -245,11 +245,10 @@ final class UpdatableIndexImpl<V> extends AbstractLayeredIndexImpl<V> implements
 
     hasOversizedEmbeddedEntry |=
         entrySerializedSizeUpperBound > maxEmbeddedEntrySizeBeforeForcedSpill;
-    var added = embedded.add(element);
-    if (added) {
-      return !reference.containsElement(element.key());
-    }
-    return false;
+
+    var existed = contains(element.key());
+    embedded.add(element);
+    return !existed;
   }
 
   @Override

--- a/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/UpdatableIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/main/java/org/apache/polaris/persistence/nosql/impl/indexes/UpdatableIndexImpl.java
@@ -233,7 +233,7 @@ final class UpdatableIndexImpl<V> extends AbstractLayeredIndexImpl<V> implements
   // Mutators
 
   @Override
-  public boolean add(@NonNull InternalIndexElement<V> element) {
+  public AddResult add(@NonNull InternalIndexElement<V> element) {
     checkNotFinalized();
 
     var maxEmbeddedIndexSize = params.maxEmbeddedIndexSize().asLong();
@@ -246,9 +246,15 @@ final class UpdatableIndexImpl<V> extends AbstractLayeredIndexImpl<V> implements
     hasOversizedEmbeddedEntry |=
         entrySerializedSizeUpperBound > maxEmbeddedEntrySizeBeforeForcedSpill;
 
-    var existed = contains(element.key());
-    embedded.add(element);
-    return !existed;
+    return switch (embedded.add(element)) {
+      // embedded index had the key with a non-null value -> updated
+      case UPDATED -> AddResult.UPDATED;
+      // embedded index had the key with a null value (removal sentinel) -> logically added
+      case UPDATED_NO_VALUE -> AddResult.NEW_KEY;
+      // embedded index did not contain the key -> the reference index determines the result
+      case NEW_KEY ->
+          reference.containsElement(element.key()) ? AddResult.UPDATED : AddResult.NEW_KEY;
+    };
   }
 
   @Override

--- a/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestIndexImpl.java
@@ -411,7 +411,7 @@ public class TestIndexImpl {
     soft.assertThat(reSerialize.apply(segment)).isEqualTo(segment);
     soft.assertThat(segment.asKeyList()).isEmpty();
 
-    soft.assertThat(segment.add(indexElement(keyD, id4))).isTrue();
+    soft.assertThat(segment.add(indexElement(keyD, id4))).isEqualTo(IndexSpi.AddResult.NEW_KEY);
     soft.assertThat(reSerialize.apply(segment)).isEqualTo(segment);
     soft.assertThat(segment.asKeyList()).containsExactly(keyD);
     soft.assertThat(asHex(segment.serialize()))
@@ -420,7 +420,7 @@ public class TestIndexImpl {
                 + "01"
                 + serializedD);
 
-    soft.assertThat(segment.add(indexElement(keyB, id2))).isTrue();
+    soft.assertThat(segment.add(indexElement(keyB, id2))).isEqualTo(IndexSpi.AddResult.NEW_KEY);
     soft.assertThat(reSerialize.apply(segment)).isEqualTo(segment);
     soft.assertThat(segment.asKeyList()).containsExactly(keyB, keyD);
     soft.assertThat(asHex(segment.serialize()))
@@ -431,7 +431,7 @@ public class TestIndexImpl {
                 + "04" // strip
                 + serializedD);
 
-    soft.assertThat(segment.add(indexElement(keyC, id3))).isTrue();
+    soft.assertThat(segment.add(indexElement(keyC, id3))).isEqualTo(IndexSpi.AddResult.NEW_KEY);
     soft.assertThat(reSerialize.apply(segment)).isEqualTo(segment);
     soft.assertThat(segment.asKeyList()).containsExactly(keyB, keyC, keyD);
     soft.assertThat(asHex(segment.serialize()))
@@ -444,7 +444,7 @@ public class TestIndexImpl {
                 + "04" // strip
                 + serializedD);
 
-    soft.assertThat(segment.add(indexElement(keyE, id1))).isTrue();
+    soft.assertThat(segment.add(indexElement(keyE, id1))).isEqualTo(IndexSpi.AddResult.NEW_KEY);
     soft.assertThat(reSerialize.apply(segment)).isEqualTo(segment);
     soft.assertThat(segment.asKeyList()).containsExactly(keyB, keyC, keyD, keyE);
     soft.assertThat(asHex(segment.serialize()))
@@ -459,7 +459,7 @@ public class TestIndexImpl {
                 + "04" // strip
                 + serializedE);
 
-    soft.assertThat(segment.add(indexElement(keyA, id1))).isTrue();
+    soft.assertThat(segment.add(indexElement(keyA, id1))).isEqualTo(IndexSpi.AddResult.NEW_KEY);
     soft.assertThat(reSerialize.apply(segment)).isEqualTo(segment);
     soft.assertThat(segment.asKeyList()).containsExactly(keyA, keyB, keyC, keyD, keyE);
     soft.assertThat(asHex(segment.serialize()))
@@ -476,7 +476,7 @@ public class TestIndexImpl {
                 + "04" // strip
                 + serializedE);
 
-    soft.assertThat(segment.add(indexElement(keyExB, id2))).isTrue();
+    soft.assertThat(segment.add(indexElement(keyExB, id2))).isEqualTo(IndexSpi.AddResult.NEW_KEY);
     soft.assertThat(reSerialize.apply(segment)).isEqualTo(segment);
     soft.assertThat(segment.asKeyList()).containsExactly(keyA, keyB, keyC, keyD, keyE, keyExB);
     soft.assertThat(asHex(segment.serialize()))
@@ -495,7 +495,7 @@ public class TestIndexImpl {
                 + "02" // strip
                 + serializedExB);
 
-    soft.assertThat(segment.add(indexElement(keyExD, id3))).isTrue();
+    soft.assertThat(segment.add(indexElement(keyExD, id3))).isEqualTo(IndexSpi.AddResult.NEW_KEY);
     soft.assertThat(reSerialize.apply(segment)).isEqualTo(segment);
     soft.assertThat(segment.asKeyList())
         .containsExactly(keyA, keyB, keyC, keyD, keyE, keyExB, keyExD);
@@ -517,7 +517,7 @@ public class TestIndexImpl {
                 + "02" // strip
                 + serializedExD);
 
-    soft.assertThat(segment.add(indexElement(keyEyC, id4))).isTrue();
+    soft.assertThat(segment.add(indexElement(keyEyC, id4))).isEqualTo(IndexSpi.AddResult.NEW_KEY);
     soft.assertThat(reSerialize.apply(segment)).isEqualTo(segment);
     soft.assertThat(segment.asKeyList())
         .containsExactly(keyA, keyB, keyC, keyD, keyE, keyExB, keyExD, keyEyC);
@@ -541,7 +541,7 @@ public class TestIndexImpl {
                 + "03" // strip
                 + serializedEyC);
 
-    soft.assertThat(segment.add(indexElement(keyExC, id1))).isTrue();
+    soft.assertThat(segment.add(indexElement(keyExC, id1))).isEqualTo(IndexSpi.AddResult.NEW_KEY);
     soft.assertThat(reSerialize.apply(segment)).isEqualTo(segment);
     soft.assertThat(segment.asKeyList())
         .containsExactly(keyA, keyB, keyC, keyD, keyE, keyExB, keyExC, keyExD, keyEyC);
@@ -569,7 +569,7 @@ public class TestIndexImpl {
     soft.assertThat(segment.getElement(keyExC)).isEqualTo(indexElement(keyExC, id1));
 
     // Re-add with a BIGGER serialized object-id
-    soft.assertThat(segment.add(indexElement(keyExC, id2))).isFalse();
+    soft.assertThat(segment.add(indexElement(keyExC, id2))).isEqualTo(IndexSpi.AddResult.UPDATED);
     soft.assertThat(reSerialize.apply(segment)).isEqualTo(segment);
     soft.assertThat(segment.asKeyList())
         .containsExactly(keyA, keyB, keyC, keyD, keyE, keyExB, keyExC, keyExD, keyEyC);

--- a/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestUpdatableIndexImpl.java
+++ b/persistence/nosql/persistence/impl/src/test/java/org/apache/polaris/persistence/nosql/impl/indexes/TestUpdatableIndexImpl.java
@@ -148,6 +148,30 @@ public class TestUpdatableIndexImpl {
   }
 
   @Test
+  public void putAfterRemoveOfKeyInReference() {
+    var foo = key("foo");
+    var bar = key("bar");
+    var baz = key("baz");
+    var id1 = randomObjId();
+    var id2 = randomObjId();
+    var id3 = randomObjId();
+    var newId = randomObjId();
+
+    var updatable =
+        updatableIndexForTest(Map.of(foo, id1, bar, id2, baz, id3), Map.of(), OBJ_REF_SERIALIZER);
+
+    soft.assertThat(updatable.remove(baz)).isTrue();
+
+    // The key was removed in this change, so it is logically absent and putting it back must be
+    // reported as a new key, even though the reference index still holds it.
+    soft.assertThat(updatable.put(baz, newId)).isTrue();
+    soft.assertThat(updatable.get(baz)).isEqualTo(newId);
+
+    // A key that is still present must continue to be reported as already existing.
+    soft.assertThat(updatable.put(foo, newId)).isFalse();
+  }
+
+  @Test
   public void removeExistsInReference() {
     var foo = key("foo");
     var bar = key("bar");

--- a/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
@@ -45,6 +45,7 @@ import org.apache.polaris.core.entity.PolarisEntityCore;
 import org.apache.polaris.core.entity.PolarisEntitySubType;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisPrivilege;
+import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.BasePolarisMetaStoreManagerTest;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
@@ -52,6 +53,7 @@ import org.apache.polaris.core.persistence.PolarisTestMetaStoreManager;
 import org.apache.polaris.core.persistence.bootstrap.RootCredentialsSet;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
 import org.apache.polaris.core.persistence.dao.entity.CreateCatalogResult;
+import org.apache.polaris.core.persistence.dao.entity.CreatePrincipalResult;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.dao.entity.LoadGrantsResult;
 import org.apache.polaris.core.persistence.dao.entity.LoadPolicyMappingsResult;
@@ -59,6 +61,9 @@ import org.apache.polaris.core.persistence.dao.entity.PolicyAttachmentResult;
 import org.apache.polaris.core.policy.PolicyEntity;
 import org.apache.polaris.core.policy.PredefinedPolicyTypes;
 import org.apache.polaris.ids.api.MonotonicClock;
+import org.apache.polaris.persistence.nosql.api.Persistence;
+import org.apache.polaris.persistence.nosql.api.RealmPersistenceFactory;
+import org.apache.polaris.persistence.nosql.coretypes.principals.PrincipalsObj;
 import org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMapping;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
@@ -85,6 +90,7 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
   @Identifier("nosql")
   MetaStoreManagerFactory metaStoreManagerFactory;
 
+  @Inject RealmPersistenceFactory realmPersistenceFactory;
   @Inject RealmConfigurationSource configurationSource;
   @Inject MonotonicClock monotonicClock;
 
@@ -139,6 +145,59 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
   void setup() {
     this.metaStore = polarisTestMetaStoreManager.polarisMetaStoreManager();
     this.callContext = polarisTestMetaStoreManager.polarisCallContext();
+  }
+
+  @Test
+  public void rotatePrincipalSecretsWhenClientIdIndexIsStriped() {
+    Persistence persistence = realmPersistenceFactory.newBuilder().realmId(realmId).build();
+
+    // Create principals until the by-client-id index spills out of the embedded region, so that
+    // client-id keys of existing principals live in stripes rather than in the embedded index.
+    CreatePrincipalResult first = null;
+    int created = 0;
+    while (created < 4000) {
+      PrincipalEntity entity =
+          new PrincipalEntity.Builder()
+              .setId(metaStore.generateNewEntityId(callContext).getId())
+              .setName("rotate_principal_" + created)
+              .setCreateTimestamp(System.currentTimeMillis())
+              .build();
+      CreatePrincipalResult result = metaStore.createPrincipal(callContext, entity);
+      assertThat(result.isSuccess()).isTrue();
+      if (first == null) {
+        first = result;
+      }
+      created++;
+      if (created % 50 == 0 && clientIdIndexIsStriped(persistence)) {
+        break;
+      }
+    }
+
+    assertThat(clientIdIndexIsStriped(persistence))
+        .describedAs(
+            "by-client-id index should have spilled to stripes after %d principals", created)
+        .isTrue();
+
+    // Rotating keeps the same client ID, so the mutation removes and re-adds the same index key.
+    var secrets = first.getPrincipalSecrets();
+    var rotated =
+        metaStore.rotatePrincipalSecrets(
+            callContext,
+            secrets.getPrincipalClientId(),
+            first.getPrincipal().getId(),
+            false,
+            secrets.getMainSecretHash());
+
+    assertThat(rotated.isSuccess()).isTrue();
+    assertThat(rotated.getPrincipalSecrets().getPrincipalClientId())
+        .isEqualTo(secrets.getPrincipalClientId());
+  }
+
+  private static boolean clientIdIndexIsStriped(Persistence persistence) {
+    return persistence
+        .fetchReferenceHead(PrincipalsObj.PRINCIPALS_REF_NAME, PrincipalsObj.class)
+        .map(principals -> !principals.byClientId().stripes().isEmpty())
+        .orElse(false);
   }
 
   @Test


### PR DESCRIPTION
Rotating or resetting a principal's secrets fails with ```AlreadyExistsException: Client ID already in use: <id>``` on the `NoSQL` backend, once a realm has enough principals. The `client ID` named in the error is the principal's own, and there is no way around it — a principal's client ID cannot be changed, so credential rotation stays blocked for every affected principal.

`UpdatableIndexImpl.add` decided whether a key already existed using `!reference.containsElement(key)`, a raw lookup against the reference layer. That lookup cannot see removal sentinels: remove does not delete a key that lives in the reference index, it records a sentinel in the embedded index which shadows it. A key removed and then re-added within the same change was therefore reported as already present, even though remove had just returned `true` for it `("the key did exist and was removed")`, and both `contains` and `get` treat it as absent.
The class already implements the layered, sentinel-aware check as `contains`, so add now uses it instead of hand-rolling one.

`PrincipalMutations.UpdateSecrets` is the only caller in the `NoSQL` tree that reads this return value, which is why the defect surfaces there and nowhere else. It removes the old client-ID mapping and re-adds the same key — rotation deliberately keeps the client ID — and treats the result as a uniqueness conflict. `CreatePrincipal` is unaffected because it checks the index with `get` rather than relying on `add's` result.

The condition only appears once the `by-client-id` index has spilled out of the embedded region, since below that the reference layer is empty and the old check happened to be right. `maxEmbeddedIndexSize` defaults to `32k`, which works out at roughly `1250` principals in a realm.

Two tests cover it: one on the index contract itself, asserting that a key removed in the current change is reported as newly added while a key still present is not, and one that creates principals until the `by-client-id` index actually spills, verifies the spill, then rotates the first principal's secrets.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
