### PR TITLE
Fix: CLI 'catalogs create --type external' skips required-flag validation, leaking a pydantic ValidationError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 
+- Python CLI `catalogs create --type external` now validates `--storage-type` and `--default-base-location` up front, matching the behavior for internal catalogs and the flags' documented "(Required)" status. Previously, omitting either produced an opaque pydantic `ValidationError` at request-build time.
 - Iceberg REST: server-side JSON processing failures (HTTP 500) now return the standard Iceberg
   error envelope (`{"error": {...}}`) instead of a flat `{"code", "message"}` body, so Iceberg
   clients can parse the response rather than failing on an off-schema shape.

--- a/client/python/apache_polaris/cli/command/catalogs.py
+++ b/client/python/apache_polaris/cli/command/catalogs.py
@@ -147,18 +147,17 @@ class CatalogsCommand(Command):
                 )
 
         if self.catalogs_subcommand == Subcommands.CREATE:
-            if self.catalog_type != CatalogType.EXTERNAL.value:
-                if not self.storage_type:
-                    raise CliError(
-                        f"Missing required argument:"
-                        f" {Argument.to_flag_name(Arguments.STORAGE_TYPE)}"
-                    )
-                if not self.default_base_location:
-                    raise CliError(
-                        f"Missing required argument:"
-                        f" {Argument.to_flag_name(Arguments.DEFAULT_BASE_LOCATION)}"
-                    )
-            else:
+            if not self.storage_type:
+                raise CliError(
+                    f"Missing required argument:"
+                    f" {Argument.to_flag_name(Arguments.STORAGE_TYPE)}"
+                )
+            if not self.default_base_location:
+                raise CliError(
+                    f"Missing required argument:"
+                    f" {Argument.to_flag_name(Arguments.DEFAULT_BASE_LOCATION)}"
+                )
+            if self.catalog_type == CatalogType.EXTERNAL.value:
                 if self.catalog_authentication_type == AuthenticationType.OAUTH.value:
                     if (
                         not self.catalog_token_uri

--- a/client/python/tests/test_catalogs_command.py
+++ b/client/python/tests/test_catalogs_command.py
@@ -47,6 +47,29 @@ class TestCatalogsCommand(CLITestBase):
             ),
             "--default-base-location",
         )
+        # External catalogs also require --storage-type and --default-base-location.
+        self.check_exception(
+            lambda: self.mock_execute(
+                mock_client,
+                ["catalogs", "create", "my-catalog", "--type", "external"],
+            ),
+            "--storage-type",
+        )
+        self.check_exception(
+            lambda: self.mock_execute(
+                mock_client,
+                [
+                    "catalogs",
+                    "create",
+                    "my-catalog",
+                    "--type",
+                    "external",
+                    "--storage-type",
+                    "file",
+                ],
+            ),
+            "--default-base-location",
+        )
         # Missing catalog name
         for sub in ["delete", "get", "update", "summarize"]:
             with self.subTest(subcommand=sub):
@@ -114,6 +137,10 @@ class TestCatalogsCommand(CLITestBase):
                     "my-catalog",
                     "--type",
                     "external",
+                    "--storage-type",
+                    "file",
+                    "--default-base-location",
+                    "dbl",
                     "--catalog-connection-type",
                     "iceberg-rest",
                     "--catalog-authentication-type",
@@ -134,6 +161,10 @@ class TestCatalogsCommand(CLITestBase):
                     "my-catalog",
                     "--type",
                     "external",
+                    "--storage-type",
+                    "file",
+                    "--default-base-location",
+                    "dbl",
                     "--catalog-connection-type",
                     "iceberg-rest",
                     "--catalog-authentication-type",


### PR DESCRIPTION
## Problem

When we call `polaris catalogs create <name> --type external ...`, if we omit required flags `--storage-type` or `--default-base-location`, it exits non-zero with an opaque pydantic `ValidationError` that names an internal SDK field rather than the CLI flag the user should pass.

`CatalogsCommand.validate()` enforces both flags only for **non-external** catalogs. The CLI's own option tree (`options/option_tree.py:234, :241`) and user docs already mark both flags **"(Required)"** unconditionally, so this is a mismatch between the CLI's advertised contract and its actual enforcement ([relevant CLI doc](https://polaris.incubator.apache.org/in-dev/unreleased/command-line-interface/#catalogs)).
<img width="65%" height="587" alt="Screenshot 2026-08-22 at 14 37 01" src="https://github.com/user-attachments/assets/50e354da-9abe-4dff-80aa-cc72e9526410" />



The issue was most likely introduced by PR #1912 (federation support, July 2025). The exempted path has never been a reachable design, because both flags have been `required` in the OpenAPI spec since commit #1 (July 2024, a year earlier).

## How to reproduce

### 1. Missing `--storage-type` (with `--default-base-location` given)

```
polaris --access-token dummy --base-url http://127.0.0.1:1 \
  catalogs create foo --type external --default-base-location dbl \
    --catalog-connection-type hadoop --hadoop-warehouse w --catalog-uri u
```

### 2. Missing `--default-base-location` (with `--storage-type` given)

```
polaris --access-token dummy --base-url http://127.0.0.1:1 \
  catalogs create foo --type external --storage-type file \
    --catalog-connection-type hadoop --hadoop-warehouse w --catalog-uri u
```

### For reference — a fully-valid invocation

It should pass (unless we don't have server set up, in which case we should only see the HTTP call fails)

```
polaris --access-token dummy --base-url http://127.0.0.1:1 \
  catalogs create foo --type external --storage-type file --default-base-location dbl \
    --catalog-connection-type hadoop --hadoop-warehouse w \
    --catalog-authentication-type implicit --catalog-uri u
```


## Before and After the fix

### Before
<img width="65%" height="190" alt="Screenshot 2026-08-22 at 14 39 07" src="https://github.com/user-attachments/assets/53f3af9c-2d72-457e-a5b6-2a35366785ae" />


### After

<img width="65%" height="153" alt="Screenshot 2026-08-22 at 14 39 46" src="https://github.com/user-attachments/assets/1a588af4-1071-4439-890b-435fbf75d85e" />
