### PR TITLE
Hide `PolarisAuthorizer` error details in `ForbiddenException` message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 ### Breaking changes
 
 - Concurrent table commits that hit a stale sequence number now return a retryable `409` instead of a fatal `400`, for both single-table commits and `commitTransaction`.
+- Authorization denials now return the generic message `Authorization denied` in client-facing
+  `ForbiddenException` responses. For Iceberg REST clients, this changes the propagated
+  `error.message` value in HTTP 403 responses.
 
 ### New Features
 

--- a/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
+++ b/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
@@ -241,7 +241,11 @@ class OpaPolarisAuthorizer implements PolarisAuthorizer {
                 toResourceEntitiesFromResolvedPaths(targets),
                 toResourceEntitiesFromResolvedPaths(secondaries)));
     if (!allowed) {
-      throw new ForbiddenException("OPA denied authorization");
+      LOGGER.debug(
+          "OPA denied authorization for principal={} operation={}",
+          polarisPrincipal.getName(),
+          authzOp);
+      throw new ForbiddenException("Authorization denied");
     }
   }
 

--- a/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
+++ b/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
@@ -54,8 +54,7 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
 
   public static final String SERVICE_TYPE = "polaris";
 
-  private static final String RANGER_AUTH_FAILED_ERROR =
-      "Principal '%s' is not authorized for op '%s'";
+  private static final String AUTHORIZATION_DENIED = "Authorization denied";
 
   private final RangerEmbeddedAuthorizer authorizer;
   private final String serviceName;
@@ -120,8 +119,11 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
         RangerPolarisOperationSemantics.forOperation(authzOp);
 
     if (semantics == null) {
-      throw new ForbiddenException(
-          RANGER_AUTH_FAILED_ERROR, polarisPrincipal.getName(), authzOp.name());
+      LOG.debug(
+          "Ranger denied authorization for principal={} operation={}: no operation semantics",
+          polarisPrincipal.getName(),
+          authzOp.name());
+      throw new ForbiddenException(AUTHORIZATION_DENIED);
     }
 
     if (LOG.isDebugEnabled()) {
@@ -137,12 +139,24 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
     }
 
     try {
-      AuthorizationPreConditions.checkCredentialRotationRequired(
-          polarisPrincipal, authzOp, realmConfig);
+      try {
+        AuthorizationPreConditions.checkCredentialRotationRequired(
+            polarisPrincipal, authzOp, realmConfig);
+      } catch (ForbiddenException excp) {
+        LOG.debug(
+            "Ranger denied authorization for principal={} operation={}",
+            polarisPrincipal.getName(),
+            authzOp.name(),
+            excp);
+        throw new ForbiddenException(AUTHORIZATION_DENIED);
+      }
 
       if (!isAccessAuthorized(polarisPrincipal, authzOp, targets, secondaries)) {
-        throw new ForbiddenException(
-            RANGER_AUTH_FAILED_ERROR, polarisPrincipal.getName(), authzOp.name());
+        LOG.debug(
+            "Ranger denied authorization for principal={} operation={}",
+            polarisPrincipal.getName(),
+            authzOp.name());
+        throw new ForbiddenException(AUTHORIZATION_DENIED);
       }
     } catch (RangerAuthzException excp) {
       throw new IllegalStateException(

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisManagementServiceIntegrationTest.java
@@ -1028,7 +1028,7 @@ public class PolarisManagementServiceIntegrationTest {
           .isNotNull()
           .extracting(ErrorResponse::message)
           .asString()
-          .contains("must rotate credentials first");
+          .isEqualTo("Authorization denied");
     }
 
     // Now try to rotate using the principal's token.

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizer.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizer.java
@@ -25,9 +25,13 @@ import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Interface for invoking authorization checks. */
 public interface PolarisAuthorizer {
+  Logger LOGGER = LoggerFactory.getLogger(PolarisAuthorizer.class);
+
   /**
    * Resolve authorizer-specific inputs before authorization.
    *
@@ -62,8 +66,8 @@ public interface PolarisAuthorizer {
       @NonNull AuthorizationState authzState, @NonNull AuthorizationRequest request) {
     AuthorizationDecision decision = authorize(authzState, request);
     if (!decision.isAllowed()) {
-      String message = decision.getMessage().orElse("Authorization denied");
-      throw new ForbiddenException("%s", message);
+      decision.getMessage().ifPresent(message -> LOGGER.debug("Authorization denied: {}", message));
+      throw new ForbiddenException("Authorization denied");
     }
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
@@ -924,12 +924,25 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
       @NonNull PolarisAuthorizableOperation authzOp,
       @Nullable List<PolarisResolvedPathWrapper> targets,
       @Nullable List<PolarisResolvedPathWrapper> secondaries) {
-    AuthorizationPreConditions.checkCredentialRotationRequired(
-        polarisPrincipal, authzOp, realmConfig);
+    try {
+      AuthorizationPreConditions.checkCredentialRotationRequired(
+          polarisPrincipal, authzOp, realmConfig);
+    } catch (ForbiddenException e) {
+      LOGGER.debug(
+          "Authorization denied for principalName {} operation {}",
+          polarisPrincipal.getName(),
+          authzOp,
+          e);
+      throw new ForbiddenException("Authorization denied");
+    }
     boolean isRoot = getRootPrincipalName().equals(polarisPrincipal.getName());
     if (authzOp == PolarisAuthorizableOperation.RESET_CREDENTIALS) {
       if (!isRoot) {
-        throw new ForbiddenException("Only Root principal(service-admin) can perform %s", authzOp);
+        LOGGER.debug(
+            "Authorization denied for principal '{}' on operation '{}': only root can reset credentials",
+            polarisPrincipal.getName(),
+            authzOp);
+        throw new ForbiddenException("Authorization denied");
       }
       LOGGER
           .atDebug()
@@ -945,12 +958,13 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
             polarisPrincipal.getName(),
             authzOp,
             missingDetails);
-        throw new ForbiddenException(
-            "Principal '%s' with activated PrincipalRoles '%s' and activated grants via '%s' is not authorized for op %s",
+        LOGGER.debug(
+            "Principal '{}' with activated PrincipalRoles '{}' and activated grants via '{}' is not authorized for op {}",
             polarisPrincipal.getName(),
             polarisPrincipal.getRoles(),
             activatedEntities.stream().map(PolarisEntityCore::getName).collect(Collectors.toSet()),
             authzOp);
+        throw new ForbiddenException("Authorization denied");
       }
     }
   }

--- a/polaris-core/src/test/java/org/apache/polaris/core/auth/PolarisAuthorizerImplTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/auth/PolarisAuthorizerImplTest.java
@@ -385,9 +385,7 @@ public class PolarisAuthorizerImplTest {
                     null))
         .isInstanceOf(ForbiddenException.class)
         // Client-facing message is generic (no missing privilege details).
-        .hasMessage(
-            "Principal 'alice' with activated PrincipalRoles '[reader]'"
-                + " and activated grants via '[]' is not authorized for op CREATE_TABLE_DIRECT")
+        .hasMessage("Authorization denied")
         .hasMessageNotContaining("TABLE_CREATE")
         .hasMessageNotContaining("NAMESPACE");
     // Server-side log contains the detailed missing privilege info (verified via log capture
@@ -412,9 +410,7 @@ public class PolarisAuthorizerImplTest {
                     null))
         .isInstanceOf(ForbiddenException.class)
         // Generic client message.
-        .hasMessage(
-            "Principal 'alice' with activated PrincipalRoles '[reader]'"
-                + " and activated grants via '[]' is not authorized for op CREATE_TABLE_DIRECT_WITH_WRITE_DELEGATION")
+        .hasMessage("Authorization denied")
         // No privilege details leaked to client.
         .hasMessageNotContaining("TABLE_CREATE")
         .hasMessageNotContaining("TABLE_WRITE_DATA");
@@ -439,9 +435,7 @@ public class PolarisAuthorizerImplTest {
                     List.of(dstNamespace)))
         .isInstanceOf(ForbiddenException.class)
         // Generic client message.
-        .hasMessage(
-            "Principal 'alice' with activated PrincipalRoles '[reader]'"
-                + " and activated grants via '[]' is not authorized for op RENAME_TABLE")
+        .hasMessage("Authorization denied")
         // No secondary details leaked to client.
         .hasMessageNotContaining("TABLE_DROP")
         .hasMessageNotContaining("TABLE_LIST")

--- a/regtests/t_cli/src/test_cli.py
+++ b/regtests/t_cli/src/test_cli.py
@@ -129,7 +129,7 @@ def test_quickstart_flow():
 
         # User initially has no catalog access:
         check_exception(cli(user_token)('catalogs', 'get', f'test_cli_catalog_{SALT}'),
-                        exception_str='not authorized')
+                        exception_str='Authorization denied')
 
         # Grant user access:
         check_output(

--- a/regtests/t_pyspark/src/test_spark_sql_s3_with_privileges.py
+++ b/regtests/t_pyspark/src/test_spark_sql_s3_with_privileges.py
@@ -1025,7 +1025,7 @@ def test_spark_credentials_s3_direct_without_read(
     )
     pytest.fail("Expected exception when creating a table without TABLE_WRITE")
   except Exception as e:
-    assert 'CREATE_TABLE_DIRECT_WITH_WRITE_DELEGATION' in str(e)
+    assert 'Authorization denied' in str(e)
 
   snowman_catalog_client.drop_namespace(
     prefix=snowflake_catalog.name,

--- a/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestsFactory.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/admin/PolarisAuthzTestsFactory.java
@@ -108,6 +108,11 @@ public abstract class PolarisAuthzTestsFactory {
   }
 
   @Value.Default
+  protected String expectedDeniedMessage() {
+    return "Authorization denied";
+  }
+
+  @Value.Default
   protected Function<PolarisPrivilege, PrivilegeResult> grantAction() {
     return privilege ->
         adminServiceSupplier()
@@ -201,6 +206,9 @@ public abstract class PolarisAuthzTestsFactory {
 
     @CanIgnoreReturnValue
     public abstract Builder useFreshRequestContext(boolean useFreshRequestContext);
+
+    @CanIgnoreReturnValue
+    public abstract Builder expectedDeniedMessage(String expectedDeniedMessage);
 
     @CanIgnoreReturnValue
     public abstract Builder grantAction(Function<PolarisPrivilege, PrivilegeResult> grantAction);
@@ -324,8 +332,8 @@ public abstract class PolarisAuthzTestsFactory {
                                         privilege,
                                         privilegeSet)
                                     .isInstanceOf(ForbiddenException.class)
-                                    .hasMessageContaining(principalName())
-                                    .hasMessageContaining("is not authorized");
+                                    .hasMessage(expectedDeniedMessage())
+                                    .hasMessageNotContaining(principalName());
                                 assertThat(grantAction().apply(privilege).isSuccess())
                                     .describedAs("Expected success after granting '%s'", privilege)
                                     .isTrue();
@@ -352,8 +360,8 @@ public abstract class PolarisAuthzTestsFactory {
                                     "Expected ForbiddenException after revoking all sufficient privileges '%s'",
                                     privilegeSet)
                                 .isInstanceOf(ForbiddenException.class)
-                                .hasMessageContaining(principalName())
-                                .hasMessageContaining("is not authorized");
+                                .hasMessage(expectedDeniedMessage())
+                                .hasMessageNotContaining(principalName());
                           }));
 
                   return DynamicContainer.dynamicContainer(
@@ -386,8 +394,8 @@ public abstract class PolarisAuthzTestsFactory {
                                     "Expected ForbiddenException with insufficient privilege set '%s'",
                                     privilegeSet)
                                 .isInstanceOf(ForbiddenException.class)
-                                .hasMessageContaining(principalName())
-                                .hasMessageContaining("is not authorized");
+                                .hasMessage(expectedDeniedMessage())
+                                .hasMessageNotContaining(principalName());
 
                           } finally {
                             for (PolarisPrivilege privilege : privilegeSet) {

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractIcebergCatalogHandlerAuthzTest.java
@@ -321,7 +321,8 @@ public abstract class AbstractIcebergCatalogHandlerAuthzTest extends PolarisAuth
     Assertions.assertThatThrownBy(
             () -> newHandler(Set.of(PRINCIPAL_ROLE2)).listNamespaces(Namespace.of(), null, null))
         .isInstanceOf(ForbiddenException.class)
-        .hasMessageContaining("is not authorized");
+        .hasMessage("Authorization denied")
+        .hasMessageNotContaining(PRINCIPAL_ROLE2);
 
     // If we revoke, then it should fail again even with all principal roles activated.
     assertSuccess(

--- a/site/content/in-dev/unreleased/getting-started/using-polaris/_index.md
+++ b/site/content/in-dev/unreleased/getting-started/using-polaris/_index.md
@@ -224,7 +224,7 @@ Spark will lose access to the table:
 ```
 INSERT INTO quickstart_table VALUES (1, 'some data');
 
-org.apache.iceberg.exceptions.ForbiddenException: Forbidden: Principal 'quickstart_user' with activated PrincipalRoles '[]' and activated grants via '[quickstart_catalog_role, quickstart_user_role]' is not authorized for op LOAD_TABLE_WITH_READ_DELEGATION
+org.apache.iceberg.exceptions.ForbiddenException: Forbidden: Authorization denied
 ```
 
 ### Connecting with Trino
@@ -272,7 +272,7 @@ Trino will lose access to the table:
 ```sql
 SELECT * FROM iceberg.quickstart_schema.quickstart_table;
 
-org.apache.iceberg.exceptions.ForbiddenException: Forbidden: Principal 'quickstart_user' with activated PrincipalRoles '[]' and activated grants via '[quickstart_catalog_role, quickstart_user_role]' is not authorized for op LOAD_TABLE_WITH_READ_DELEGATION
+org.apache.iceberg.exceptions.ForbiddenException: Forbidden: Authorization denied
 ```
 
 ### Connecting with PyIceberg


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Hide authorization decision internal logic from error details in `ForbiddenException` message, so the security internals are not leaked to the client.

This is consistent with https://github.com/apache/polaris/pull/4197 , and we go even further by unifying all `PolarisAuthorizer` produced `ForbiddenException` messages to `Authorization denied` in preparation for PolarisAuthorizer SPI refactoring (reference: https://github.com/apache/polaris/pull/5194)


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
