### PR TITLE
Add the missing indexes to the CockroachDB schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   ```
   H2 is unaffected.
 
+- Relational JDBC: schema version 6 also declares `idx_grants_realm_grantee`,
+  `idx_grants_realm_securable` and `idx_entities_catalog_id_id` on CockroachDB (see Fixes), which
+  the Postgres and H2 schemas have declared since schema v4. Fresh bootstraps get them
+  automatically; existing CockroachDB deployments, including any already at schema version 6,
+  need them created manually:
+  ```sql
+  CREATE INDEX IF NOT EXISTS idx_grants_realm_grantee ON polaris_schema.grant_records (realm_id, grantee_id);
+  CREATE INDEX IF NOT EXISTS idx_grants_realm_securable ON polaris_schema.grant_records (realm_id, securable_id);
+  CREATE INDEX IF NOT EXISTS idx_entities_catalog_id_id ON polaris_schema.entities (catalog_id, id);
+  ```
+  Postgres and H2 are unaffected.
+
 ### Breaking changes
 
 - Concurrent table commits that hit a stale sequence number now return a retryable `409` instead of a fatal `400`, for both single-table commits and `commitTransaction`.
@@ -89,6 +101,12 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   schema version 6 creates the index on `(realm_id, catalog_id, location_without_scheme)`; H2 was
   already correct. Existing deployments need a manual index recreation — see Upgrade notes.
 - A metastore failure while resolving a principal's roles during authentication now returns HTTP 503, as it already did when looking up the principal entity; previously it propagated unwrapped and was reported as HTTP 500. All three lookups now report `PolarisServiceUnavailableException` as the error `type`, where the principal entity lookup previously reported `ServiceUnavailableException` with the same status. All three also send `Retry-After: 0`; the Iceberg REST spec has a client retry a non-idempotent request only when that header is present.
+- Relational JDBC: the CockroachDB schema now declares `idx_grants_realm_grantee`,
+  `idx_grants_realm_securable` and `idx_entities_catalog_id_id` as of schema version 6; the
+  Postgres and H2 schemas have carried them since schema v4. Without `idx_grants_realm_grantee`,
+  loading the grants held by a principal, principal role or catalog role scans every grant record
+  in the realm, because the `grant_records` primary key continues with the securable columns after
+  `realm_id`. Existing CockroachDB deployments need a manual index creation — see Upgrade notes.
 
 ### Commits
 

--- a/persistence/relational-jdbc/src/main/resources/cockroachdb/schema-v6.sql
+++ b/persistence/relational-jdbc/src/main/resources/cockroachdb/schema-v6.sql
@@ -23,6 +23,10 @@
 --    QueryGenerator.generateOverlapQuery (WHERE realm_id = ? AND catalog_id = ?). The previous
 --    definition let the optimized sibling check (OPTIMIZED_SIBLING_CHECK) use only the realm_id
 --    prefix, degrading CREATE TABLE / CREATE NAMESPACE to a realm-wide scan.
+--  * `idx_grants_realm_grantee`, `idx_grants_realm_securable` and `idx_entities_catalog_id_id`
+--    are now declared, matching PostgreSQL and H2, which have carried them since v4. Without the
+--    first, JdbcBasePersistenceImpl.loadAllGrantRecordsOnGrantee can use only the realm_id prefix
+--    of the grant_records primary key, degrading grant lookups by grantee to a realm-wide scan.
 -- Features:
 --  * Uses INT4 explicitly for all integer columns (required for CockroachDB JDBC driver)
 --  * Includes all tables: version, entities, grant_records, principal_authentication_data,
@@ -66,6 +70,7 @@ CREATE TABLE IF NOT EXISTS entities (
 
 -- TODO: create indexes based on all query pattern.
 CREATE INDEX IF NOT EXISTS idx_entities ON entities (realm_id, catalog_id, id);
+CREATE INDEX IF NOT EXISTS idx_entities_catalog_id_id ON entities (catalog_id, id);
 CREATE INDEX IF NOT EXISTS idx_locations
     ON entities USING btree (realm_id, catalog_id, location_without_scheme)
     WHERE location_without_scheme IS NOT NULL;
@@ -105,6 +110,11 @@ COMMENT ON COLUMN grant_records.securable_id IS 'entity id of the securable';
 COMMENT ON COLUMN grant_records.grantee_catalog_id IS 'catalog id of the grantee';
 COMMENT ON COLUMN grant_records.grantee_id IS 'id of the grantee';
 COMMENT ON COLUMN grant_records.privilege_code IS 'privilege code';
+
+CREATE INDEX IF NOT EXISTS idx_grants_realm_grantee
+    ON grant_records (realm_id, grantee_id);
+CREATE INDEX IF NOT EXISTS idx_grants_realm_securable
+    ON grant_records (realm_id, securable_id);
 
 CREATE TABLE IF NOT EXISTS principal_authentication_data (
     realm_id TEXT NOT NULL,


### PR DESCRIPTION
`cockroachdb/schema-v6.sql` declares 7 indexes where `postgres/schema-v6.sql` declares 10, though its own header says it matches PostgreSQL schema v6. #3939 added the three to Postgres and H2, fixing #3685; #3352 had branched the CockroachDB script from Postgres v4 a week earlier.

`idx_grants_realm_grantee` is the one that changes a plan. The `grant_records` primary key continues with the securable columns after `realm_id`, so `loadAllGrantRecordsOnGrantee`, which filters `realm_id`, `grantee_catalog_id` and `grantee_id`, can use only the realm prefix. `EXPLAIN ANALYZE` on CockroachDB 25.3, 200k grant records in one realm: 200,000 KV rows in 61ms on `grant_records_pkey`, against 200 rows in 377µs on the new index.

Measured, the other two change no plan: the primary key already yields exact spans for the securable lookup and for the entities tuple-`IN` query. They are declared so schema v6 means the same objects on every backend, as #5349's v3-to-v4 migration assumes; its `cockroachdb/schema.sql` still lacks all three.

Only `schema-v6.sql` is touched; v4 and v5 have shipped. Existing deployments need the one-time DDL in the CHANGELOG upgrade notes. The Cockroach bootstrap, purge and IT suites run this script against a real container in CI.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Related to #3685
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
