### PR TITLE
Remove invalid alert banner

### DIFF
--- a/site/content/guides/rustfs/index.md
+++ b/site/content/guides/rustfs/index.md
@@ -32,10 +32,6 @@ menus:
         weight: 200
 ---
 
-{{< alert warning >}}
-**Disclaimer:** This guide uses mc from MinIO OSS for local testing only. MinIO OSS is in maintenance mode, and MinIO container images may no longer receive updates or security fixes. For production setups, [rc](https://github.com/rustfs/cli) should be used.
-{{< /alert >}}
-
 ## Overview
 
 This example uses [RustFS](https://rustfs.com/) as a storage provider with Polaris.


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

This PR removed an invalid alert banner for rustfs guide where we switched from MC CLI to AWS CLI long time back.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
