### PR TITLE
Gradle Idea plugin: download sources and javadocs

### DIFF
--- a/build-logic/src/main/kotlin/polaris-root.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-root.gradle.kts
@@ -34,8 +34,8 @@ apply<PublishingHelperPlugin>()
 if (providers.systemProperty("idea.sync.active").getOrElse("false").toBoolean()) {
   idea {
     module {
-      isDownloadJavadoc = false // was 'true', but didn't work
-      isDownloadSources = false // was 'true', but didn't work
+      isDownloadJavadoc = true
+      isDownloadSources = true
       inheritOutputDirs = true
 
       excludeDirs =


### PR DESCRIPTION
Enable downloading sources and javadocs by default for IntelliJ IDEA.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
