### PR TITLE
Fix NPE in IcebergExceptionMapper when a cloud exception has a null message

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/exception/IcebergExceptionMapper.java
@@ -118,6 +118,9 @@ public class IcebergExceptionMapper implements ExceptionMapper<RuntimeException>
   }
 
   public static boolean containsAnyAccessDeniedHint(String message) {
+    if (message == null) {
+      return false;
+    }
     String messageLower = message.toLowerCase(Locale.ENGLISH);
     return ACCESS_DENIED_HINTS.stream().anyMatch(messageLower::contains);
   }
@@ -133,7 +136,7 @@ public class IcebergExceptionMapper implements ExceptionMapper<RuntimeException>
       return false;
     }
 
-    if (t.getMessage() != null && containsAnyAccessDeniedHint(t.getMessage())) {
+    if (containsAnyAccessDeniedHint(t.getMessage())) {
       return false;
     }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/exception/ExceptionMapperTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.cloud.storage.StorageException;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
@@ -113,6 +114,21 @@ public class ExceptionMapperTest {
     PolarisExceptionMapper mapper = new PolarisExceptionMapper();
     Response response = mapper.toResponse(new CommitConflictException("test"));
     assertThat(response.getStatus()).isEqualTo(409);
+  }
+
+  @Test
+  public void testCloudExceptionWithNullMessageDoesNotNpe() {
+    // Regression: containsAnyAccessDeniedHint used to dereference a null message. A cloud
+    // exception with a null message reached the unguarded call in mapCloudExceptionToResponseCode,
+    // NPE'd, and that NPE escaped toResponse -> generic 500 with no Iceberg envelope.
+    assertThat(IcebergExceptionMapper.containsAnyAccessDeniedHint(null)).isFalse();
+
+    StorageException nullMessageCloudException = new StorageException(0, null);
+    assertThat(nullMessageCloudException.getMessage()).isNull();
+
+    Optional<Integer> code =
+        IcebergExceptionMapper.mapCloudExceptionToResponseCode(nullMessageCloudException);
+    assertThat(code).contains(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
containsAnyAccessDeniedHint dereferences its argument with no null check, it just does `message.toLowerCase(...)`.

theres two callers in the same class and they disagree. isStorageProviderRetryableException guards it with `t.getMessage() != null && containsAnyAccessDeniedHint(t.getMessage())`, but mapCloudExceptionToResponseCode calls it straight on the message: `containsAnyAccessDeniedHint(t.getMessage())`.

mapCloudExceptionToResponseCode runs for every S3/Azure/GCS exception in the causal chain, and getMessage() is nullable for those SDK exceptions. so if one of them has a null message it NPEs. and since this happens while the mapper is mapping another exception, the NPE escapes toResponse, so the client gets a generic container 500 with no iceberg envelope, for exactly the cloud access-denied case this was supposed to turn into a 403.

looks like a copy-omission: same helper, same nullable input, one call site guarded and one not.

so this null-checks inside the helper (return false on null) instead of just mirroring the guard. that fixes the unguarded caller, makes the != null in the other caller harmless, and protects any future caller. a null message just means "no access-denied hint", which is the right default.

extended ExceptionMapperTest to feed a null-message cloud exception through and assert it maps cleanly instead of throwing.

no behavior change, a null message used to throw, now it doesnt.