### PR TITLE
Re-enable cloud storage ViewCatalogTests

### DIFF
--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewAdlsIntegrationTestBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewAdlsIntegrationTestBase.java
@@ -19,12 +19,10 @@
 package org.apache.polaris.service.it.test;
 
 import com.google.common.base.Strings;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.polaris.core.admin.model.AzureStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
-import org.junit.jupiter.api.Disabled;
 
 /** Runs PolarisRestCatalogViewIntegrationTest on Azure. */
 public abstract class PolarisRestCatalogViewAdlsIntegrationTestBase
@@ -38,7 +36,7 @@ public abstract class PolarisRestCatalogViewAdlsIntegrationTestBase
     return AzureStorageConfigInfo.builder()
         .setTenantId(TENANT_ID)
         .setStorageType(StorageConfigInfo.StorageTypeEnum.AZURE)
-        .setAllowedLocations(List.of(BASE_LOCATION))
+        .setAllowedLocations(allowedLocations(BASE_LOCATION))
         .setHierarchical(Optional.ofNullable(HIERARCHICAL).map(Boolean::parseBoolean).orElse(null))
         .build();
   }
@@ -47,25 +45,4 @@ public abstract class PolarisRestCatalogViewAdlsIntegrationTestBase
   protected boolean shouldSkip() {
     return Stream.of(BASE_LOCATION, TENANT_ID).anyMatch(Strings::isNullOrEmpty);
   }
-
-  /**
-   * Disable tests that use @TempDir from ViewCatalogTests (Iceberg base class). These tests are
-   * disabled for now because they use @TempDir which internally goes through Paths.get, and we
-   * cannot make it point to a cloud storage path at the moment.
-   */
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void completeCreateView() {}
-
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void createViewWithCustomMetadataLocation() {}
-
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void createAndReplaceViewWithLocation() {}
-
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void updateViewLocation() {}
 }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewFileIntegrationTestBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewFileIntegrationTestBase.java
@@ -20,7 +20,6 @@ package org.apache.polaris.service.it.test;
 
 import java.lang.reflect.Field;
 import java.nio.file.Path;
-import java.util.List;
 import org.apache.iceberg.view.ViewCatalogTests;
 import org.apache.polaris.core.admin.model.FileStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
@@ -45,8 +44,7 @@ public abstract class PolarisRestCatalogViewFileIntegrationTestBase
     }
     return FileStorageConfigInfo.builder()
         .setStorageType(StorageConfigInfo.StorageTypeEnum.FILE)
-        .setAllowedLocations(
-            List.of(baseLocation, baseLocation + "/" + System.getenv("USER") + "/path/to/data"))
+        .setAllowedLocations(allowedLocations(baseLocation))
         .build();
   }
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewGcsIntegrationTestBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewGcsIntegrationTestBase.java
@@ -19,11 +19,9 @@
 package org.apache.polaris.service.it.test;
 
 import com.google.common.base.Strings;
-import java.util.List;
 import java.util.stream.Stream;
 import org.apache.polaris.core.admin.model.GcpStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
-import org.junit.jupiter.api.Disabled;
 
 /** Runs PolarisRestCatalogViewIntegrationTest on GCP. */
 public abstract class PolarisRestCatalogViewGcsIntegrationTestBase
@@ -37,7 +35,7 @@ public abstract class PolarisRestCatalogViewGcsIntegrationTestBase
     return GcpStorageConfigInfo.builder()
         .setGcsServiceAccount(SERVICE_ACCOUNT)
         .setStorageType(StorageConfigInfo.StorageTypeEnum.GCS)
-        .setAllowedLocations(List.of(BASE_LOCATION))
+        .setAllowedLocations(allowedLocations(BASE_LOCATION))
         .build();
   }
 
@@ -45,25 +43,4 @@ public abstract class PolarisRestCatalogViewGcsIntegrationTestBase
   protected boolean shouldSkip() {
     return Stream.of(BASE_LOCATION, SERVICE_ACCOUNT).anyMatch(Strings::isNullOrEmpty);
   }
-
-  /**
-   * Disable tests that use @TempDir from ViewCatalogTests (Iceberg base class). These tests are
-   * disabled for now because they use @TempDir which internally goes through Paths.get, and we
-   * cannot make it point to a cloud storage path at the moment.
-   */
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void completeCreateView() {}
-
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void createViewWithCustomMetadataLocation() {}
-
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void createAndReplaceViewWithLocation() {}
-
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void updateViewLocation() {}
 }

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewIntegrationBase.java
@@ -21,10 +21,11 @@ package org.apache.polaris.service.it.test;
 import static org.apache.polaris.service.it.env.PolarisClient.polarisClient;
 
 import java.lang.reflect.Method;
-import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.view.BaseView;
 import org.apache.iceberg.view.View;
 import org.apache.iceberg.view.ViewCatalogTests;
@@ -162,6 +163,18 @@ public abstract class PolarisRestCatalogViewIntegrationBase extends ViewCatalogT
   protected abstract StorageConfigInfo getStorageConfigInfo();
 
   /**
+   * Builds the {@code allowedLocations} list for a catalog rooted at {@code baseLocation}.
+   *
+   * <p>Namespace creation validates the namespace's default location against the catalog's allowed
+   * locations with the namespace name appended. {@link #defaultBaseLocation} always resolves to
+   * {@code baseLocation/$USER/path/to/data}, so that variant must be present alongside the raw base
+   * location or top-level namespace creation is rejected.
+   */
+  protected static List<String> allowedLocations(String baseLocation) {
+    return List.of(baseLocation, baseLocation + "/" + System.getenv("USER") + "/path/to/data");
+  }
+
+  /**
    * @return Whether the tests should be skipped, for example due to environment variables not being
    *     specified.
    */
@@ -192,13 +205,54 @@ public abstract class PolarisRestCatalogViewIntegrationBase extends ViewCatalogT
     return true;
   }
 
+  /**
+   * Roots view locations at the catalog's default base location instead of the {@code @TempDir}
+   * used by {@link ViewCatalogTests}.
+   *
+   * <p>The inherited implementation derives locations from a local temporary directory, which
+   * Polaris rejects because it falls outside the catalog's allowed locations, and which cloud
+   * storage backends cannot address at all. Anchoring on the base location keeps the requested
+   * locations valid for every storage type this class is subclassed for.
+   *
+   * <p>The file-based test base builds its base location via {@link java.nio.file.Path#toUri},
+   * which produces a {@code file:///} URI. Polaris normalises stored metadata paths to the
+   * single-slash form {@code file:/} used by {@link java.io.File#toURI}. Stripping the redundant
+   * authority component keeps the return value consistent with the stored form so that the {@code
+   * startsWith} assertions in {@link ViewCatalogTests} remain valid for file-backed catalogs. Cloud
+   * URI schemes (s3://, gs://, abfss://) are not affected by this normalisation.
+   */
+  @Override
+  protected String viewLocation(String... paths) {
+    StringBuilder location =
+        new StringBuilder(LocationUtil.stripTrailingSlash(defaultBaseLocation));
+    for (String path : paths) {
+      location.append("/").append(path);
+    }
+
+    return normalizeToStoredForm(location.toString());
+  }
+
+  /**
+   * Normalises a {@code file:///} URI to the single-slash {@code file:/} form that Polaris stores
+   * (see {@link #viewLocation} for the rationale). Cloud URI schemes (s3://, gs://, abfss://) are
+   * returned unchanged.
+   */
+  private static String normalizeToStoredForm(String location) {
+    if (location.startsWith("file:///")) {
+      return "file:/" + location.substring(8);
+    }
+    return location;
+  }
+
   @Test
   public void createViewWithCustomMetadataLocationUsingPolaris() {
     TableIdentifier identifier = TableIdentifier.of("ns", "view");
 
     String location = defaultBaseLocation + "/custom-view-location";
     String customLocation =
-        Paths.get(storageConfig.getAllowedLocations().getFirst(), "/custom-location1").toString();
+        normalizeToStoredForm(
+                LocationUtil.stripTrailingSlash(storageConfig.getAllowedLocations().getFirst()))
+            + "/custom-location1";
 
     catalog().createNamespace(identifier.namespace());
 

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewS3IntegrationTestBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogViewS3IntegrationTestBase.java
@@ -19,12 +19,10 @@
 package org.apache.polaris.service.it.test;
 
 import com.google.common.base.Strings;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
-import org.junit.jupiter.api.Disabled;
 
 /** Runs PolarisRestCatalogViewIntegrationTest on AWS. */
 public abstract class PolarisRestCatalogViewS3IntegrationTestBase
@@ -39,7 +37,7 @@ public abstract class PolarisRestCatalogViewS3IntegrationTestBase
     return AwsStorageConfigInfo.builder()
         .setRoleArn(ROLE_ARN)
         .setStorageType(StorageConfigInfo.StorageTypeEnum.S3)
-        .setAllowedLocations(List.of(BASE_LOCATION))
+        .setAllowedLocations(allowedLocations(BASE_LOCATION))
         .build();
   }
 
@@ -47,25 +45,4 @@ public abstract class PolarisRestCatalogViewS3IntegrationTestBase
   protected boolean shouldSkip() {
     return Stream.of(BASE_LOCATION, ROLE_ARN).anyMatch(Strings::isNullOrEmpty);
   }
-
-  /**
-   * Disable tests that use @TempDir from ViewCatalogTests (Iceberg base class). These tests are
-   * disabled for now because they use @TempDir which internally goes through Paths.get, and we
-   * cannot make it point to a cloud storage path at the moment.
-   */
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void completeCreateView() {}
-
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void createViewWithCustomMetadataLocation() {}
-
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void createAndReplaceViewWithLocation() {}
-
-  @Disabled("Test uses @TempDir which cannot point to cloud storage paths")
-  @Override
-  public void updateViewLocation() {}
 }


### PR DESCRIPTION
Re-enables the four `ViewCatalogTests` cases disabled for the S3/GCS/ADLS cloud view IT bases, and fixes what surfaced when they ran against real cloud storage. Fixes #3174.

### Timeline
- Iceberg's `ViewCatalogTests.viewLocation(...)` roots view locations at a `@TempDir` (`file:///tmp/...`) — outside any catalog's allowed locations and unaddressable by cloud FileIO.
- #3095 disabled the four affected cases for S3/GCS/ADLS (they remained enabled for file-based ITs).
- `viewLocation` only became overridable once Iceberg made it `protected`; Polaris is now on Iceberg 1.11.0, so the shared base overrides it to root at the catalog's `defaultBaseLocation` and the `@Disabled` stubs are removed.
- Running the re-enabled suites against real cloud credentials surfaced two more fixes: a two-entry `allowedLocations` (base + `$USER/path/to/data`) so top-level namespace creation passes, and `LocationUtil.stripTrailingSlash` instead of `Paths.get` (which collapses the `//` in `s3://`/`gs://`/`abfss://`).

### Testing done
| Backend | Result |
|---|---|
| S3   | 52 tests, 1 skipped, 0 failures |
| GCS  | 52 tests, 1 skipped, 0 failures |
| ADLS | 52 tests, 1 skipped, 0 failures |
| File | 52 tests, 1 skipped, 0 failures |

Run via `./gradlew :polaris-runtime-service:cloudTest` (S3/GCS/ADLS bases) plus the file-based ITs. The single skip is the pre-existing `listViewsInEmptyNamespace` case, gated by `supportsEmptyNamespace()` (unrelated to this change).

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #3174
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed) — not needed; test-only change with no user-facing behavior
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed) — not needed

---
_AI assistance disclosure: prepared with the help of Claude Code. The submitter is the author of this contribution and is responsible for it._
