### PR TITLE
ServerManager: simplify management URI computation

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/env/Server.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/env/Server.java
@@ -56,8 +56,7 @@ public interface Server extends AutoCloseable {
    * be confused with the Polaris Management API. This URI includes the management interface root
    * path, usually {@code /q} on Quarkus platforms.
    *
-   * <p>The management URI is sometimes unavailable, e.g. in the case of a @QuarkusIntegrationTest;
-   * in such cases this method returns empty.
+   * <p>The management URI may be unavailable; in such cases this method returns empty.
    */
   default Optional<URI> managementUri() {
     return Optional.empty();

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/ext/ExternalPolarisServerManager.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/ext/ExternalPolarisServerManager.java
@@ -19,6 +19,8 @@
 package org.apache.polaris.service.it.ext;
 
 import java.net.URI;
+import java.util.Optional;
+import java.util.OptionalInt;
 import org.apache.polaris.service.it.env.ClientCredentials;
 import org.apache.polaris.service.it.env.ClientPrincipal;
 import org.apache.polaris.service.it.env.Server;
@@ -31,15 +33,23 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 public class ExternalPolarisServerManager implements PolarisServerManager {
 
   public static final String HTTP_PORT_PROPERTY = "quarkus.http.test-port";
+  public static final String MANAGEMENT_PORT_PROPERTY = "quarkus.management.test-port";
   public static final String HOST_PROPERTY = "polaris.test.server.host";
 
   @Override
   public Server serverForContext(ExtensionContext context) {
-    URI baseUri = URI.create(String.format("http://%s:%d", host(), httpPort()));
+    URI baseUri = formatUri(httpPort());
+    Optional<URI> managementUri =
+        managementPort().stream().boxed().map(ExternalPolarisServerManager::formatUri).findFirst();
     return new Server() {
       @Override
       public URI baseUri() {
         return baseUri;
+      }
+
+      @Override
+      public Optional<URI> managementUri() {
+        return managementUri;
       }
 
       @Override
@@ -54,6 +64,10 @@ public class ExternalPolarisServerManager implements PolarisServerManager {
     };
   }
 
+  private static URI formatUri(int port) {
+    return URI.create(String.format("http://%s:%d", host(), port));
+  }
+
   private static String host() {
     String host = System.getProperty(HOST_PROPERTY, "localhost");
     return host.isBlank() ? "localhost" : host;
@@ -61,9 +75,19 @@ public class ExternalPolarisServerManager implements PolarisServerManager {
 
   private static int httpPort() {
     String port = System.getProperty(HTTP_PORT_PROPERTY);
+    return portAsInt(port, HTTP_PORT_PROPERTY);
+  }
+
+  private static OptionalInt managementPort() {
+    String port = System.getProperty(MANAGEMENT_PORT_PROPERTY);
+    return port == null || port.isBlank()
+        ? OptionalInt.empty()
+        : OptionalInt.of(portAsInt(port, MANAGEMENT_PORT_PROPERTY));
+  }
+
+  private static int portAsInt(String port, String property) {
     if (port == null || port.isBlank()) {
-      throw new IllegalStateException(
-          String.format("System property '%s' must be set", HTTP_PORT_PROPERTY));
+      throw new IllegalStateException(String.format("System property '%s' must be set", property));
     }
     try {
       int parsed = Integer.parseInt(port);
@@ -73,9 +97,7 @@ public class ExternalPolarisServerManager implements PolarisServerManager {
       return parsed;
     } catch (IllegalArgumentException e) {
       throw new IllegalStateException(
-          String.format(
-              "System property '%s' must be a valid TCP port: %s", HTTP_PORT_PROPERTY, port),
-          e);
+          String.format("System property '%s' must be a valid TCP port: %s", property, port), e);
     }
   }
 }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/ext/ExternalPolarisServerManager.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/ext/ExternalPolarisServerManager.java
@@ -38,9 +38,12 @@ public class ExternalPolarisServerManager implements PolarisServerManager {
 
   @Override
   public Server serverForContext(ExtensionContext context) {
-    URI baseUri = formatUri(httpPort());
+    URI baseUri = URI.create(String.format("http://%s:%d", host(), httpPort()));
     Optional<URI> managementUri =
-        managementPort().stream().boxed().map(ExternalPolarisServerManager::formatUri).findFirst();
+        managementPort().stream()
+            .boxed()
+            .map(port -> URI.create(String.format("http://%s:%d/q", host(), port)))
+            .findFirst();
     return new Server() {
       @Override
       public URI baseUri() {
@@ -62,10 +65,6 @@ public class ExternalPolarisServerManager implements PolarisServerManager {
         // The external process owner is responsible for server lifecycle.
       }
     };
-  }
-
-  private static URI formatUri(int port) {
-    return URI.create(String.format("http://%s:%d", host(), port));
   }
 
   private static String host() {

--- a/integration-tests/src/test/java/org/apache/polaris/service/it/ext/ExternalPolarisServerManagerTest.java
+++ b/integration-tests/src/test/java/org/apache/polaris/service/it/ext/ExternalPolarisServerManagerTest.java
@@ -49,17 +49,6 @@ class ExternalPolarisServerManagerTest {
   }
 
   @Test
-  void serverForContextUsesConfiguredHost() {
-    System.setProperty(ExternalPolarisServerManager.HTTP_PORT_PROPERTY, "12345");
-    System.setProperty(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY, "12346");
-    System.setProperty(ExternalPolarisServerManager.HOST_PROPERTY, "127.0.0.1");
-
-    Server server = new ExternalPolarisServerManager().serverForContext(null);
-
-    assertThat(server.baseUri()).hasToString("http://127.0.0.1:12345");
-  }
-
-  @Test
   void serverForContextUsesConfiguredHttpPort() {
     System.setProperty(ExternalPolarisServerManager.HTTP_PORT_PROPERTY, "12345");
 
@@ -69,6 +58,16 @@ class ExternalPolarisServerManagerTest {
     assertThat(server.adminCredentials().principalName()).isEqualTo("root");
     assertThat(server.adminCredentials().credentials().clientId()).isEqualTo("test-admin");
     assertThat(server.adminCredentials().credentials().clientSecret()).isEqualTo("test-secret");
+  }
+
+  @Test
+  void serverForContextUsesConfiguredHost() {
+    System.setProperty(ExternalPolarisServerManager.HTTP_PORT_PROPERTY, "12345");
+    System.setProperty(ExternalPolarisServerManager.HOST_PROPERTY, "127.0.0.1");
+
+    Server server = new ExternalPolarisServerManager().serverForContext(null);
+
+    assertThat(server.baseUri()).hasToString("http://127.0.0.1:12345");
   }
 
   @Test
@@ -104,21 +103,16 @@ class ExternalPolarisServerManagerTest {
     System.setProperty(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY, "12346");
 
     Server server = new ExternalPolarisServerManager().serverForContext(null);
-
     assertThat(server.managementUri()).contains(URI.create("http://localhost:12346/q"));
-    assertThat(server.adminCredentials().principalName()).isEqualTo("root");
-    assertThat(server.adminCredentials().credentials().clientId()).isEqualTo("test-admin");
-    assertThat(server.adminCredentials().credentials().clientSecret()).isEqualTo("test-secret");
   }
 
   @Test
-  void serverForContextRejectsMissingManagementPort() {
+  void serverForContextAcceptsMissingManagementPort() {
     System.setProperty(ExternalPolarisServerManager.HTTP_PORT_PROPERTY, "12345");
     System.clearProperty(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY);
 
-    assertThatThrownBy(() -> new ExternalPolarisServerManager().serverForContext(null))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY);
+    Server server = new ExternalPolarisServerManager().serverForContext(null);
+    assertThat(server.managementUri()).isEmpty();
   }
 
   @Test

--- a/integration-tests/src/test/java/org/apache/polaris/service/it/ext/ExternalPolarisServerManagerTest.java
+++ b/integration-tests/src/test/java/org/apache/polaris/service/it/ext/ExternalPolarisServerManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.polaris.service.it.ext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.net.URI;
 import org.apache.polaris.service.it.env.Server;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,18 +30,33 @@ import org.junit.jupiter.api.Test;
 class ExternalPolarisServerManagerTest {
 
   private String originalHost;
-  private String originalPort;
+  private String originalHttpPort;
+  private String originalManagementPort;
 
   @BeforeEach
   void captureProperties() {
     originalHost = System.getProperty(ExternalPolarisServerManager.HOST_PROPERTY);
-    originalPort = System.getProperty(ExternalPolarisServerManager.HTTP_PORT_PROPERTY);
+    originalHttpPort = System.getProperty(ExternalPolarisServerManager.HTTP_PORT_PROPERTY);
+    originalManagementPort =
+        System.getProperty(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY);
   }
 
   @AfterEach
   void restoreProperties() {
     restore(ExternalPolarisServerManager.HOST_PROPERTY, originalHost);
-    restore(ExternalPolarisServerManager.HTTP_PORT_PROPERTY, originalPort);
+    restore(ExternalPolarisServerManager.HTTP_PORT_PROPERTY, originalHttpPort);
+    restore(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY, originalManagementPort);
+  }
+
+  @Test
+  void serverForContextUsesConfiguredHost() {
+    System.setProperty(ExternalPolarisServerManager.HTTP_PORT_PROPERTY, "12345");
+    System.setProperty(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY, "12346");
+    System.setProperty(ExternalPolarisServerManager.HOST_PROPERTY, "127.0.0.1");
+
+    Server server = new ExternalPolarisServerManager().serverForContext(null);
+
+    assertThat(server.baseUri()).hasToString("http://127.0.0.1:12345");
   }
 
   @Test
@@ -53,16 +69,6 @@ class ExternalPolarisServerManagerTest {
     assertThat(server.adminCredentials().principalName()).isEqualTo("root");
     assertThat(server.adminCredentials().credentials().clientId()).isEqualTo("test-admin");
     assertThat(server.adminCredentials().credentials().clientSecret()).isEqualTo("test-secret");
-  }
-
-  @Test
-  void serverForContextUsesConfiguredHost() {
-    System.setProperty(ExternalPolarisServerManager.HTTP_PORT_PROPERTY, "12345");
-    System.setProperty(ExternalPolarisServerManager.HOST_PROPERTY, "127.0.0.1");
-
-    Server server = new ExternalPolarisServerManager().serverForContext(null);
-
-    assertThat(server.baseUri()).hasToString("http://127.0.0.1:12345");
   }
 
   @Test
@@ -90,6 +96,49 @@ class ExternalPolarisServerManagerTest {
     assertThatThrownBy(() -> new ExternalPolarisServerManager().serverForContext(null))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining(ExternalPolarisServerManager.HTTP_PORT_PROPERTY);
+  }
+
+  @Test
+  void serverForContextUsesConfiguredManagementPort() {
+    System.setProperty(ExternalPolarisServerManager.HTTP_PORT_PROPERTY, "12345");
+    System.setProperty(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY, "12346");
+
+    Server server = new ExternalPolarisServerManager().serverForContext(null);
+
+    assertThat(server.managementUri()).contains(URI.create("http://localhost:12346/q"));
+    assertThat(server.adminCredentials().principalName()).isEqualTo("root");
+    assertThat(server.adminCredentials().credentials().clientId()).isEqualTo("test-admin");
+    assertThat(server.adminCredentials().credentials().clientSecret()).isEqualTo("test-secret");
+  }
+
+  @Test
+  void serverForContextRejectsMissingManagementPort() {
+    System.setProperty(ExternalPolarisServerManager.HTTP_PORT_PROPERTY, "12345");
+    System.clearProperty(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY);
+
+    assertThatThrownBy(() -> new ExternalPolarisServerManager().serverForContext(null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY);
+  }
+
+  @Test
+  void serverForContextRejectsInvalidManagementPort() {
+    System.setProperty(ExternalPolarisServerManager.HTTP_PORT_PROPERTY, "12345");
+    System.setProperty(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY, "not-a-port");
+
+    assertThatThrownBy(() -> new ExternalPolarisServerManager().serverForContext(null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY);
+  }
+
+  @Test
+  void serverForContextRejectsOutOfRangeManagementPort() {
+    System.setProperty(ExternalPolarisServerManager.HTTP_PORT_PROPERTY, "12345");
+    System.setProperty(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY, "65536");
+
+    assertThatThrownBy(() -> new ExternalPolarisServerManager().serverForContext(null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(ExternalPolarisServerManager.MANAGEMENT_PORT_PROPERTY);
   }
 
   private static void restore(String propertyName, String value) {

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/it/ServerManager.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/it/ServerManager.java
@@ -50,12 +50,7 @@ public class ServerManager implements PolarisServerManager {
       public Optional<URI> managementUri() {
         var registry = ValueRegistryInjector.get(context);
         var config = ConfigInjector.get(context);
-        // Probe whether the actual port to use has been registered. If not, the management
-        // interface is not available, and we are likely in a @QuarkusIntegrationTest.
-        int dynamicPort = registry.getOrDefault(MANAGEMENT_PORT, -1);
-        return dynamicPort == -1
-            ? Optional.empty()
-            : Optional.of(URI.create(TestHTTPResourceManager.testManagementUrl(registry, config)));
+        return Optional.of(URI.create(TestHTTPResourceManager.testManagementUrl(registry, config)));
       }
 
       @Override

--- a/runtime/service/src/testFixtures/java/org/apache/polaris/service/it/ServerManager.java
+++ b/runtime/service/src/testFixtures/java/org/apache/polaris/service/it/ServerManager.java
@@ -21,7 +21,6 @@ package org.apache.polaris.service.it;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
 import io.quarkus.test.config.ConfigInjector;
 import io.quarkus.test.config.ValueRegistryInjector;
-import io.quarkus.value.registry.ValueRegistry;
 import java.net.URI;
 import java.util.Optional;
 import org.apache.polaris.service.it.env.ClientCredentials;
@@ -31,9 +30,6 @@ import org.apache.polaris.service.it.ext.PolarisServerManager;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class ServerManager implements PolarisServerManager {
-
-  private static final ValueRegistry.RuntimeKey<Integer> MANAGEMENT_PORT =
-      ValueRegistry.RuntimeKey.intKey("quarkus.management.port");
 
   @Override
   public Server serverForContext(ExtensionContext context) {


### PR DESCRIPTION
This is a follow-up to #4841: in Quarkus 3.38.1, https://github.com/quarkusio/quarkus/pull/55023 was released, making it easier to infer the test management port.

This PR also modifies ExternalPolarisServerManager to enhance its handling of the test management port.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
