### PR TITLE
Silence verbose Ranger logger during tests

### DIFF
--- a/extensions/auth/ranger/src/intTest/resources/logback-test.xml
+++ b/extensions/auth/ranger/src/intTest/resources/logback-test.xml
@@ -29,5 +29,9 @@
   <root level="${test.log.level:-ERROR}">
     <appender-ref ref="console"/>
   </root>
+  <!--
+  Silence verbose Ranger audit lifecycle logs.
+  OFF is required since the logger logs at ERROR level.
+  -->
   <logger name="org.apache.ranger.audit.provider.AuditProviderFactory" level="OFF"/>
 </configuration>

--- a/extensions/auth/ranger/src/intTest/resources/logback-test.xml
+++ b/extensions/auth/ranger/src/intTest/resources/logback-test.xml
@@ -29,4 +29,5 @@
   <root level="${test.log.level:-ERROR}">
     <appender-ref ref="console"/>
   </root>
+  <logger name="org.apache.ranger.audit.provider.AuditProviderFactory" level="OFF"/>
 </configuration>

--- a/extensions/auth/ranger/src/test/resources/logback-test.xml
+++ b/extensions/auth/ranger/src/test/resources/logback-test.xml
@@ -29,5 +29,9 @@
   <root level="${test.log.level:-ERROR}">
     <appender-ref ref="console"/>
   </root>
+  <!--
+  Silence verbose Ranger audit lifecycle logs.
+  OFF is required since the logger logs at ERROR level.
+  -->
   <logger name="org.apache.ranger.audit.provider.AuditProviderFactory" level="OFF"/>
 </configuration>

--- a/extensions/auth/ranger/src/test/resources/logback-test.xml
+++ b/extensions/auth/ranger/src/test/resources/logback-test.xml
@@ -29,4 +29,5 @@
   <root level="${test.log.level:-ERROR}">
     <appender-ref ref="console"/>
   </root>
+  <logger name="org.apache.ranger.audit.provider.AuditProviderFactory" level="OFF"/>
 </configuration>

--- a/runtime/defaults/src/main/resources/application-it.properties
+++ b/runtime/defaults/src/main/resources/application-it.properties
@@ -50,6 +50,3 @@ polaris.realm-context.realms=POLARIS,OTHER
 
 polaris.storage.gcp.token=token
 polaris.storage.gcp.lifespan=PT1H
-
-# Silence verbose Ranger audit lifecycle logs
-quarkus.log.category."org.apache.ranger.audit.provider.AuditProviderFactory".level=WARN


### PR DESCRIPTION
The previous fix wasn't being applied at the right place: the log messages are produced by the `polaris-extensions-auth-ranger` module, which doesn't use Quarkus.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
