### PR TITLE
Return Iceberg ErrorResponse envelope for server-side JSON processing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 
+- Iceberg REST: server-side JSON processing failures (HTTP 500) now return the standard Iceberg
+  error envelope (`{"error": {...}}`) instead of a flat `{"code", "message"}` body, so Iceberg
+  clients can parse the response rather than failing on an off-schema shape.
 - Python CLI `setup export` now writes each catalog's `policies` as a list of
   `{name, namespace, ...}` entries instead of the previous name-keyed mapping, preserving policies
   with the same name in different namespaces. The new export format cannot be applied by older CLI

--- a/runtime/service/src/main/java/org/apache/polaris/service/exception/IcebergJsonProcessingExceptionMapper.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/exception/IcebergJsonProcessingExceptionMapper.java
@@ -18,9 +18,6 @@
  */
 package org.apache.polaris.service.exception;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -35,7 +32,6 @@ import jakarta.ws.rs.ext.Provider;
 import java.util.Locale;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.iceberg.rest.responses.ErrorResponse;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,12 +42,6 @@ public class IcebergJsonProcessingExceptionMapper
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(IcebergJsonProcessingExceptionMapper.class);
-
-  @JsonInclude(Include.NON_NULL)
-  public record ErrorMessage(
-      @JsonProperty("code") int code,
-      @JsonProperty("message") @Nullable String message,
-      @JsonProperty("details") @Nullable String details) {}
 
   @Override
   public Response toResponse(JsonProcessingException exception) {
@@ -68,9 +58,15 @@ public class IcebergJsonProcessingExceptionMapper
               Locale.ROOT,
               "There was an error processing your request. It has been logged (ID %016x).",
               id);
-      return Response.status(Status.INTERNAL_SERVER_ERROR.getStatusCode())
+      ErrorResponse icebergErrorResponse =
+          ErrorResponse.builder()
+              .responseCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
+              .withType(exception.getClass().getSimpleName())
+              .withMessage(message)
+              .build();
+      return Response.status(Status.INTERNAL_SERVER_ERROR)
           .type(MediaType.APPLICATION_JSON_TYPE)
-          .entity(new ErrorMessage(500, message, null))
+          .entity(icebergErrorResponse)
           .build();
     }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
@@ -36,6 +36,8 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.ErrorResponseParser;
 import org.apache.polaris.core.exceptions.AlreadyExistsException;
 import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.exceptions.FileIOUnknownHostException;
@@ -119,6 +121,26 @@ public class ExceptionMapperTest {
         mapper.toResponse(new PolarisServiceUnavailableException(3, "transient conflict"));
     assertThat(response.getStatus()).isEqualTo(503);
     assertThat(response.getHeaderString(HttpHeaders.RETRY_AFTER)).isEqualTo("3");
+  }
+
+  @Test
+  public void testServerSideJsonErrorUsesIcebergErrorEnvelope() {
+    IcebergJsonProcessingExceptionMapper mapper = new IcebergJsonProcessingExceptionMapper();
+    Response response =
+        mapper.toResponse(new JsonGenerationException(MESSAGE, new RuntimeException(CAUSE), null));
+
+    assertThat(response.getStatus()).isEqualTo(500);
+    assertThat(response.getEntity()).isInstanceOf(ErrorResponse.class);
+
+    // The body must be a well-formed Iceberg error envelope so clients using
+    // ErrorResponseParser can parse the 500 instead of failing on an off-schema shape.
+    String json = ErrorResponseParser.toJson((ErrorResponse) response.getEntity());
+    assertThat(json).contains("\"error\"");
+    ErrorResponse parsed = ErrorResponseParser.fromJson(json);
+    assertThat(parsed.code()).isEqualTo(500);
+    assertThat(parsed.type()).isEqualTo(JsonGenerationException.class.getSimpleName());
+    // Generic, log-correlated message only — no internal exception detail leaked.
+    assertThat(parsed.message()).contains("has been logged").doesNotContain(MESSAGE);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
IcebergJsonProcessingExceptionMapper has two branches and they return different json shapes.

the user-error branch (bad request json) already returns the proper iceberg envelope `{"error":{"message","type","code"}}`. but the server-error branch (JsonGenerationException / InvalidDefinitionException) still returns a flat `{"code":500,"message":"..."}` body. thats leftover dropwizard shape (the class doc even points at dropwizard's JsonProcessingExceptionMapper). looks like when this was migrated to iceberg ErrorResponse only the user-error branch got updated and the server one got missed.

the problem is a client parsing that 500 with ErrorResponseParser.fromJson finds no `error` node and just throws a parse exception, so the original error gets masked.

so this changes the server-error branch to return the same iceberg ErrorResponse envelope, still http 500. i kept the generic "has been logged (ID ...)" message so no internal detail leaks. also removed the ErrorMessage record since nothing uses it anymore, and extended ExceptionMapperTest to check the 500 body actually round-trips through ErrorResponseParser (code == 500, right type, generic message).

no real behavior change other than the 500 body shape. only thing that'd notice is a client that was depending on the old flat `{"code","message"}` 500, and now it just gets the standard envelope every other polaris mapper already uses.