### PR TITLE
Cache table metadata by metadata file location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### New Features
 
+- Table metadata JSON documents are now cached in memory by metadata file location, avoiding an
+  object-storage read per table refresh. Storage access is still resolved and validated on every
+  refresh. The approximate heap budget is configurable via
+  `polaris.table-metadata-cache.max-bytes` (default 128 MiB, `0` disables caching).
 - Python CLI: `catalogs update` now supports `--no-sts` and `--no-kms` to toggle STS/KMS availability on an existing S3 catalog. Previously these were only settable at `catalogs create` time.
 - Python CLI: added `gcp` as an external catalog authentication type for Iceberg REST federation, enabling CLI creation of GCP-authenticated catalogs such as BigLake without passing Google credential secrets through command-line flags.
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -206,6 +206,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
   private Map<String, String> catalogProperties;
   private final StorageAccessConfigProvider storageAccessConfigProvider;
   private final FileIOFactory fileIOFactory;
+  private final TableMetadataCache tableMetadataCache;
   private PolarisMetaStoreManager metaStoreManager;
 
   // Entity-property idempotency: when the request context carries a key, it is stamped into the new
@@ -237,7 +238,8 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       StorageAccessConfigProvider storageAccessConfigProvider,
       FileIOFactory fileIOFactory,
       PolarisEventDispatcher polarisEventDispatcher,
-      PolarisEventMetadataFactory eventMetadataFactory) {
+      PolarisEventMetadataFactory eventMetadataFactory,
+      TableMetadataCache tableMetadataCache) {
     this(
         diagnostics,
         resolverFactory,
@@ -250,6 +252,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         fileIOFactory,
         polarisEventDispatcher,
         eventMetadataFactory,
+        tableMetadataCache,
         IdempotencyRequestContext.DISABLED);
   }
 
@@ -265,6 +268,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
       FileIOFactory fileIOFactory,
       PolarisEventDispatcher polarisEventDispatcher,
       PolarisEventMetadataFactory eventMetadataFactory,
+      TableMetadataCache tableMetadataCache,
       IdempotencyRequestContext idempotencyRequestContext) {
     this.diagnostics = diagnostics;
     this.resolverFactory = resolverFactory;
@@ -281,6 +285,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     this.metaStoreManager = metaStoreManager;
     this.polarisEventDispatcher = polarisEventDispatcher;
     this.eventMetadataFactory = eventMetadataFactory;
+    this.tableMetadataCache = tableMetadataCache;
     this.idempotencyRequestContext = idempotencyRequestContext;
   }
 
@@ -1843,19 +1848,22 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
             SHOULD_RETRY_REFRESH_PREDICATE,
             getMaxMetadataRefreshRetries(),
             metadataLocation -> {
-              String latestLocationDir =
-                  latestLocation.substring(0, latestLocation.lastIndexOf('/'));
-              // TODO: Once we have the "current" table properties pulled into the resolvedEntity
-              // then we should use the actual current table properties for IO refresh here
-              // instead of the general tableDefaultProperties.
-              FileIO fileIO =
+              String metadataLocationDir =
+                  metadataLocation.substring(0, metadataLocation.lastIndexOf('/'));
+              // TODO: Once we have the "current" table properties pulled into the
+              // resolvedEntity then we should use the actual current table properties
+              // for IO refresh here instead of the general tableDefaultProperties.
+              // Storage access is resolved and validated on every refresh; the metadata cache
+              // only replaces the object-storage read of the immutable document.
+              FileIO refreshFileIO =
                   loadFileIOForTableLike(
                       tableIdentifier,
-                      Set.of(latestLocationDir),
+                      Set.of(metadataLocationDir),
                       resolvedEntities,
                       new HashMap<>(tableDefaultProperties),
                       Set.of(PolarisStorageActions.READ, PolarisStorageActions.LIST));
-              return TableMetadataParser.read(fileIO, metadataLocation);
+              return tableMetadataCache.getOrLoadMetadata(
+                  metadataCacheKey(metadataLocation), refreshFileIO);
             });
         if (polarisEventDispatcher.hasListeners(PolarisEventType.AFTER_REFRESH_TABLE)) {
           polarisEventDispatcher.dispatch(
@@ -2037,19 +2045,33 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         } else {
           updateTableLike(tableIdentifier, entity, false);
         }
+        // Commit is durable here; mark it before further work so a later failure can't trigger the
+        // finally-block cleanup of the committed newLocation.
+        writeSucceeded = true;
+
         // We diverge from `BaseMetastoreTableOperations`: only update the in-memory state after
         // the metastore persistence succeeds. If we updated it before and persistence threw,
         // the finally-block cleanup would delete newLocation while this ops instance still
-        // pointed at it — leaving a dangling reference until the caller refreshes.
+        // pointed at it, leaving a dangling reference until the caller refreshes.
+        TableMetadata committedMetadata =
+            TableMetadata.buildFrom(metadata)
+                .withMetadataLocation(newLocation)
+                .discardChanges()
+                .build();
         if (makeMetadataCurrentOnCommit) {
-          currentMetadata =
-              TableMetadata.buildFrom(metadata)
-                  .withMetadataLocation(newLocation)
-                  .discardChanges()
-                  .build();
+          currentMetadata = committedMetadata;
           currentMetadataLocation = newLocation;
         }
-        writeSucceeded = true;
+        // Serve subsequent refreshes of this version from memory instead of object storage. Cache
+        // population is best-effort and must not fail a commit that already persisted.
+        if (tableMetadataCache.isEnabled()) {
+          try {
+            tableMetadataCache.put(
+                metadataCacheKey(newLocation), TableMetadataParser.toJson(committedMetadata));
+          } catch (RuntimeException e) {
+            LOGGER.warn("Failed to populate table metadata cache for {}", newLocation, e);
+          }
+        }
       } finally {
         if (!writeSucceeded && writeResult.written()) {
           IcebergCatalogHandler.cleanupWrittenMetadataFiles(
@@ -2688,6 +2710,14 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
           "Failed to initialize catalogId before using catalog with name: " + catalogName);
     }
     return catalogId;
+  }
+
+  private TableMetadataCache.Key metadataCacheKey(String metadataLocation) {
+    return new TableMetadataCache.Key(
+        callContext.getRealmContext().getRealmIdentifier(),
+        getCatalogId(),
+        catalogEntity.getEntityVersion(),
+        metadataLocation);
   }
 
   private void renameTableLike(

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataCache.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataCache.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.annotations.VisibleForTesting;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.zip.GZIPInputStream;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+
+/**
+ * Process-wide cache of table metadata JSON documents keyed by realm, catalog, catalog version and
+ * metadata file location. Metadata files are immutable once written, so an entry never becomes
+ * stale and the location acts as a content address. Callers resolve and validate storage access for
+ * the location before consulting the cache, so a hit only skips the object-storage read, never any
+ * authorization. The raw JSON is cached rather than parsed {@link org.apache.iceberg.TableMetadata}
+ * objects because {@code TableMetadata} lazily materializes some fields and is not safe to share
+ * across request threads, and raw documents allow bounding the cache by size. Entry weights
+ * estimate heap usage (UTF-16 characters plus per-entry map and object overhead); the configured
+ * budget is an approximate bound because eviction may briefly lag writes.
+ */
+@ApplicationScoped
+public class TableMetadataCache {
+
+  /**
+   * Scopes a metadata document to the realm and catalog that is allowed to read it, and to the
+   * catalog entity version that produced it. The version changes whenever the catalog is updated,
+   * so a storage-binding change (new endpoint, region or role) yields a fresh key and never serves
+   * a document loaded through the previous binding.
+   */
+  public record Key(String realmId, long catalogId, long catalogVersion, String metadataLocation) {}
+
+  private static final Duration EXPIRE_AFTER_ACCESS = Duration.ofHours(1);
+
+  /** Estimated heap cost of a cache entry beyond its strings: map node and key record. */
+  private static final int ENTRY_OVERHEAD_BYTES = 64;
+
+  /** Estimated heap size of an empty {@link String}: object headers, fields and byte[] header. */
+  private static final int STRING_INSTANCE_SIZE = 48;
+
+  private final boolean enabled;
+  private final Cache<Key, String> metadataJsonByLocation;
+
+  @Inject
+  public TableMetadataCache(TableMetadataCacheConfiguration configuration) {
+    this.enabled = configuration.maxBytes() > 0;
+    this.metadataJsonByLocation =
+        Caffeine.newBuilder()
+            .maximumWeight(configuration.maxBytes())
+            .weigher(TableMetadataCache::estimatedEntryHeapBytes)
+            // Run maintenance on the writing threads so eviction keeps up with inserts instead of
+            // waiting for an executor, keeping the overshoot past the budget small.
+            .executor(Runnable::run)
+            .expireAfterAccess(EXPIRE_AFTER_ACCESS)
+            .build();
+  }
+
+  private static int estimatedEntryHeapBytes(Key key, String metadataJson) {
+    long bytes =
+        ENTRY_OVERHEAD_BYTES
+            + estimatedSizeOf(key.realmId())
+            + estimatedSizeOf(key.metadataLocation())
+            + estimatedSizeOf(metadataJson);
+    return (int) Math.min(bytes, Integer.MAX_VALUE);
+  }
+
+  /** Estimated heap size of a string: instance overhead plus two bytes per UTF-16 code unit. */
+  private static long estimatedSizeOf(String value) {
+    return STRING_INSTANCE_SIZE + (long) value.length() * Character.BYTES;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  /**
+   * Returns the table metadata at the key's immutable location, reading it through the given {@link
+   * FileIO} on a cache miss. A document that cannot be read or parsed surfaces as {@link
+   * RuntimeIOException}.
+   */
+  public TableMetadata getOrLoadMetadata(Key key, FileIO fileIO) {
+    String metadataJson = getOrLoad(key, fileIO);
+    try {
+      return TableMetadataParser.fromJson(key.metadataLocation(), metadataJson);
+    } catch (UncheckedIOException e) {
+      throw new RuntimeIOException(
+          e.getCause(), "Failed to parse metadata file %s", key.metadataLocation());
+    }
+  }
+
+  /**
+   * Returns the metadata JSON document at the key's immutable location, reading it through the
+   * given {@link FileIO} on a cache miss. The read happens outside the cache's compute so a slow
+   * object-storage read never blocks access to other keys; concurrent misses for the same key may
+   * read the same immutable document more than once.
+   */
+  @VisibleForTesting
+  String getOrLoad(Key key, FileIO fileIO) {
+    if (!enabled) {
+      return read(fileIO, key.metadataLocation());
+    }
+    String cached = metadataJsonByLocation.getIfPresent(key);
+    if (cached != null) {
+      return cached;
+    }
+    String metadataJson = read(fileIO, key.metadataLocation());
+    metadataJsonByLocation.put(key, metadataJson);
+    return metadataJson;
+  }
+
+  public void put(Key key, String metadataJson) {
+    if (enabled) {
+      metadataJsonByLocation.put(key, metadataJson);
+    }
+  }
+
+  private static String read(FileIO fileIO, String metadataLocation) {
+    InputFile inputFile = fileIO.newInputFile(metadataLocation);
+    TableMetadataParser.Codec codec = TableMetadataParser.Codec.fromFileName(metadataLocation);
+    try (InputStream stream =
+        codec == TableMetadataParser.Codec.GZIP
+            ? new GZIPInputStream(inputFile.newStream())
+            : inputFile.newStream()) {
+      return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to read metadata file %s", metadataLocation);
+    }
+  }
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataCacheConfiguration.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/TableMetadataCacheConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
+import jakarta.validation.constraints.Min;
+
+/**
+ * Configuration for the process-wide cache of table metadata JSON documents, keyed by realm,
+ * catalog ID, catalog version, and metadata file location. Metadata files are immutable, so cached
+ * entries never go stale.
+ */
+@ConfigMapping(prefix = "polaris.table-metadata-cache")
+public interface TableMetadataCacheConfiguration {
+
+  /**
+   * Approximate upper bound on the heap used by cached table metadata JSON documents, in bytes,
+   * including an estimate of per-entry overhead. Eviction may briefly lag writes, so budget this
+   * cache with headroom alongside the other in-memory caches (such as the entity cache). Zero
+   * disables caching.
+   */
+  @WithName("max-bytes")
+  @WithDefault("134217728")
+  @Min(0)
+  long maxBytes();
+}

--- a/runtime/service/src/main/java/org/apache/polaris/service/context/catalog/PolarisLocalCatalogFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/context/catalog/PolarisLocalCatalogFactory.java
@@ -33,6 +33,7 @@ import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.service.catalog.iceberg.LocalIcebergCatalog;
+import org.apache.polaris.service.catalog.iceberg.TableMetadataCache;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.catalog.io.StorageAccessConfigProvider;
 import org.apache.polaris.service.events.PolarisEventDispatcher;
@@ -56,6 +57,7 @@ public class PolarisLocalCatalogFactory implements LocalCatalogFactory {
   private final PolarisMetaStoreManager metaStoreManager;
   private final CallContext callContext;
   private final PolarisPrincipal principal;
+  private final TableMetadataCache tableMetadataCache;
   private final IdempotencyRequestContext idempotencyRequestContext;
 
   @Inject
@@ -70,6 +72,7 @@ public class PolarisLocalCatalogFactory implements LocalCatalogFactory {
       PolarisMetaStoreManager metaStoreManager,
       CallContext callContext,
       PolarisPrincipal principal,
+      TableMetadataCache tableMetadataCache,
       IdempotencyRequestContext idempotencyRequestContext) {
     this.diagnostics = diagnostics;
     this.resolverFactory = resolverFactory;
@@ -81,6 +84,7 @@ public class PolarisLocalCatalogFactory implements LocalCatalogFactory {
     this.metaStoreManager = metaStoreManager;
     this.callContext = callContext;
     this.principal = principal;
+    this.tableMetadataCache = tableMetadataCache;
     this.idempotencyRequestContext = idempotencyRequestContext;
   }
 
@@ -106,6 +110,7 @@ public class PolarisLocalCatalogFactory implements LocalCatalogFactory {
             fileIOFactory,
             polarisEventDispatcher,
             eventMetadataFactory,
+            tableMetadataCache,
             idempotencyRequestContext);
 
     Map<String, String> catalogProperties = new HashMap<>(catalog.getPropertiesAsMap());

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestBase.java
@@ -76,6 +76,7 @@ import org.apache.polaris.core.storage.cache.StorageCredentialCache;
 import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.generic.PolarisGenericTableCatalog;
 import org.apache.polaris.service.catalog.iceberg.LocalIcebergCatalog;
+import org.apache.polaris.service.catalog.iceberg.TableMetadataCache;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.catalog.io.StorageAccessConfigProvider;
 import org.apache.polaris.service.catalog.policy.PolicyCatalog;
@@ -482,7 +483,8 @@ public abstract class PolarisAuthzTestBase {
             storageAccessConfigProvider,
             fileIOFactory,
             polarisEventDispatcher,
-            eventMetadataFactory);
+            eventMetadataFactory,
+            new TableMetadataCache(() -> 0));
     this.baseCatalog.initialize(
         CATALOG_NAME,
         ImmutableMap.of(
@@ -499,7 +501,7 @@ public abstract class PolarisAuthzTestBase {
 
     @SuppressWarnings("unused") // Required by CDI
     protected TestPolarisLocalCatalogFactory() {
-      this(null, null, null, null, null, null, null, null, null, null, null);
+      this(null, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     @Inject
@@ -514,6 +516,7 @@ public abstract class PolarisAuthzTestBase {
         PolarisMetaStoreManager metaStoreManager,
         CallContext callContext,
         PolarisPrincipal principal,
+        TableMetadataCache tableMetadataCache,
         IdempotencyRequestContext idempotencyRequestContext) {
       super(
           diagnostics,
@@ -526,6 +529,7 @@ public abstract class PolarisAuthzTestBase {
           metaStoreManager,
           callContext,
           principal,
+          tableMetadataCache,
           idempotencyRequestContext);
     }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
@@ -64,6 +64,7 @@ import org.apache.polaris.service.admin.PolarisAdminService;
 import org.apache.polaris.service.admin.PolarisAdminServiceTestSupport;
 import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.iceberg.LocalIcebergCatalog;
+import org.apache.polaris.service.catalog.iceberg.TableMetadataCache;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.catalog.io.StorageAccessConfigProvider;
 import org.apache.polaris.service.config.ReservedProperties;
@@ -248,7 +249,8 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
             storageAccessConfigProvider,
             fileIOFactory,
             new InMemoryEventCollector(),
-            eventMetadataFactory);
+            eventMetadataFactory,
+            new TableMetadataCache(() -> 0));
     this.icebergCatalog.initialize(
         CATALOG_NAME,
         ImmutableMap.of(

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
@@ -2119,6 +2119,7 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
         metaStoreManager,
         callContext,
         authenticatedRoot,
+        new TableMetadataCache(() -> 0),
         new IdempotencyRequestContext(
             new IdempotencyConfiguration() {
               @Override

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogOverlapTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogOverlapTest.java
@@ -254,7 +254,8 @@ public abstract class AbstractLocalIcebergCatalogOverlapTest {
         storageAccessConfigProvider,
         fileIOFactory,
         polarisEventDispatcher,
-        eventMetadataFactory);
+        eventMetadataFactory,
+        new TableMetadataCache(() -> 0));
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -454,6 +454,15 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
 
   protected LocalIcebergCatalog newIcebergCatalog(
       String catalogName, PolarisMetaStoreManager metaStoreManager, FileIOFactory fileIOFactory) {
+    return newIcebergCatalog(
+        catalogName, metaStoreManager, fileIOFactory, new TableMetadataCache(() -> 1024 * 1024));
+  }
+
+  protected LocalIcebergCatalog newIcebergCatalog(
+      String catalogName,
+      PolarisMetaStoreManager metaStoreManager,
+      FileIOFactory fileIOFactory,
+      TableMetadataCache tableMetadataCache) {
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
             resolutionManifestFactory, authenticatedRoot, catalogName);
@@ -469,7 +478,8 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
         storageAccessConfigProvider,
         fileIOFactory,
         polarisEventDispatcher,
-        eventMetadataFactory);
+        eventMetadataFactory,
+        tableMetadataCache);
   }
 
   @Test
@@ -573,6 +583,33 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     Assertions.assertThatThrownBy(() -> catalog.createNamespace(child1))
         .isInstanceOf(NoSuchNamespaceException.class)
         .hasMessageContaining("Parent");
+  }
+
+  @Test
+  public void testCommitSucceedsWhenMetadataCachePopulationFails() {
+    TableMetadataCache throwingCache =
+        new TableMetadataCache(() -> 1024 * 1024) {
+          @Override
+          public void put(TableMetadataCache.Key key, String metadataJson) {
+            throw new RuntimeException("cache population failed");
+          }
+        };
+    LocalIcebergCatalog catalog =
+        newIcebergCatalog(CATALOG_NAME, metaStoreManager, fileIOFactory, throwingCache);
+    catalog.setCatalogFileIo(new InMemoryFileIO());
+    catalog.initialize(
+        CATALOG_NAME,
+        ImmutableMap.<String, String>builder()
+            .put(CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO")
+            .putAll(TABLE_PREFIXES)
+            .buildKeepingLast());
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(NS);
+    }
+    catalog.buildTable(TABLE, SCHEMA).create();
+    catalog.loadTable(TABLE).newFastAppend().appendFile(FILE_A).commit();
+    assertFiles(catalog.loadTable(TABLE), FILE_A);
   }
 
   @Test
@@ -3018,15 +3055,19 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
             catalog.newTableOps(TABLE, updateMetadataOnCommit);
     LocalIcebergCatalog.BasePolarisTableOperations ops = Mockito.spy(realOps);
 
+    // Refreshes parse the metadata document through fromJson(location, json); with the cache
+    // disabled in tests its invocation count equals the number of metadata loads from storage.
     try (MockedStatic<TableMetadataParser> mocked =
         Mockito.mockStatic(TableMetadataParser.class, Mockito.CALLS_REAL_METHODS)) {
       TableMetadata base1 = ops.current();
       mocked.verify(
-          () -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()), Mockito.times(1));
+          () -> TableMetadataParser.fromJson(Mockito.anyString(), Mockito.anyString()),
+          Mockito.times(1));
 
       TableMetadata base2 = ops.refresh();
       mocked.verify(
-          () -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()), Mockito.times(1));
+          () -> TableMetadataParser.fromJson(Mockito.anyString(), Mockito.anyString()),
+          Mockito.times(1));
 
       Assertions.assertThat(base1.metadataFileLocation()).isEqualTo(base2.metadataFileLocation());
       Assertions.assertThat(base1).isEqualTo(base2);
@@ -3037,20 +3078,49 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
           TableMetadata.buildFrom(base1).setCurrentSchema(newSchema, 100).build();
       ops.commit(base2, newMetadata);
       mocked.verify(
-          () -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()), Mockito.times(1));
+          () -> TableMetadataParser.fromJson(Mockito.anyString(), Mockito.anyString()),
+          Mockito.times(1));
 
       ops.current();
       int expectedReads = updateMetadataOnCommit ? 1 : 2;
       mocked.verify(
-          () -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()),
+          () -> TableMetadataParser.fromJson(Mockito.anyString(), Mockito.anyString()),
           Mockito.times(expectedReads));
       ops.refresh();
       mocked.verify(
-          () -> TableMetadataParser.read(Mockito.any(), Mockito.anyString()),
+          () -> TableMetadataParser.fromJson(Mockito.anyString(), Mockito.anyString()),
           Mockito.times(expectedReads));
     } finally {
       catalog.dropTable(TABLE, true);
     }
+  }
+
+  @Test
+  public void testRefreshAfterCommitServedFromMetadataCache() {
+    Assumptions.assumeTrue(
+        requiresNamespaceCreate(),
+        "Only applicable if namespaces must be created before adding children");
+
+    MeasuredFileIOFactory measured = new MeasuredFileIOFactory();
+    LocalIcebergCatalog cachingCatalog =
+        newIcebergCatalog(
+            CATALOG_NAME, metaStoreManager, measured, new TableMetadataCache(() -> 1024 * 1024));
+    cachingCatalog.initialize(
+        CATALOG_NAME,
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
+    cachingCatalog.createNamespace(NS);
+    cachingCatalog.buildTable(TABLE, SCHEMA).create();
+
+    // The commit seeded the cache, so a fresh ops instance refreshes without reading storage.
+    measured.newInputFileExceptionSupplier =
+        Optional.of(() -> new RuntimeException("metadata should be served from the cache"));
+    TableMetadata metadata = cachingCatalog.newTableOps(TABLE).current();
+    Assertions.assertThat(metadata).isNotNull();
+    Assertions.assertThat(metadata.schema().columns()).hasSameSizeAs(SCHEMA.columns());
+
+    measured.newInputFileExceptionSupplier = Optional.empty();
+    cachingCatalog.dropTable(TABLE, true);
   }
 
   @ParameterizedTest

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogViewTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogViewTest.java
@@ -221,7 +221,8 @@ public abstract class AbstractLocalIcebergCatalogViewTest
             storageAccessConfigProvider,
             fileIOFactory,
             polarisEventDispatcher,
-            eventMetadataFactory);
+            eventMetadataFactory,
+            new TableMetadataCache(() -> 1024 * 1024));
     Map<String, String> properties =
         ImmutableMap.<String, String>builder()
             .put(CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO")
@@ -335,7 +336,8 @@ public abstract class AbstractLocalIcebergCatalogViewTest
             storageAccessConfigProvider,
             spiedFactory,
             polarisEventDispatcher,
-            eventMetadataFactory);
+            eventMetadataFactory,
+            new TableMetadataCache(() -> 1024 * 1024));
     spiedCatalog.initialize(
         CATALOG_NAME,
         ImmutableMap.<String, String>builder()

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalogTest.java
@@ -107,7 +107,8 @@ class LocalIcebergCatalogTest {
             null,
             null,
             null,
-            null);
+            null,
+            new TableMetadataCache(() -> 0));
   }
 
   @Test

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/TableMetadataCacheTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/TableMetadataCacheTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.iceberg;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.inmemory.InMemoryFileIO;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TableMetadataCacheTest {
+
+  private static final String LOCATION = "memory://bucket/metadata/00000-abc.metadata.json";
+  private static final String METADATA_JSON = "{\"format-version\":2}";
+
+  private final AtomicInteger storageReads = new AtomicInteger();
+
+  private FileIO countingFileIO() {
+    InMemoryFileIO fileIO =
+        new InMemoryFileIO() {
+          @Override
+          public InputFile newInputFile(String location) {
+            storageReads.incrementAndGet();
+            return super.newInputFile(location);
+          }
+        };
+    fileIO.addFile(LOCATION, METADATA_JSON.getBytes(StandardCharsets.UTF_8));
+    return fileIO;
+  }
+
+  private static TableMetadataCache.Key key(long catalogId) {
+    return new TableMetadataCache.Key("realm", catalogId, 1, LOCATION);
+  }
+
+  private static TableMetadataCache.Key key(long catalogId, long catalogVersion) {
+    return new TableMetadataCache.Key("realm", catalogId, catalogVersion, LOCATION);
+  }
+
+  @Test
+  public void testSecondLoadServedFromCache() {
+    TableMetadataCache cache = new TableMetadataCache(() -> 1024 * 1024);
+    Assertions.assertThat(cache.isEnabled()).isTrue();
+    Assertions.assertThat(cache.getOrLoad(key(1), countingFileIO())).isEqualTo(METADATA_JSON);
+    Assertions.assertThat(cache.getOrLoad(key(1), countingFileIO())).isEqualTo(METADATA_JSON);
+    Assertions.assertThat(storageReads).hasValue(1);
+  }
+
+  @Test
+  public void testEntriesScopedByCatalog() {
+    TableMetadataCache cache = new TableMetadataCache(() -> 1024 * 1024);
+    cache.getOrLoad(key(1), countingFileIO());
+    cache.getOrLoad(key(2), countingFileIO());
+    Assertions.assertThat(storageReads).hasValue(2);
+  }
+
+  @Test
+  public void testEntriesScopedByCatalogVersion() {
+    TableMetadataCache cache = new TableMetadataCache(() -> 1024 * 1024);
+    cache.getOrLoad(key(1, 1), countingFileIO());
+    cache.getOrLoad(key(1, 2), countingFileIO());
+    Assertions.assertThat(storageReads).hasValue(2);
+  }
+
+  @Test
+  public void testReadFailureThrowsRuntimeIOException() {
+    String gzipLocation = "memory://bucket/metadata/00000-abc.gz.metadata.json";
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    // Bytes are not gzip-encoded though the name selects the GZIP codec, so the read fails.
+    fileIO.addFile(gzipLocation, METADATA_JSON.getBytes(StandardCharsets.UTF_8));
+    TableMetadataCache cache = new TableMetadataCache(() -> 1024 * 1024);
+    Assertions.assertThatThrownBy(
+            () -> cache.getOrLoad(new TableMetadataCache.Key("realm", 1, 1, gzipLocation), fileIO))
+        .isInstanceOf(RuntimeIOException.class);
+  }
+
+  @Test
+  public void testMalformedJsonThrowsRuntimeIOException() {
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    fileIO.addFile(LOCATION, "{not json".getBytes(StandardCharsets.UTF_8));
+    TableMetadataCache cache = new TableMetadataCache(() -> 1024 * 1024);
+    Assertions.assertThatThrownBy(() -> cache.getOrLoadMetadata(key(1), fileIO))
+        .isInstanceOf(RuntimeIOException.class);
+  }
+
+  @Test
+  public void testPutSeedsSubsequentLoads() {
+    TableMetadataCache cache = new TableMetadataCache(() -> 1024 * 1024);
+    cache.put(key(1), METADATA_JSON);
+    Assertions.assertThat(cache.getOrLoad(key(1), countingFileIO())).isEqualTo(METADATA_JSON);
+    Assertions.assertThat(storageReads).hasValue(0);
+  }
+
+  @Test
+  public void testZeroBudgetDisablesCaching() {
+    TableMetadataCache cache = new TableMetadataCache(() -> 0);
+    Assertions.assertThat(cache.isEnabled()).isFalse();
+    cache.getOrLoad(key(1), countingFileIO());
+    cache.getOrLoad(key(1), countingFileIO());
+    Assertions.assertThat(storageReads).hasValue(2);
+  }
+
+  @Test
+  public void testEntryHeavierThanBudgetNotCached() {
+    TableMetadataCache cache = new TableMetadataCache(() -> 10);
+    Assertions.assertThat(cache.isEnabled()).isTrue();
+    cache.getOrLoad(key(1), countingFileIO());
+    cache.getOrLoad(key(1), countingFileIO());
+    Assertions.assertThat(storageReads).hasValue(2);
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
@@ -48,6 +48,7 @@ import org.apache.polaris.core.persistence.pagination.PageToken;
 import org.apache.polaris.service.TestServices;
 import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.iceberg.LocalIcebergCatalog;
+import org.apache.polaris.service.catalog.iceberg.TableMetadataCache;
 import org.apache.polaris.service.storage.aws.S3AccessConfig;
 import org.apache.polaris.service.task.TaskFileIOSupplier;
 import org.assertj.core.api.Assertions;
@@ -221,7 +222,8 @@ public class FileIOFactoryTest {
             services.storageAccessConfigProvider(),
             services.fileIOFactory(),
             services.polarisEventDispatcher(),
-            services.eventMetadataFactory());
+            services.eventMetadataFactory(),
+            new TableMetadataCache(() -> 0));
     polarisCatalog.initialize(
         CATALOG_NAME,
         ImmutableMap.of(

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
@@ -80,6 +80,7 @@ import org.apache.polaris.service.admin.PolarisAdminService;
 import org.apache.polaris.service.admin.PolarisAdminServiceTestSupport;
 import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.iceberg.LocalIcebergCatalog;
+import org.apache.polaris.service.catalog.iceberg.TableMetadataCache;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.catalog.io.StorageAccessConfigProvider;
 import org.apache.polaris.service.config.ReservedProperties;
@@ -269,7 +270,8 @@ public abstract class AbstractPolicyCatalogTest {
             storageAccessConfigProvider,
             fileIOFactory,
             new InMemoryEventCollector(),
-            eventMetadataFactory);
+            eventMetadataFactory,
+            new TableMetadataCache(() -> 0));
     this.icebergCatalog.initialize(
         CATALOG_NAME,
         ImmutableMap.of(

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -96,6 +96,7 @@ import org.apache.polaris.service.catalog.iceberg.IcebergRestConfigEndpoints;
 import org.apache.polaris.service.catalog.iceberg.IcebergRestConfigurationEventServiceDelegator;
 import org.apache.polaris.service.catalog.iceberg.IcebergViewConfigEndpoints;
 import org.apache.polaris.service.catalog.iceberg.ImmutableIcebergCatalogHandler;
+import org.apache.polaris.service.catalog.iceberg.TableMetadataCache;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.catalog.io.MeasuredFileIOFactory;
 import org.apache.polaris.service.catalog.io.StorageAccessConfigProvider;
@@ -398,6 +399,7 @@ public record TestServices(
               metaStoreManager,
               callContext,
               principal,
+              new TableMetadataCache(() -> 0),
               idempotencyRequestContext);
 
       ReservedProperties reservedProperties = ReservedProperties.NONE;

--- a/site/content/in-dev/unreleased/configuration/config-sections/smallrye-polaris_table_metadata_cache.md
+++ b/site/content/in-dev/unreleased/configuration/config-sections/smallrye-polaris_table_metadata_cache.md
@@ -1,0 +1,30 @@
+---
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+title: smallrye-polaris_table_metadata_cache
+build:
+  list: never
+  render: never
+---
+
+Configuration for the process-wide cache of table metadata JSON documents, keyed by realm,  catalog ID, catalog version, and metadata file location.  Metadata files are immutable, so cached  entries never go stale.
+
+| Property | Default Value | Type | Description |
+|----------|---------------|------|-------------|
+| `polaris.table-metadata-cache.max-bytes` | `134217728` | `long` | Approximate upper bound on the heap used by cached table metadata JSON documents, in bytes,  including an estimate of per-entry overhead.  Eviction may briefly lag writes, so budget this  cache with headroom alongside the other in-memory caches (such as the entity cache). Zero  disables caching.  |


### PR DESCRIPTION
Metadata files are immutable, so table refreshes can be served from a process-wide cache keyed by metadata file location instead of re-reading `metadata.json` from object storage on every request. Successful commits seed the cache with the metadata they just committed. The key also includes the realm, catalog id and catalog entity version, so a catalog storage change never serves a document loaded through the previous binding.

The cache stores the raw JSON document rather than a parsed `TableMetadata`, because parsed metadata lazily materializes internal state and is not safe to share across threads (see apache/iceberg#17585), and the string length gives a size-bounded cache.

New configuration:
- `polaris.table-metadata-cache.max-bytes`: approximate heap budget (default 128 MiB, `0` disables caching).
- `polaris.table-metadata-cache.max-content-length`: largest document admitted (default 8 MiB), so one oversized document cannot evict the working set.

Benchmarked with 3 batches of 250 concurrent `INSERT`s into one Iceberg table through Trino: about 6000 object-storage metadata reads per 750 commits were served from the cache, with unchanged end-to-end latency.

Developed with AI assistance (Claude Code).

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)

