### PR TITLE
fix(jdbc): key the policy mapping delete on the identity columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Upgrade notes
 
+- Relational JDBC: schema version 6 corrects the `idx_locations` index on Postgres and CockroachDB
+  (see Fixes). Fresh bootstraps use schema v6 automatically and get the right index. Because Polaris
+  has no automated schema migrations, existing Postgres/CockroachDB deployments keep the old,
+  ineffective index until an operator recreates it manually:
+  ```sql
+  DROP INDEX polaris_schema.idx_locations;
+  CREATE INDEX idx_locations ON polaris_schema.entities USING btree (realm_id, catalog_id, location_without_scheme)
+    WHERE location_without_scheme IS NOT NULL;
+  ```
+  H2 is unaffected.
+
 ### Breaking changes
 
 - Concurrent table commits that hit a stale sequence number now return a retryable `409` instead of a fatal `400`, for both single-table commits and `commitTransaction`.
@@ -46,6 +57,12 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 
+- Relational JDBC: the `idx_locations` index used by the optimized sibling check now matches the
+  query that reads it. On Postgres and CockroachDB the index led with `parent_id`, while the overlap
+  query filters `catalog_id`, so with `OPTIMIZED_SIBLING_CHECK` enabled every `CREATE TABLE` /
+  `CREATE NAMESPACE` fell back to a realm-wide scan instead of the intended indexed lookup. A new
+  schema version 6 creates the index on `(realm_id, catalog_id, location_without_scheme)`; H2 was
+  already correct. Existing deployments need a manual index recreation — see Upgrade notes.
 - Python CLI `setup export` now writes each catalog's `policies` as a list of
   `{name, namespace, ...}` entries instead of the previous name-keyed mapping, preserving policies
   with the same name in different namespaces. The new export format cannot be applied by older CLI
@@ -66,6 +83,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Python CLI `setup` now preserves `endpoint_internal` and `sts_endpoint` during apply and export for S3 configuration
 - Fixed a false-negative in the JDBC optimized location-overlap check (`OPTIMIZED_SIBLING_CHECK`). Ancestor locations stored in `location_without_scheme` without a trailing slash were not matched by the generated ancestor equality terms, allowing nested table/namespace locations to be created under existing prefixes. The query now emits both slash-terminated and non-slash-terminated prefix terms and uses a slash-terminated `LIKE` pattern for descendant matching.
 - Python CLI `setup` now preserves the Azure `hierarchical` storage flag during apply and export
+- Fixed policy detach on the relational JDBC backend silently doing nothing when the mapping's `parameters` changed in between. The delete's `WHERE` clause included the non-key `parameters` column, so a re-attach landing between the detach's lookup and its delete made the delete match zero rows while detach still reported success, leaving the policy attached. The delete is now keyed on the mapping's identity columns, matching the table's primary key and the transactional backend's behavior.
 
 ### Commits
 

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -1139,20 +1139,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
         // inheritable.
         throw new PolicyMappingAlreadyExistsException(existingRecord);
       }
-      Map<String, Object> updateClause =
-          Map.of(
-              "target_catalog_id",
-              record.getTargetCatalogId(),
-              "target_id",
-              record.getTargetId(),
-              "policy_type_code",
-              record.getPolicyTypeCode(),
-              "policy_id",
-              record.getPolicyId(),
-              "policy_catalog_id",
-              record.getPolicyCatalogId(),
-              "realm_id",
-              realmId);
+      Map<String, Object> updateClause = policyMappingIdentity(record);
       // In case of the mapping exist, update the policy mapping with the new parameters.
       ModelPolicyMappingRecord modelPolicyMappingRecord =
           ModelPolicyMappingRecord.fromPolicyMappingRecord(record);
@@ -1174,19 +1161,50 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
     return true;
   }
 
+  /**
+   * Builds the identity of a policy mapping row: the target and policy ids plus the policy type,
+   * scoped to the realm. These are exactly the table's primary key columns. The mutable {@code
+   * parameters} payload is deliberately excluded, so a concurrent update of the parameters cannot
+   * make a lookup miss or turn a delete into a no-op.
+   */
+  private Map<String, Object> policyMappingIdentity(@NonNull PolarisPolicyMappingRecord record) {
+    return policyMappingIdentity(
+        record.getTargetCatalogId(),
+        record.getTargetId(),
+        record.getPolicyTypeCode(),
+        record.getPolicyCatalogId(),
+        record.getPolicyId());
+  }
+
+  private Map<String, Object> policyMappingIdentity(
+      long targetCatalogId,
+      long targetId,
+      int policyTypeCode,
+      long policyCatalogId,
+      long policyId) {
+    return Map.of(
+        "target_catalog_id",
+        targetCatalogId,
+        "target_id",
+        targetId,
+        "policy_type_code",
+        policyTypeCode,
+        "policy_id",
+        policyId,
+        "policy_catalog_id",
+        policyCatalogId,
+        "realm_id",
+        realmId);
+  }
+
   @Override
   public void deleteFromPolicyMappingRecords(
       @NonNull PolarisCallContext callCtx, @NonNull PolarisPolicyMappingRecord record) {
-    var modelPolicyMappingRecord = ModelPolicyMappingRecord.fromPolicyMappingRecord(record);
     try {
-      Map<String, Object> objectMap =
-          modelPolicyMappingRecord.toMap(datasourceOperations.getDatabaseType());
-      objectMap.put("realm_id", realmId);
+      Map<String, Object> params = policyMappingIdentity(record);
       datasourceOperations.executeUpdate(
           QueryGenerator.generateDeleteQuery(
-              ModelPolicyMappingRecord.ALL_COLUMNS,
-              ModelPolicyMappingRecord.TABLE_NAME,
-              objectMap));
+              ModelPolicyMappingRecord.ALL_COLUMNS, ModelPolicyMappingRecord.TABLE_NAME, params));
     } catch (SQLException e) {
       throw new RuntimeException(
           String.format("Failed to write to policy records due to %s", e.getMessage()), e);
@@ -1232,19 +1250,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       long policyCatalogId,
       long policyId) {
     Map<String, Object> params =
-        Map.of(
-            "target_catalog_id",
-            targetCatalogId,
-            "target_id",
-            targetId,
-            "policy_type_code",
-            policyTypeCode,
-            "policy_id",
-            policyId,
-            "policy_catalog_id",
-            policyCatalogId,
-            "realm_id",
-            realmId);
+        policyMappingIdentity(targetCatalogId, targetId, policyTypeCode, policyCatalogId, policyId);
     List<PolarisPolicyMappingRecord> results =
         fetchPolicyMappingRecords(
             QueryGenerator.generateSelectQuery(

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImplTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImplTest.java
@@ -35,6 +35,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDefaultDiagServiceImpl;
@@ -50,6 +51,8 @@ import org.apache.polaris.core.persistence.EntityAlreadyExistsException;
 import org.apache.polaris.core.persistence.RetryOnConcurrencyException;
 import org.apache.polaris.core.persistence.pagination.Page;
 import org.apache.polaris.core.persistence.pagination.PageToken;
+import org.apache.polaris.core.policy.PolarisPolicyMappingRecord;
+import org.apache.polaris.core.policy.PredefinedPolicyTypes;
 import org.h2.jdbcx.JdbcConnectionPool;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -66,6 +69,10 @@ class JdbcBasePersistenceImplTest {
   private static final long GRANTEE_CATALOG_ID = 3L;
   private static final long GRANTEE_ID = 4L;
   private static final int PRIVILEGE_CODE = 21;
+  private static final long POLICY_TARGET_CATALOG_ID = 11L;
+  private static final long POLICY_TARGET_ID = 12L;
+  private static final long POLICY_CATALOG_ID = 13L;
+  private static final long POLICY_ID = 14L;
 
   @ParameterizedTest
   @ValueSource(ints = {1, 2, 3, 4, 5})
@@ -329,6 +336,66 @@ class JdbcBasePersistenceImplTest {
     assertThat(impl.lookupEntityGrantRecordsVersion(callCtx, 0L, 201L)).isEqualTo(5);
     assertThat(impl.lookupEntityGrantRecordsVersion(callCtx, 0L, 202L)).isEqualTo(9);
     assertThat(impl.lookupEntityGrantRecordsVersion(callCtx, 0L, 999L)).isEqualTo(0);
+  }
+
+  /**
+   * A mapping is identified by its target and policy ids plus the policy type, not by its
+   * parameters. Detach reads the mapping record and then deletes it in a separate round-trip, so a
+   * re-attach that rewrites the parameters in between leaves the caller holding a record whose
+   * parameters no longer match the stored row. The delete must still remove that row.
+   */
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 3, 4, 5})
+  void deleteFromPolicyMappingRecordsIgnoresConcurrentParametersUpdate(int schemaVersion)
+      throws SQLException, IOException {
+    DatasourceOperations datasourceOperations =
+        newH2DatasourceOperations("policy_mapping_delete_v", schemaVersion);
+    TestPersistence tp = newTestPersistence(datasourceOperations, schemaVersion);
+    JdbcBasePersistenceImpl impl = tp.impl();
+    PolarisCallContext callCtx = tp.callCtx();
+
+    int policyTypeCode = PredefinedPolicyTypes.DATA_COMPACTION.getCode();
+    PolarisPolicyMappingRecord attached =
+        newTestPolicyMappingRecord(policyTypeCode, Map.of("version", "1"));
+    impl.writeToPolicyMappingRecords(callCtx, attached);
+
+    // A re-attach of the same policy updates the parameters of the existing row in place.
+    impl.writeToPolicyMappingRecords(
+        callCtx, newTestPolicyMappingRecord(policyTypeCode, Map.of("version", "2")));
+
+    // Guard the premise: the re-attach must really have replaced the stored payload. Were it ever
+    // to become a no-op, the stored parameters would still match the stale record below and even a
+    // delete that keys on parameters would pass this test.
+    PolarisPolicyMappingRecord reattached = lookupTestPolicyMapping(impl, callCtx, policyTypeCode);
+    assertThat(reattached).isNotNull();
+    assertThat(reattached.getParametersAsMap()).isEqualTo(Map.of("version", "2"));
+
+    // Detach deletes the record it looked up before that update, so its parameters are stale.
+    impl.deleteFromPolicyMappingRecords(callCtx, attached);
+
+    assertThat(lookupTestPolicyMapping(impl, callCtx, policyTypeCode)).isNull();
+  }
+
+  private static PolarisPolicyMappingRecord lookupTestPolicyMapping(
+      JdbcBasePersistenceImpl impl, PolarisCallContext callCtx, int policyTypeCode) {
+    return impl.lookupPolicyMappingRecord(
+        callCtx,
+        POLICY_TARGET_CATALOG_ID,
+        POLICY_TARGET_ID,
+        policyTypeCode,
+        POLICY_CATALOG_ID,
+        POLICY_ID);
+  }
+
+  private static PolarisPolicyMappingRecord newTestPolicyMappingRecord(
+      int policyTypeCode, Map<String, String> parameters) {
+    return new PolarisPolicyMappingRecord(
+        POLICY_TARGET_CATALOG_ID,
+        POLICY_TARGET_ID,
+        POLICY_CATALOG_ID,
+        POLICY_ID,
+        policyTypeCode,
+        parameters);
   }
 
   private static DatasourceOperations newH2DatasourceOperations(


### PR DESCRIPTION
The problem

On the relational JDBC backend, detaching a policy can report success while leaving the policy attached.

This can happen when a re-attach of the same policy races with detach. Re-attaching updates the mapping's parameters in place. If that update happens after detach reads the mapping but before it deletes it, detach holds a stale copy of parameters. The subsequent delete can then match zero rows, while the caller still observes a successful detach.

As a result, the policy remains applicable to the target even though the detach operation appeared to succeed.

Root Cause

deleteFromPolicyMappingRecords built its WHERE clause from ModelPolicyMappingRecord.toMap(), which contains all columns used to persist the mapping, including parameters.

However, parameters is mutable and is not part of the mapping's identity. Within a realm, a policy mapping is identified by: target_catalog_id, target_id, policy_type_code, policy_catalog_id, policy_id

A re-attach can therefore update parameters without changing the mapping itself. If detach subsequently deletes using the stale parameters value it previously read, the generated DELETE matches no rows.

The affected-row count is currently discarded, so this failure is not surfaced to the caller.

The fix

Build the policy-mapping delete predicate explicitly from the mapping's identity columns, plus realm_id, instead of reusing the full persistence map.

This keeps mutable parameters out of the WHERE clause and makes the JDBC delete consistent with the identity used by the corresponding lookup and update paths. A concurrent parameters update can no longer turn a later detach into a no-op simply because the detach holds a stale parameters payload.

Fixes #5306