### PR TITLE
Fix namespace creation rejecting its own default location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,13 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   loading the grants held by a principal, principal role or catalog role scans every grant record
   in the realm, because the `grant_records` primary key continues with the securable columns after
   `realm_id`. Existing CockroachDB deployments need a manual index creation — see Upgrade notes.
-- Creating a namespace without an explicit location no longer fails with HTTP 400 when the catalog's `default-base-location` is nested under an allowed location rather than being equal to one. The derived location is now validated against the location it is derived from.
+- Creating a namespace without an explicit location no longer fails with HTTP 400 when the
+  catalog's `default-base-location` sits inside an allowed location instead of being one of
+  them. For example, with allowed location `s3://b1` and `default-base-location` `s3://b1/d1`,
+  `CREATE NAMESPACE ns` places the namespace at `s3://b1/d1/ns`, but the check expected it
+  directly under an allowed location, at `s3://b1/ns`, and rejected it as a custom location even
+  though the request asked for none. The namespace location is now compared against the
+  catalog's `default-base-location`, which is what it is derived from.
 
 ### Commits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   loading the grants held by a principal, principal role or catalog role scans every grant record
   in the realm, because the `grant_records` primary key continues with the securable columns after
   `realm_id`. Existing CockroachDB deployments need a manual index creation — see Upgrade notes.
+- Creating a namespace without an explicit location no longer fails with HTTP 400 when the catalog's `default-base-location` is nested under an allowed location rather than being equal to one. The derived location is now validated against the location it is derived from.
 
 ### Commits
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -1457,24 +1457,19 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
         throw new IllegalArgumentException(
             "Cannot create namespace without a parent storage configuration");
       }
-      List<StorageLocation> defaultLocations =
-          parentEntity.getStorageConfigurationInfo().getAllowedLocations().stream()
-              .filter(java.util.Objects::nonNull)
-              .map(
-                  l ->
-                      StorageLocation.ensureTrailingSlash(
-                          StorageLocation.ensureTrailingSlash(l) + namespace.getName()))
-              .map(StorageLocation::of)
-              .toList();
-      if (!defaultLocations.contains(namespaceLocation)) {
+      String parentLocation = resolveLocationForPath(diagnostics, List.of(parent));
+      StorageLocation defaultLocation =
+          StorageLocation.of(
+              StorageLocation.ensureTrailingSlash(
+                  StorageLocation.ensureTrailingSlash(parentLocation) + namespace.getName()));
+      if (!defaultLocation.equals(namespaceLocation)) {
         throw new IllegalArgumentException(
             "Namespace "
                 + namespace.getName()
                 + " has a custom location, "
-                + "which is not enabled. Expected a location in: ["
-                + String.join(
-                    ", ", defaultLocations.stream().map(StorageLocation::toString).toList())
-                + "]. Got location: "
+                + "which is not enabled. Expected location: ["
+                + defaultLocation
+                + "]. Got location: ["
                 + namespaceLocation
                 + "]");
       }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -697,7 +697,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     }
     if (!realmConfig.getConfig(
         BehaviorChangeConfiguration.ALLOW_NAMESPACE_CUSTOM_LOCATION, catalogEntity)) {
-      validateNamespaceLocation(entity, resolvedParent);
+      validateNamespaceUsesDefaultLocation(entity, resolvedParent);
     }
     EntityResult result =
         getMetaStoreManager()
@@ -894,7 +894,7 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     if (!realmConfig.getConfig(
         BehaviorChangeConfiguration.ALLOW_NAMESPACE_CUSTOM_LOCATION, catalogEntity)) {
       if (properties.containsKey(PolarisEntityConstants.ENTITY_BASE_LOCATION)) {
-        validateNamespaceLocation(NamespaceEntity.of(entity), resolvedEntities);
+        validateNamespaceUsesDefaultLocation(NamespaceEntity.of(entity), resolvedEntities);
       }
     }
 
@@ -1434,8 +1434,8 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     }
   }
 
-  /** Checks whether the location of a namespace is valid given its parent */
-  private void validateNamespaceLocation(
+  /** Checks that a namespace sits at the default location derived from its parent. */
+  private void validateNamespaceUsesDefaultLocation(
       NamespaceEntity namespace, PolarisResolvedPathWrapper resolvedParent) {
     StorageLocation namespaceLocation =
         StorageLocation.of(

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
@@ -678,6 +678,58 @@ public class IcebergAllowedLocationTest {
         .hasMessageContaining("Invalid locations");
   }
 
+  @Test
+  void testCreateNamespaceWhenBaseLocationIsNestedInsideAllowedLocation(@TempDir Path tmpDir) {
+    TestServices services =
+        TestServices.builder()
+            .config(
+                Map.of(
+                    "ALLOW_INSECURE_STORAGE_TYPES",
+                    "true",
+                    "SUPPORTED_CATALOG_STORAGE_TYPES",
+                    List.of("FILE")))
+            .build();
+
+    String allowedLocation = tmpDir.toAbsolutePath().toUri().toString();
+    String catalogLocation = tmpDir.resolve("warehouse").toAbsolutePath().toUri().toString();
+    createCatalog(services, Map.of(), catalogLocation, List.of(allowedLocation));
+
+    CreateNamespaceRequest derivedLocationRequest =
+        CreateNamespaceRequest.builder().withNamespace(Namespace.of(namespace)).build();
+    try (Response response =
+        services
+            .restApi()
+            .createNamespace(
+                catalog,
+                derivedLocationRequest,
+                IDEMPOTENCY_KEY,
+                services.realmContext(),
+                services.securityContext())) {
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
+
+    // A caller-specified location must still be rejected.
+    Map<String, String> customLocation = new HashMap<>();
+    customLocation.put("location", allowedLocation + "elsewhere");
+    CreateNamespaceRequest customLocationRequest =
+        CreateNamespaceRequest.builder()
+            .withNamespace(Namespace.of("ns2"))
+            .setProperties(customLocation)
+            .build();
+    assertThatThrownBy(
+            () ->
+                services
+                    .restApi()
+                    .createNamespace(
+                        catalog,
+                        customLocationRequest,
+                        IDEMPOTENCY_KEY,
+                        services.realmContext(),
+                        services.securityContext()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("has a custom location");
+  }
+
   private void createCatalog(
       TestServices services,
       Map<String, String> catalogConfig,


### PR DESCRIPTION
Creating a namespace without a location fails with `400` whenever a catalog's
`default-base-location` is nested inside an allowed location rather than being equal to one:

Namespace ns has a custom location, which is not enabled.
```
Expected a location in: [file:///tmp/x/ns/].
Got location: file:///tmp/x/warehouse/test-catalog/ns/]
```

The caller supplied no location at all, so the message is doubly misleading: the location it
rejects is the one the server itself just derived.

Two validations disagree about what "inside an allowed location" means. Catalog creation asks only
for containment — `CatalogEntity.validateBaseLocationAgainstAllowedList` uses
`anyMatch(baseLocation::isChildOf)` — so `default-base-location` may sit anywhere beneath an allowed
location. Namespace creation then demanded exact equality: `validateNamespaceLocation` built its
candidates from `getStorageConfigurationInfo().getAllowedLocations()` mapped to
`<allowedLocation>/<namespaceName>` and required set membership. But a namespace's location is
derived from the catalog's `default-base-location`, never from the allowed locations, so the two
only agree when `default-base-location` happens to equal an allowed location. With the common
layout — allowed `s3://bucket/warehouse/`, `default-base-location` `s3://bucket/warehouse/mycat` —
the catalog is created successfully and then every plain `CREATE NAMESPACE` fails.
`ALLOW_NAMESPACE_CUSTOM_LOCATION` defaults to `false`, so the check runs by default.

The sibling branch of the same method already does this correctly: when the parent is a namespace it
compares against the parent's actual resolved location. This makes the parent-catalog branch do the
same, deriving the expected location with `resolveLocationForPath`, which is the helper
`resolveNamespaceLocation` itself uses. The check can no longer drift from the derivation it
validates, and the existing null-default-base-location diagnostic in `baseLocation()` now covers
this path too.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
