### PR TITLE
Add Community and Slack actions to the homepage

### DIFF
--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -282,108 +282,6 @@ h6:hover .heading-anchor {
   }
 }
 
-.polaris-landing .polaris-landing-community {
-  padding: 3.75rem 0;
-  border-top: 1px solid rgba(114, 232, 221, 0.08);
-  background:
-    radial-gradient(circle at 50% 45%, rgba($td-navbar-bg-color, 0.12), rgba($td-navbar-bg-color, 0) 58%),
-    #073b47;
-}
-
-.polaris-landing-community__grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: clamp(1.5rem, 3vw, 3rem);
-
-  > a,
-  > article {
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-    align-items: center;
-    justify-content: flex-start;
-    padding: 0.75rem 1rem;
-    border: 0;
-    border-radius: 0.75rem;
-    color: #fff;
-    background: transparent;
-    text-align: center;
-
-    > i {
-      display: flex;
-      width: 3.5rem;
-      height: 3.5rem;
-      align-items: center;
-      justify-content: center;
-      color: #72e8dd;
-      font-size: 2.25rem;
-      transition: color 160ms ease;
-    }
-
-    span,
-    > div {
-      display: flex;
-      width: 100%;
-      max-width: 20rem;
-      flex-direction: column;
-      gap: 0.7rem;
-      align-items: center;
-    }
-
-    strong {
-      font-size: clamp(1.25rem, 2vw, 1.5rem);
-    }
-
-    small {
-      color: rgba(255, 255, 255, 0.76);
-      font-size: 0.92rem;
-      line-height: 1.6;
-    }
-  }
-
-  > a {
-    text-decoration: none;
-    transition: color 160ms ease, transform 160ms ease;
-
-    &:hover {
-      color: #fff;
-      transform: translateY(-2px);
-
-      > i {
-        color: #a1f5ed;
-      }
-    }
-
-    &:focus-visible {
-      outline: 3px solid #7bf3e8;
-      outline-offset: 3px;
-    }
-  }
-}
-
-.polaris-landing-community__contribute {
-  h3 {
-    margin: 0;
-    color: #fff;
-    font-size: clamp(1.25rem, 2vw, 1.5rem);
-  }
-
-  p {
-    margin: 0;
-    color: rgba(255, 255, 255, 0.76);
-    font-size: 0.92rem;
-    line-height: 1.6;
-  }
-
-  a {
-    color: #72e8dd;
-
-    &:hover {
-      color: #a1f5ed;
-    }
-  }
-}
-
 .polaris-landing .polaris-landing-trademarks {
   padding: 1rem 0;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
@@ -428,10 +326,6 @@ h6:hover .heading-anchor {
     width: 100%;
     max-width: 21rem;
     margin-inline: auto;
-  }
-
-  .polaris-landing-community__grid {
-    grid-template-columns: 1fr;
   }
 
   .polaris-landing-about {

--- a/site/layouts/home/list.html
+++ b/site/layouts/home/list.html
@@ -31,13 +31,17 @@
           <i class="fas fa-rocket" aria-hidden="true"></i>
           Get started
         </a>
-        <a class="polaris-landing-button" href="/releases/latest/">
-          <i class="fas fa-book-open" aria-hidden="true"></i>
-          Documentation
+        <a class="polaris-landing-button" href="/community/">
+          <i class="fa-solid fa-people-group" aria-hidden="true"></i>
+          Community
         </a>
         <a class="polaris-landing-button" href="https://github.com/apache/polaris">
           <i class="fab fa-github" aria-hidden="true"></i>
           GitHub
+        </a>
+        <a class="polaris-landing-button" href="https://join.slack.com/t/apache-polaris/shared_invite/zt-3txht5g9x-9NYK98fK6hk40bOaWGW83Q">
+          <i class="fa-brands fa-slack" aria-hidden="true"></i>
+          Slack
         </a>
       </nav>
     </div>
@@ -51,29 +55,6 @@
         a wide range of platforms, including Apache Doris™, Apache Flink®, Apache Spark™,
         Dremio® OSS, StarRocks, and Trino.
       </p>
-    </div>
-  </section>
-
-  <section class="polaris-landing-community" aria-label="Apache Polaris community links">
-    <div class="polaris-landing-shell polaris-landing-community__grid">
-      <a href="https://join.slack.com/t/apache-polaris/shared_invite/zt-3txht5g9x-9NYK98fK6hk40bOaWGW83Q">
-        <i class="fa-regular fa-comment-dots" aria-hidden="true"></i>
-        <span><strong>Join the community</strong><small>Chat with users and project developers.</small></span>
-      </a>
-      <article class="polaris-landing-community__contribute">
-        <i class="fab fa-github" aria-hidden="true"></i>
-        <div>
-          <h3>Contributions welcome!</h3>
-          <p>
-            We do a <a href="https://github.com/apache/polaris/pulls">Pull Request</a>
-            contributions workflow on GitHub. New users are always welcome!
-          </p>
-        </div>
-      </article>
-      <a href="https://lists.apache.org/list.html?dev@polaris.apache.org">
-        <i class="fa-regular fa-envelope" aria-hidden="true"></i>
-        <span><strong>Join the mailing list</strong><small>Follow announcements and project discussions.</small></span>
-      </a>
     </div>
   </section>
 

--- a/site/layouts/home/list.html
+++ b/site/layouts/home/list.html
@@ -28,7 +28,7 @@
       <hr>
       <nav class="polaris-landing-actions" aria-label="Apache Polaris resources">
         <a class="polaris-landing-button polaris-landing-button--primary" href="/releases/latest/getting-started/">
-          <i class="fas fa-rocket" aria-hidden="true"></i>
+          <i class="fa-solid fa-rocket" aria-hidden="true"></i>
           Get started
         </a>
         <a class="polaris-landing-button" href="/community/">
@@ -36,7 +36,7 @@
           Community
         </a>
         <a class="polaris-landing-button" href="https://github.com/apache/polaris">
-          <i class="fab fa-github" aria-hidden="true"></i>
+          <i class="fa-brands fa-github" aria-hidden="true"></i>
           GitHub
         </a>
         <a class="polaris-landing-button" href="https://join.slack.com/t/apache-polaris/shared_invite/zt-3txht5g9x-9NYK98fK6hk40bOaWGW83Q">


### PR DESCRIPTION
## Summary

- add Community and Slack actions to the homepage hero
- remove the Documentation hero action and the redundant lower community link strip
- remove the unused styles for the deleted community section

## Why

The homepage previously placed the public Slack invitation below the fold and did not offer a direct Community action in the hero. Moving both destinations into the primary action group makes them easier to discover, while removing the duplicated lower section keeps the landing page focused.

The expected homepage hero now contains Get started, Community, GitHub, and Slack actions. The introduction flows directly into the trademark and footer area.

Screenshot
<img width="994" height="498" alt="Screenshot 2026-08-22 at 11 30 49 PM" src="https://github.com/user-attachments/assets/69327fc1-95e0-4328-82bc-324d07b2814f" />


## Checklist

- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic (not applicable; template and style cleanup only)
- [x] 🧾 Updated CHANGELOG.md (not needed for a website navigation change)
- [x] 📚 Updated documentation in site/content/in-dev/unreleased (not needed)

AI assistance was used to prepare this change. Responsibility and authorship remain with the pull request author.
