### PR TITLE
Fix Documentation menu entry name for release 1.7.0

### DIFF
--- a/1.7.0/_index.md
+++ b/1.7.0/_index.md
@@ -30,7 +30,6 @@ menus:
     parent: doc
     weight: -10700
     identifier: doc-1.7.0
-    name: Developer Docs (unreleased)
 cascade:
   type: docs
   params:


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Fix document release name.

Here is the current:
<img width="299" height="547" alt="image" src="https://github.com/user-attachments/assets/03e80730-f922-4c89-a17d-4b2b34ee55d5" />


Here is the fixed one with this PR:
<img width="299" height="547" alt="image" src="https://github.com/user-attachments/assets/74691d41-e9e0-45eb-ad33-15938c1c4162" />


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
