### PR TITLE
Preserve catalog storage names in setup round trips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 
+- Python CLI `setup` now preserves the catalog `storageName` field during export and apply, so named storage credential selection survives backup and migration round trips.
 - The NoSQL persistence commit log (`Commits.commitLog`) no longer stops early when a commit's recent-ancestor tail is shorter than the internal fetch page size. With a `polaris.persistence.reference-previous-head-count` smaller than the page size, the natural-order commit log previously truncated at the first short tail because trailing null entries in the fetch page were treated as end-of-history, which could also drop still-referenced objects during maintenance.
 - Python CLI REPL now shows a clear "Syntax error" message for malformed input instead of a generic "unexpected error" message.
 - Python CLI `setup apply` now exits with an error after any setup operation fails, while still attempting the remaining operations. Previously, individual failures were logged but the command reported success and exited with status 0.

--- a/client/python/apache_polaris/cli/command/catalogs.py
+++ b/client/python/apache_polaris/cli/command/catalogs.py
@@ -78,6 +78,7 @@ class CatalogsCommand(Command):
     catalog_type: Optional[str] = None
     default_base_location: Optional[str] = None
     storage_type: Optional[str] = None
+    storage_name: Optional[str] = None
     allowed_locations: Optional[List[str]] = None
     role_arn: Optional[str] = None
     external_id: Optional[str] = None
@@ -296,6 +297,7 @@ class CatalogsCommand(Command):
         if self.storage_type == StorageType.S3.value:
             config = AwsStorageConfigInfo(
                 storage_type=self.storage_type.upper(),
+                storage_name=self.storage_name,
                 allowed_locations=self.allowed_locations,
                 role_arn=self.role_arn,
                 external_id=self.external_id,
@@ -313,6 +315,7 @@ class CatalogsCommand(Command):
         elif self.storage_type == StorageType.AZURE.value:
             config = AzureStorageConfigInfo(
                 storage_type=self.storage_type.upper(),
+                storage_name=self.storage_name,
                 allowed_locations=self.allowed_locations,
                 tenant_id=self.tenant_id,
                 multi_tenant_app_name=self.multi_tenant_app_name,
@@ -322,12 +325,14 @@ class CatalogsCommand(Command):
         elif self.storage_type == StorageType.GCS.value:
             config = GcpStorageConfigInfo(
                 storage_type=self.storage_type.upper(),
+                storage_name=self.storage_name,
                 allowed_locations=self.allowed_locations,
                 gcs_service_account=self.service_account,
             )
         elif self.storage_type == StorageType.FILE.value:
             config = StorageConfigInfo(
                 storage_type=self.storage_type.upper(),
+                storage_name=self.storage_name,
                 allowed_locations=self.allowed_locations,
             )
         return config

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -312,7 +312,6 @@ class SetupCommand(Command):
                     "name": c.name,
                     "type": c.type.lower() if c.type else "internal",
                     "storage_type": storage_type.lower(),
-                    "storage_name": c.storage_config_info.storage_name,
                     "default_base_location": c.properties.default_base_location,
                     "allowed_locations": sorted(
                         c.storage_config_info.allowed_locations
@@ -321,6 +320,8 @@ class SetupCommand(Command):
                     if c.properties.additional_properties
                     else {},
                 }
+                if c.storage_config_info.storage_name is not None:
+                    catalog_info["storage_name"] = c.storage_config_info.storage_name
                 # Serialize storage config details
                 if storage_type.lower() == StorageType.S3.value:
                     s3_info = {

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -312,6 +312,7 @@ class SetupCommand(Command):
                     "name": c.name,
                     "type": c.type.lower() if c.type else "internal",
                     "storage_type": storage_type.lower(),
+                    "storage_name": c.storage_config_info.storage_name,
                     "default_base_location": c.properties.default_base_location,
                     "allowed_locations": sorted(
                         c.storage_config_info.allowed_locations
@@ -808,6 +809,7 @@ class SetupCommand(Command):
         """Maps storage-related properties from YAML data to command arguments."""
         storage_keys = [
             "storage_type",
+            "storage_name",
             "default_base_location",
             "allowed_locations",
             "properties",
@@ -979,6 +981,7 @@ class SetupCommand(Command):
                         catalog_type=command_args.get("catalog_type"),
                         default_base_location=command_args.get("default_base_location"),
                         storage_type=command_args.get("storage_type"),
+                        storage_name=command_args.get("storage_name"),
                         allowed_locations=command_args.get("allowed_locations"),
                         properties=command_args.get("properties"),
                         set_properties=command_args.get("set_properties"),

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -530,6 +530,7 @@ class TestSetupCommand(CLITestBase):
 
         catalog = command._export_catalogs(mock_client)[0]
 
+        self.assertNotIn("storage_name", catalog)
         self.assertEqual(
             catalog["namespaces"], [{"name": "parent"}, {"name": "parent.child"}]
         )

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -746,7 +746,7 @@ class TestSetupCommand(CLITestBase):
         self.assertEqual(mock_stdout.getvalue(), "")
 
     @patch("apache_polaris.cli.command.setup.IcebergCatalogAPI")
-    def test_setup_export_s3_catalog_round_trips_sts_and_internal_endpoints(
+    def test_setup_export_s3_catalog_round_trips_storage_details(
         self, mock_catalog_api: MagicMock
     ) -> None:
         mock_catalog_api.return_value.list_namespaces.return_value = []
@@ -764,6 +764,7 @@ class TestSetupCommand(CLITestBase):
             ),
             storage_config_info=AwsStorageConfigInfo(
                 storage_type="S3",
+                storage_name="analytics-prod",
                 allowed_locations=["s3://bucket/path"],
                 role_arn="arn:aws:iam::123456789012:user/QuickstartUser",
                 endpoint="https://s3.us-west-2.amazonaws.com",
@@ -780,8 +781,10 @@ class TestSetupCommand(CLITestBase):
         exported = export_command._export_catalogs(mock_client)
 
         self.assertEqual(len(exported), 1)
+        self.assertEqual(exported[0]["storage_name"], "analytics-prod")
         self.assertEqual(
-            exported[0]["endpoint_internal"], "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com"
+            exported[0]["endpoint_internal"],
+            "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com",
         )
         self.assertEqual(exported[0]["sts_endpoint"], "https://sts.amazonaws.com")
 
@@ -794,6 +797,7 @@ class TestSetupCommand(CLITestBase):
 
         apply_client.create_catalog.assert_called_once()
         created = apply_client.create_catalog.call_args[0][0].catalog
+        self.assertEqual(created.storage_config_info.storage_name, "analytics-prod")
         self.assertEqual(
             created.storage_config_info.endpoint_internal,
             "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-west-2.vpce.amazonaws.com",

--- a/site/content/guides/assets/polaris/reference-setup-config.yaml
+++ b/site/content/guides/assets/polaris/reference-setup-config.yaml
@@ -175,6 +175,8 @@ catalogs:
   - name: "quickstart_catalog_s3"
     type: internal
     storage_type: "s3"
+    # Optional name referencing a server-side storage configuration.
+    # storage_name: "analytics-prod"
     default_base_location: "s3://quickstart-bucket/quickstart_catalog/"
     allowed_locations:
       - "s3://quickstart-bucket/quickstart_catalog/"


### PR DESCRIPTION
## Summary

`polaris setup export` omitted a catalog's optional `storageName`, and the apply
path could not restore it. A successful backup, migration, or bootstrap round
trip therefore changed credential selection when
`RESOLVE_CREDENTIALS_BY_STORAGE_NAME` was enabled.

This change preserves the field across export and apply for every supported
storage type. Existing setup files remain compatible because `storage_name` is
optional and defaults to `None` when absent.

Fixes #5344.

## Changes

- Export `storageName` as `storage_name` in setup YAML.
- Map the optional field through setup apply and all catalog storage model
  builders.
- Extend the S3 setup round-trip regression test to assert the exported and
  recreated storage name.
- Document the optional setup field and add an unreleased changelog entry.

## Validation

- `JAVA_HOME=/private/tmp/polaris-jdk21/Contents/Home ./gradlew format compileAll`
  — passed (981 actionable tasks).
- `JAVA_HOME=/private/tmp/polaris-jdk21/Contents/Home make client-regenerate`
  — passed.
- `JAVA_HOME=/private/tmp/polaris-jdk21/Contents/Home make client-unit-test`
  — passed (193 tests).
- `make client-lint` — passed (trailing whitespace, EOF, debug statements,
  Ruff check/format, MyPy).
- `make client-license-check` — passed.
- YAML parse of `reference-setup-config.yaml` and `git diff --check` — passed.

## Checklist

- [x] 🛡️ This is a non-security configuration-fidelity bug; no security issue is disclosed.
- [x] 🔗 The need and current failure mode are documented in Fixes #5344.
- [x] 🧪 The setup export/apply regression test covers the lossy round trip.
- [x] 💡 No complex logic was added that requires explanatory comments.
- [x] 🧾 Updated `CHANGELOG.md` under Unreleased / Fixes.
- [x] 📚 Updated the setup reference configuration; the existing unreleased CLI guide already links it and its setup contract is unchanged.

## AI assistance

Codex assisted with repository analysis, implementation, and validation. The
contributor reviewed the resulting issue, code, tests, documentation, and PR
description.
