### PR TITLE
fix: propagate SupportsBulkOperations through the FileIO wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,14 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   directly under an allowed location, at `s3://b1/ns`, and rejected it as a custom location even
   though the request asked for none. The namespace location is now compared against the
   catalog's `default-base-location`, which is what it is derived from.
+- File cleanup tasks now issue batched object-storage deletes again. `CatalogUtil.deleteFiles`
+  batches only when the `FileIO` is an `instanceof SupportsBulkOperations`, but the `FileIO` reaching
+  the cleanup tasks is wrapped by `ExceptionMappingFileIO` and, on Azure, by
+  `WasbTranslatingFileIO`. Neither wrapper declared the capability held by the wrapped `FileIO`, so
+  the check always failed and every file was deleted individually. Both wrappers now propagate
+  `SupportsBulkOperations` when the wrapped `FileIO` supports it, which affects every storage
+  backend, since `S3FileIO`, `GCSFileIO`, `ADLSFileIO` and `HadoopFileIO` all implement
+  `DelegateFileIO`.
 
 ### Commits
 

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
@@ -123,6 +123,6 @@ public class DefaultFileIOFactory implements FileIOFactory {
   @VisibleForTesting
   FileIO loadFileIOInternal(
       @NonNull String ioImplClassName, @NonNull Map<String, String> properties) {
-    return new ExceptionMappingFileIO(CatalogUtil.loadFileIO(ioImplClassName, properties, null));
+    return ExceptionMappingFileIO.wrap(CatalogUtil.loadFileIO(ioImplClassName, properties, null));
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/ExceptionMappingFileIO.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/ExceptionMappingFileIO.java
@@ -22,20 +22,34 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import java.net.UnknownHostException;
 import java.util.Map;
+import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.polaris.core.exceptions.FileIOUnknownHostException;
 
-/** A {@link FileIO} implementation that wraps an existing FileIO and re-maps exceptions */
+/**
+ * A {@link FileIO} implementation that wraps an existing FileIO and re-maps exceptions.
+ *
+ * <p>Instances are created with {@link #wrap(FileIO)}, which preserves the wrapped FileIO's {@link
+ * SupportsBulkOperations} capability. Callers discover that capability with {@code instanceof}, and
+ * a plain wrapper would hide it.
+ */
 public class ExceptionMappingFileIO implements FileIO {
   private final FileIO io;
 
-  public ExceptionMappingFileIO(FileIO io) {
+  private ExceptionMappingFileIO(FileIO io) {
     this.io = io;
   }
 
-  private void handleException(RuntimeException e) {
+  public static ExceptionMappingFileIO wrap(FileIO io) {
+    return io instanceof SupportsBulkOperations
+        ? new BulkExceptionMappingFileIO(io)
+        : new ExceptionMappingFileIO(io);
+  }
+
+  private static void handleException(RuntimeException e) {
     for (Throwable t : Throwables.getCausalChain(e)) {
       // UnknownHostException isn't a RuntimeException so it's always wrapped
       if (t instanceof UnknownHostException) {
@@ -106,6 +120,27 @@ public class ExceptionMappingFileIO implements FileIO {
     } catch (RuntimeException e) {
       handleException(e);
       throw e;
+    }
+  }
+
+  private static class BulkExceptionMappingFileIO extends ExceptionMappingFileIO
+      implements SupportsBulkOperations {
+
+    private final SupportsBulkOperations bulkIo;
+
+    private BulkExceptionMappingFileIO(FileIO io) {
+      super(io);
+      this.bulkIo = (SupportsBulkOperations) io;
+    }
+
+    @Override
+    public void deleteFiles(Iterable<String> paths) throws BulkDeletionFailureException {
+      try {
+        bulkIo.deleteFiles(paths);
+      } catch (RuntimeException e) {
+        ExceptionMappingFileIO.handleException(e);
+        throw e;
+      }
     }
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIO.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIO.java
@@ -18,8 +18,8 @@
  */
 package org.apache.polaris.service.catalog.io;
 
+import com.google.common.collect.Iterables;
 import java.util.Map;
-import java.util.stream.StreamSupport;
 import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
@@ -117,11 +117,7 @@ public class WasbTranslatingFileIO implements FileIO {
 
     @Override
     public void deleteFiles(Iterable<String> paths) throws BulkDeletionFailureException {
-      bulkIo.deleteFiles(
-          () ->
-              StreamSupport.stream(paths.spliterator(), false)
-                  .map(WasbTranslatingFileIO::translate)
-                  .iterator());
+      bulkIo.deleteFiles(Iterables.transform(paths, WasbTranslatingFileIO::translate));
     }
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIO.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIO.java
@@ -19,15 +19,22 @@
 package org.apache.polaris.service.catalog.io;
 
 import java.util.Map;
+import java.util.stream.StreamSupport;
+import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.polaris.core.storage.StorageLocation;
 import org.apache.polaris.core.storage.azure.AzureLocation;
 
 /**
  * A {@link FileIO} implementation that translates WASB paths into ABFS paths and then delegates to
  * another underlying FileIO implementation
+ *
+ * <p>Instances are created with {@link #wrap(FileIO)}, which preserves the wrapped FileIO's {@link
+ * SupportsBulkOperations} capability. Callers discover that capability with {@code instanceof}, and
+ * a plain wrapper would hide it.
  */
 public class WasbTranslatingFileIO implements FileIO {
   private final FileIO io;
@@ -35,8 +42,14 @@ public class WasbTranslatingFileIO implements FileIO {
   private static final String WASB_SCHEME = "wasb";
   private static final String ABFS_SCHEME = "abfs";
 
-  public WasbTranslatingFileIO(FileIO io) {
+  private WasbTranslatingFileIO(FileIO io) {
     this.io = io;
+  }
+
+  public static WasbTranslatingFileIO wrap(FileIO io) {
+    return io instanceof SupportsBulkOperations
+        ? new BulkWasbTranslatingFileIO(io)
+        : new WasbTranslatingFileIO(io);
   }
 
   private static String translate(String path) {
@@ -90,5 +103,25 @@ public class WasbTranslatingFileIO implements FileIO {
   @Override
   public void close() {
     io.close();
+  }
+
+  private static class BulkWasbTranslatingFileIO extends WasbTranslatingFileIO
+      implements SupportsBulkOperations {
+
+    private final SupportsBulkOperations bulkIo;
+
+    private BulkWasbTranslatingFileIO(FileIO io) {
+      super(io);
+      this.bulkIo = (SupportsBulkOperations) io;
+    }
+
+    @Override
+    public void deleteFiles(Iterable<String> paths) throws BulkDeletionFailureException {
+      bulkIo.deleteFiles(
+          () ->
+              StreamSupport.stream(paths.spliterator(), false)
+                  .map(WasbTranslatingFileIO::translate)
+                  .iterator());
+    }
   }
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIOFactory.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIOFactory.java
@@ -44,7 +44,7 @@ public class WasbTranslatingFileIOFactory implements FileIOFactory {
       @NonNull StorageAccessConfig accessConfig,
       @NonNull String ioImplClassName,
       @NonNull Map<String, String> properties) {
-    return new WasbTranslatingFileIO(
+    return WasbTranslatingFileIO.wrap(
         defaultFileIOFactory.loadFileIO(accessConfig, ioImplClassName, properties));
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/ExceptionMappingFileIOTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/ExceptionMappingFileIOTest.java
@@ -19,10 +19,12 @@
 package org.apache.polaris.service.catalog.io;
 
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.polaris.core.exceptions.FileIOUnknownHostException;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -34,7 +36,7 @@ public class ExceptionMappingFileIOTest {
   @Test
   void testProxiesMethodCalls() {
     try (var io = Mockito.mock(FileIO.class)) {
-      var wrappedIO = new ExceptionMappingFileIO(io);
+      var wrappedIO = ExceptionMappingFileIO.wrap(io);
 
       wrappedIO.newInputFile(PATH);
       Mockito.verify(io, Mockito.times(1)).newInputFile(PATH);
@@ -61,8 +63,60 @@ public class ExceptionMappingFileIOTest {
     try (var io = Mockito.mock(FileIO.class)) {
       Mockito.doThrow(new RuntimeException(new UnknownHostException())).when(io).newInputFile(PATH);
 
-      var wrappedIO = new ExceptionMappingFileIO(io);
-      Assertions.assertThrows(FileIOUnknownHostException.class, () -> wrappedIO.newInputFile(PATH));
+      var wrappedIO = ExceptionMappingFileIO.wrap(io);
+      Assertions.assertThatThrownBy(() -> wrappedIO.newInputFile(PATH))
+          .isInstanceOf(FileIOUnknownHostException.class);
+    }
+  }
+
+  /** A FileIO that also supports bulk operations, as S3FileIO, GCSFileIO and ADLSFileIO all do. */
+  private interface BulkFileIO extends SupportsBulkOperations {}
+
+  @Test
+  void testAdvertisesBulkSupportOnlyWhenTheWrappedIoHasIt() {
+    try (var bulkIo = Mockito.mock(BulkFileIO.class)) {
+      Assertions.assertThat(ExceptionMappingFileIO.wrap(bulkIo))
+          .isInstanceOf(SupportsBulkOperations.class);
+    }
+    try (var plainIo = Mockito.mock(FileIO.class)) {
+      Assertions.assertThat(ExceptionMappingFileIO.wrap(plainIo))
+          .isNotInstanceOf(SupportsBulkOperations.class);
+    }
+  }
+
+  @Test
+  void testDeleteFilesDelegatesToTheWrappedIo() {
+    try (var io = Mockito.mock(BulkFileIO.class)) {
+      var paths = List.of(PATH, "a/b/c");
+
+      ((SupportsBulkOperations) ExceptionMappingFileIO.wrap(io)).deleteFiles(paths);
+
+      Mockito.verify(io, Mockito.times(1)).deleteFiles(paths);
+      Mockito.verify(io, Mockito.never()).deleteFile(Mockito.anyString());
+    }
+  }
+
+  @Test
+  void testDeleteFilesRemapsExceptions() {
+    try (var io = Mockito.mock(BulkFileIO.class)) {
+      var paths = List.of(PATH);
+      Mockito.doThrow(new RuntimeException(new UnknownHostException())).when(io).deleteFiles(paths);
+
+      var wrappedIO = (SupportsBulkOperations) ExceptionMappingFileIO.wrap(io);
+      Assertions.assertThatThrownBy(() -> wrappedIO.deleteFiles(paths))
+          .isInstanceOf(FileIOUnknownHostException.class);
+    }
+  }
+
+  @Test
+  void testDeleteFilesRethrowsUnmappedExceptionsUnchanged() {
+    try (var io = Mockito.mock(BulkFileIO.class)) {
+      var paths = List.of(PATH);
+      var failure = new IllegalStateException("boom");
+      Mockito.doThrow(failure).when(io).deleteFiles(paths);
+
+      var wrappedIO = (SupportsBulkOperations) ExceptionMappingFileIO.wrap(io);
+      Assertions.assertThatThrownBy(() -> wrappedIO.deleteFiles(paths)).isSameAs(failure);
     }
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIOTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIOTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.catalog.io;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.SupportsBulkOperations;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/** Unit tests for WasbTranslatingFileIO */
+public class WasbTranslatingFileIOTest {
+  private static final String WASB_PATH =
+      "wasb://container@storageaccount.blob.core.windows.net/f1";
+  private static final String ABFS_PATH =
+      "abfs://container@storageaccount.blob.core.windows.net/f1";
+  private static final String OTHER_WASB_PATH =
+      "wasb://container@storageaccount.blob.core.windows.net/f2";
+  private static final String OTHER_ABFS_PATH =
+      "abfs://container@storageaccount.blob.core.windows.net/f2";
+  private static final String NON_AZURE_PATH = "s3://bucket/key";
+
+  /** A FileIO that also supports bulk operations, as ADLSFileIO does. */
+  private interface BulkFileIO extends SupportsBulkOperations {}
+
+  @Test
+  void testAdvertisesBulkSupportOnlyWhenTheWrappedIoHasIt() {
+    try (var bulkIo = Mockito.mock(BulkFileIO.class)) {
+      Assertions.assertThat(WasbTranslatingFileIO.wrap(bulkIo))
+          .isInstanceOf(SupportsBulkOperations.class);
+    }
+    try (var plainIo = Mockito.mock(FileIO.class)) {
+      Assertions.assertThat(WasbTranslatingFileIO.wrap(plainIo))
+          .isNotInstanceOf(SupportsBulkOperations.class);
+    }
+  }
+
+  @Test
+  void testDeleteFileTranslatesWasbToAbfs() {
+    try (var io = Mockito.mock(FileIO.class)) {
+      WasbTranslatingFileIO.wrap(io).deleteFile(WASB_PATH);
+
+      Mockito.verify(io, Mockito.times(1)).deleteFile(ABFS_PATH);
+    }
+  }
+
+  @Test
+  void testDeleteFilesTranslatesEveryPath() {
+    try (var io = Mockito.mock(BulkFileIO.class)) {
+      var wrappedIO = (SupportsBulkOperations) WasbTranslatingFileIO.wrap(io);
+
+      wrappedIO.deleteFiles(List.of(WASB_PATH, OTHER_WASB_PATH, NON_AZURE_PATH));
+
+      ArgumentCaptor<Iterable<String>> captor = ArgumentCaptor.captor();
+      Mockito.verify(io, Mockito.times(1)).deleteFiles(captor.capture());
+      Assertions.assertThat(captor.getValue())
+          .containsExactly(ABFS_PATH, OTHER_ABFS_PATH, NON_AZURE_PATH);
+    }
+  }
+
+  @Test
+  void testDeleteFilesArgumentCanBeIteratedMoreThanOnce() {
+    try (var io = Mockito.mock(BulkFileIO.class)) {
+      var wrappedIO = (SupportsBulkOperations) WasbTranslatingFileIO.wrap(io);
+
+      wrappedIO.deleteFiles(List.of(WASB_PATH));
+
+      ArgumentCaptor<Iterable<String>> captor = ArgumentCaptor.captor();
+      Mockito.verify(io).deleteFiles(captor.capture());
+
+      // an implementation may size the batch before deleting, so a one-shot iterator would
+      // silently delete nothing on the second pass
+      var first = new ArrayList<String>();
+      captor.getValue().forEach(first::add);
+      var second = new ArrayList<String>();
+      captor.getValue().forEach(second::add);
+      Assertions.assertThat(first).containsExactly(ABFS_PATH);
+      Assertions.assertThat(second).isEqualTo(first);
+    }
+  }
+
+  @Test
+  void testDeleteFilesPropagatesBulkDeletionFailures() {
+    try (var io = Mockito.mock(BulkFileIO.class)) {
+      Mockito.doThrow(new BulkDeletionFailureException(1)).when(io).deleteFiles(Mockito.any());
+
+      var wrappedIO = (SupportsBulkOperations) WasbTranslatingFileIO.wrap(io);
+      Assertions.assertThatThrownBy(() -> wrappedIO.deleteFiles(List.of(WASB_PATH)))
+          .isInstanceOf(BulkDeletionFailureException.class);
+    }
+  }
+
+  @Test
+  void testWrappingAnExceptionMappingFileIoKeepsBulkSupport() {
+    try (var io = Mockito.mock(BulkFileIO.class)) {
+      // the production stack: WasbTranslatingFileIOFactory wraps what DefaultFileIOFactory returns
+      var wrappedIO = WasbTranslatingFileIO.wrap(ExceptionMappingFileIO.wrap(io));
+      Assertions.assertThat(wrappedIO).isInstanceOf(SupportsBulkOperations.class);
+
+      ((SupportsBulkOperations) wrappedIO).deleteFiles(List.of(WASB_PATH, NON_AZURE_PATH));
+
+      ArgumentCaptor<Iterable<String>> captor = ArgumentCaptor.captor();
+      Mockito.verify(io, Mockito.times(1)).deleteFiles(captor.capture());
+      Assertions.assertThat(captor.getValue()).containsExactly(ABFS_PATH, NON_AZURE_PATH);
+    }
+  }
+}


### PR DESCRIPTION
## Background

#4850 added batched deletion to the file cleanup tasks: `BatchFileCleanupTaskHandler` hands the
whole batch to `FileCleanupTaskHandler.tryDelete(..., Iterable<String> files, type, isConcurrent,
...)`, which calls `CatalogUtil.deleteFiles`.

`CatalogUtil.deleteFiles` batches only when the FileIO satisfies
`instanceof SupportsBulkOperations`, and falls back to one `deleteFile` per path otherwise.

The FileIO that reaches the cleanup tasks is never the configured one. It is wrapped by
`DefaultFileIOFactory` in `ExceptionMappingFileIO`, and on Azure wrapped again by
`WasbTranslatingFileIOFactory` in `WasbTranslatingFileIO`. Both declared only `FileIO`, and a
capability held by the wrapped object is not visible through the wrapper: `instanceof` tests the
wrapper's own type. The check was therefore always false and the per-file branch always ran, so the
batching added by #4850 never executed.

This affects every storage backend, since each FileIO Polaris selects by storage type implements
`DelegateFileIO`, which extends `SupportsBulkOperations`: `S3FileIO`, `GCSFileIO`, `ADLSFileIO` and
`HadoopFileIO`.

Fixes #5377

## Change

Both wrappers gain a `wrap(FileIO)` factory that returns a subclass implementing
`SupportsBulkOperations`, delegating `deleteFiles` to the wrapped FileIO but only when the wrapped
FileIO actually supports bulk operations. The constructors become `private` so callers go through
the factory and cannot silently reintroduce the problem. Both factories now call `wrap()`.

`WasbTranslatingFileIO` translates each path on the bulk path, as it already does for `deleteFile`.
It passes a re-iterable `Iterable` rather than a one-shot iterator, since an implementation may
traverse the paths more than once (for example to size the batch before deleting).

Advertising the capability unconditionally was deliberately avoided: it would send callers down a
bulk path the wrapped FileIO cannot serve. Implementing `DelegateFileIO` was also avoided, because
it would additionally claim `SupportsPrefixOperations`, which these wrappers do not delegate.

## Effect

Measured on a downstream deployment carrying the same wrappers, dropping a table with 660 data
files across 66 manifests (859 files deleted in total):

| | requests to object storage |
|---|---|
| wrappers as they were | 859 `DeleteObject` + 859 `HeadObject` |
| with the capability propagated | 859 files deleted in 86 batched calls |

## Notes

Two follow-ups were left out to keep this change focused, and can be filed separately if useful:

- `ManifestFileCleanupTaskHandler` still deletes manifest data files one per file; it never adopted
  the batch method from #4850.
- `TableCleanupTaskHandler` builds each cleanup task's name by concatenating the batch's file list.
  Since the name is part of a unique index, raising `TABLE_METADATA_CLEANUP_BATCH_SIZE` makes the
  insert exceed the PostgreSQL btree limit, the parent cleanup task fails, and the dropped table's
  files are never removed. This currently caps metadata batches at roughly 26 paths.

AI assistance was used in preparing this change (investigation, drafting and tests); the
implementation and its rationale have been reviewed and are my responsibility.