### PR TITLE
NoSQL: Bulk-fetch grant targets instead of one round-trip per grant

### DIFF
--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
@@ -54,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1236,7 +1237,9 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
     // fetches without adding index work.
     var targetObjs = new ObjBase[targets.size()];
     var accesses = new HashMap<GrantTargetType, IndexedContainerAccess<?>>();
-    var toFetch = new ArrayList<GrantTargetRef>();
+    // fetchMany requires the ids to be distinct, and the same target can be referenced by more
+    // than one grant, so each reference is fetched once and copied to every occurrence.
+    var refOccurrences = new LinkedHashMap<ObjRef, List<Integer>>();
     for (int i = 0; i < targets.size(); i++) {
       var target = targets.get(i);
       var access =
@@ -1245,20 +1248,22 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
               key -> memoizedIndexedAccess.indexedAccess(key.catalogId(), key.typeCode()));
       var objRef = access.objRefById(target.id());
       if (objRef.isPresent()) {
-        toFetch.add(new GrantTargetRef(i, objRef.get()));
+        refOccurrences.computeIfAbsent(objRef.get(), key -> new ArrayList<>()).add(i);
       } else {
         // The root container is the only access that cannot yield a reference without fetching.
         targetObjs[i] = access.byId(target.id()).orElse(null);
       }
     }
 
-    for (int start = 0; start < toFetch.size(); start += FETCH_PAGE_SIZE) {
-      var batch = toFetch.subList(start, Math.min(start + FETCH_PAGE_SIZE, toFetch.size()));
-      var objs =
-          persistence.fetchMany(
-              ObjBase.class, batch.stream().map(GrantTargetRef::objRef).toArray(ObjRef[]::new));
+    var distinctRefs = new ArrayList<>(refOccurrences.keySet());
+    for (int start = 0; start < distinctRefs.size(); start += FETCH_PAGE_SIZE) {
+      var batch =
+          distinctRefs.subList(start, Math.min(start + FETCH_PAGE_SIZE, distinctRefs.size()));
+      var objs = persistence.fetchMany(ObjBase.class, batch.toArray(ObjRef[]::new));
       for (int i = 0; i < batch.size(); i++) {
-        targetObjs[batch.get(i).index()] = objs[i];
+        for (int occurrence : refOccurrences.get(batch.get(i))) {
+          targetObjs[occurrence] = objs[i];
+        }
       }
     }
 
@@ -1403,8 +1408,6 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
       int typeCode) {}
 
   record GrantTargetType(long catalogId, int typeCode) {}
-
-  record GrantTargetRef(int index, ObjRef objRef) {}
 
   static class GrantRecordsCollector implements AclEntryHandler {
     final List<PolarisGrantRecord> grantRecords = new ArrayList<>();

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
@@ -54,7 +54,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1379,7 +1378,7 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
     var accesses = new HashMap<GrantTargetType, IndexedContainerAccess<?>>();
     // fetchMany requires the ids to be distinct, and the same target can be referenced by more
     // than one grant, so each reference is fetched once and copied to every occurrence.
-    var refOccurrences = new LinkedHashMap<ObjRef, List<Integer>>();
+    var refOccurrences = new HashMap<ObjRef, List<Integer>>();
     for (int i = 0; i < targets.size(); i++) {
       var target = targets.get(i);
       var access =
@@ -1395,17 +1394,15 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
       }
     }
 
-    var distinctRefs = new ArrayList<>(refOccurrences.keySet());
-    for (int start = 0; start < distinctRefs.size(); start += FETCH_PAGE_SIZE) {
-      var batch =
-          distinctRefs.subList(start, Math.min(start + FETCH_PAGE_SIZE, distinctRefs.size()));
-      var objs = persistence.fetchMany(ObjBase.class, batch.toArray(ObjRef[]::new));
-      for (int i = 0; i < batch.size(); i++) {
-        for (int occurrence : refOccurrences.get(batch.get(i))) {
-          targetObjs[occurrence] = objs[i];
-        }
-      }
-    }
+    persistence
+        .bucketizedBulkFetches(refOccurrences.keySet().stream(), ObjBase.class)
+        .forEach(
+            obj -> {
+              var occurrences = refOccurrences.get(objRef(obj));
+              for (var occurrence : occurrences) {
+                targetObjs[occurrence] = obj;
+              }
+            });
     return targetObjs;
   }
 

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
@@ -1196,6 +1196,7 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
     Predicate<GrantTriplet> entryFilter = GrantTriplet::reverseOrKey;
     entryFilter = onSecurable ? entryFilter.negate() : entryFilter;
 
+    var targets = new ArrayList<GrantTarget>();
     collectGrantRecords(
         catalogId,
         aclName,
@@ -1225,28 +1226,63 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
             return;
           }
 
-          var indexedAccess = memoizedIndexedAccess.indexedAccess(targetCatalogId, targetTypeCode);
-          var entityOptional =
-              indexedAccess.byId(targetId).map(o -> mapToEntity(o, targetCatalogId));
-
-          if (entityOptional.isPresent()) {
-            PolarisBaseEntity entity = entityOptional.get();
-            LOGGER.trace(
-                "    Adding entity to load-grants-result: catalog:{}, id:{}, type:{}",
-                entity.getCatalogId(),
-                entity.getId(),
-                entity.getType());
-            collector.handle(securableAndGrantee, granted);
-            if (ids.add(targetId)) {
-              entities.add(entity);
-            }
-          } else {
-            // Missing targets indicate tolerated stale grant references that maintenance will
-            // eventually prune.
-            LOGGER.trace("    Not returning stale entity reference");
-          }
+          targets.add(
+              new GrantTarget(
+                  securableAndGrantee, granted, targetCatalogId, targetId, targetTypeCode));
         },
         entryFilter);
+
+    // byId() resolves the reference before fetching, so collecting the references first defers the
+    // fetches without adding index work.
+    var targetObjs = new ObjBase[targets.size()];
+    var accesses = new HashMap<GrantTargetType, IndexedContainerAccess<?>>();
+    var toFetch = new ArrayList<GrantTargetRef>();
+    for (int i = 0; i < targets.size(); i++) {
+      var target = targets.get(i);
+      var access =
+          accesses.computeIfAbsent(
+              new GrantTargetType(target.catalogId(), target.typeCode()),
+              key -> memoizedIndexedAccess.indexedAccess(key.catalogId(), key.typeCode()));
+      var objRef = access.objRefById(target.id());
+      if (objRef.isPresent()) {
+        toFetch.add(new GrantTargetRef(i, objRef.get()));
+      } else {
+        // The root container is the only access that cannot yield a reference without fetching.
+        targetObjs[i] = access.byId(target.id()).orElse(null);
+      }
+    }
+
+    for (int start = 0; start < toFetch.size(); start += FETCH_PAGE_SIZE) {
+      var batch = toFetch.subList(start, Math.min(start + FETCH_PAGE_SIZE, toFetch.size()));
+      var objs =
+          persistence.fetchMany(
+              ObjBase.class, batch.stream().map(GrantTargetRef::objRef).toArray(ObjRef[]::new));
+      for (int i = 0; i < batch.size(); i++) {
+        targetObjs[batch.get(i).index()] = objs[i];
+      }
+    }
+
+    for (int i = 0; i < targets.size(); i++) {
+      var target = targets.get(i);
+      var obj = targetObjs[i];
+      var entity = obj != null ? mapToEntity(obj, target.catalogId()) : null;
+
+      if (entity != null) {
+        LOGGER.trace(
+            "    Adding entity to load-grants-result: catalog:{}, id:{}, type:{}",
+            entity.getCatalogId(),
+            entity.getId(),
+            entity.getType());
+        collector.handle(target.securableAndGrantee(), target.granted());
+        if (ids.add(target.id())) {
+          entities.add(entity);
+        }
+      } else {
+        // Missing targets indicate tolerated stale grant references that maintenance will
+        // eventually prune.
+        LOGGER.trace("    Not returning stale entity reference");
+      }
+    }
 
     LOGGER.trace(
         "Returning {} grant records for loadGrants for catalog:{}, id:{}, entityType:{}({})",
@@ -1358,6 +1394,17 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
                   });
             });
   }
+
+  record GrantTarget(
+      SecurableAndGrantee securableAndGrantee,
+      PrivilegeSet granted,
+      long catalogId,
+      long id,
+      int typeCode) {}
+
+  record GrantTargetType(long catalogId, int typeCode) {}
+
+  record GrantTargetRef(int index, ObjRef objRef) {}
 
   static class GrantRecordsCollector implements AclEntryHandler {
     final List<PolarisGrantRecord> grantRecords = new ArrayList<>();

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/NoSqlMetaStore.java
@@ -1235,37 +1235,7 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
 
     // byId() resolves the reference before fetching, so collecting the references first defers the
     // fetches without adding index work.
-    var targetObjs = new ObjBase[targets.size()];
-    var accesses = new HashMap<GrantTargetType, IndexedContainerAccess<?>>();
-    // fetchMany requires the ids to be distinct, and the same target can be referenced by more
-    // than one grant, so each reference is fetched once and copied to every occurrence.
-    var refOccurrences = new LinkedHashMap<ObjRef, List<Integer>>();
-    for (int i = 0; i < targets.size(); i++) {
-      var target = targets.get(i);
-      var access =
-          accesses.computeIfAbsent(
-              new GrantTargetType(target.catalogId(), target.typeCode()),
-              key -> memoizedIndexedAccess.indexedAccess(key.catalogId(), key.typeCode()));
-      var objRef = access.objRefById(target.id());
-      if (objRef.isPresent()) {
-        refOccurrences.computeIfAbsent(objRef.get(), key -> new ArrayList<>()).add(i);
-      } else {
-        // The root container is the only access that cannot yield a reference without fetching.
-        targetObjs[i] = access.byId(target.id()).orElse(null);
-      }
-    }
-
-    var distinctRefs = new ArrayList<>(refOccurrences.keySet());
-    for (int start = 0; start < distinctRefs.size(); start += FETCH_PAGE_SIZE) {
-      var batch =
-          distinctRefs.subList(start, Math.min(start + FETCH_PAGE_SIZE, distinctRefs.size()));
-      var objs = persistence.fetchMany(ObjBase.class, batch.toArray(ObjRef[]::new));
-      for (int i = 0; i < batch.size(); i++) {
-        for (int occurrence : refOccurrences.get(batch.get(i))) {
-          targetObjs[occurrence] = objs[i];
-        }
-      }
-    }
+    var targetObjs = resolveGrantTargetObjs(targets);
 
     for (int i = 0; i < targets.size(); i++) {
       var target = targets.get(i);
@@ -1398,6 +1368,45 @@ class NoSqlMetaStore extends NonFunctionalBasePersistence {
                     aclEntryConsumer.handle(securableAndGrantee, entry.granted());
                   });
             });
+  }
+
+  /**
+   * Resolves each grant target to its object, fetching in batches. Returns an array parallel to
+   * {@code targets}, with {@code null} for targets that no longer exist.
+   */
+  private ObjBase[] resolveGrantTargetObjs(List<GrantTarget> targets) {
+    var targetObjs = new ObjBase[targets.size()];
+    var accesses = new HashMap<GrantTargetType, IndexedContainerAccess<?>>();
+    // fetchMany requires the ids to be distinct, and the same target can be referenced by more
+    // than one grant, so each reference is fetched once and copied to every occurrence.
+    var refOccurrences = new LinkedHashMap<ObjRef, List<Integer>>();
+    for (int i = 0; i < targets.size(); i++) {
+      var target = targets.get(i);
+      var access =
+          accesses.computeIfAbsent(
+              new GrantTargetType(target.catalogId(), target.typeCode()),
+              key -> memoizedIndexedAccess.indexedAccess(key.catalogId(), key.typeCode()));
+      var objRef = access.objRefById(target.id());
+      if (objRef.isPresent()) {
+        refOccurrences.computeIfAbsent(objRef.get(), key -> new ArrayList<>()).add(i);
+      } else {
+        // The root container is the only access that cannot yield a reference without fetching.
+        targetObjs[i] = access.byId(target.id()).orElse(null);
+      }
+    }
+
+    var distinctRefs = new ArrayList<>(refOccurrences.keySet());
+    for (int start = 0; start < distinctRefs.size(); start += FETCH_PAGE_SIZE) {
+      var batch =
+          distinctRefs.subList(start, Math.min(start + FETCH_PAGE_SIZE, distinctRefs.size()));
+      var objs = persistence.fetchMany(ObjBase.class, batch.toArray(ObjRef[]::new));
+      for (int i = 0; i < batch.size(); i++) {
+        for (int occurrence : refOccurrences.get(batch.get(i))) {
+          targetObjs[occurrence] = objs[i];
+        }
+      }
+    }
+    return targetObjs;
   }
 
   record GrantTarget(

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/indexaccess/IndexedContainerAccess.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/indexaccess/IndexedContainerAccess.java
@@ -59,6 +59,14 @@ public abstract class IndexedContainerAccess<C extends ContainerObj> {
 
   public abstract Optional<ObjBase> byId(long stableId);
 
+  /**
+   * Returns the reference for the given stable id if it can be determined without fetching the
+   * object; an empty result means the caller must fall back to {@link #byId(long)}.
+   */
+  public Optional<ObjRef> objRefById(long stableId) {
+    return Optional.empty();
+  }
+
   public abstract Optional<IndexKey> nameKeyById(long stableId);
 
   public abstract Optional<ObjBase> byParentIdAndName(long parentId, String name);

--- a/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/indexaccess/IndexedContainerAccessImpl.java
+++ b/persistence/nosql/persistence/metastore/src/main/java/org/apache/polaris/persistence/nosql/metastore/indexaccess/IndexedContainerAccessImpl.java
@@ -147,7 +147,8 @@ final class IndexedContainerAccessImpl<C extends ContainerObj> extends IndexedCo
     return catalogStableId;
   }
 
-  private Optional<ObjRef> objRefById(long stableId) {
+  @Override
+  public Optional<ObjRef> objRefById(long stableId) {
     return nameKeyById(stableId).flatMap(this::objRefByName);
   }
 

--- a/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
@@ -28,11 +28,15 @@ import static org.assertj.core.api.InstanceOfAssertFactories.BOOLEAN;
 
 import io.smallrye.common.annotation.Identifier;
 import jakarta.inject.Inject;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.polaris.core.PolarisCallContext;
@@ -63,6 +67,7 @@ import org.apache.polaris.core.policy.PredefinedPolicyTypes;
 import org.apache.polaris.ids.api.MonotonicClock;
 import org.apache.polaris.persistence.nosql.api.Persistence;
 import org.apache.polaris.persistence.nosql.api.RealmPersistenceFactory;
+import org.apache.polaris.persistence.nosql.authz.api.Privileges;
 import org.apache.polaris.persistence.nosql.coretypes.principals.PrincipalsObj;
 import org.apache.polaris.persistence.nosql.coretypes.realm.PolicyMapping;
 import org.assertj.core.api.SoftAssertions;
@@ -92,6 +97,7 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
 
   @Inject RealmPersistenceFactory realmPersistenceFactory;
   @Inject RealmConfigurationSource configurationSource;
+  @Inject Privileges privileges;
   @Inject MonotonicClock monotonicClock;
 
   String realmId;
@@ -705,4 +711,93 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
           + "because both the creation and modification timestamps are enforced by the implementation and "
           + "cannot be tweaked by call sites")
   protected void testCreatePrincipalReturnedEntitySameAsPersisted() {}
+
+  @Test
+  public void testLoadGrantsToGranteeDoesNotFetchPerGrant() {
+    var few = loadGrantsForGrantee(UUID.randomUUID().toString(), 5);
+    var many = loadGrantsForGrantee(UUID.randomUUID().toString(), 25);
+
+    soft.assertThat(many.fetchMany()).describedAs("grant targets are bulk-fetched").isPositive();
+    soft.assertThat(many)
+        .describedAs("every kind of backend round-trip is independent of the grant count")
+        .isEqualTo(few);
+  }
+
+  private FetchCounts loadGrantsForGrantee(String grantsRealmId, int grantCount) {
+    metaStoreManagerFactory.bootstrapRealms(List.of(grantsRealmId), RootCredentialsSet.EMPTY);
+
+    var counters = new HashMap<String, AtomicInteger>();
+    var persistence =
+        countingPersistence(
+            realmPersistenceFactory.newBuilder().realmId(grantsRealmId).build(), counters);
+
+    RealmContext grantsRealmContext = () -> grantsRealmId;
+    var callCtx =
+        new PolarisCallContext(
+            grantsRealmContext, new NoSqlMetaStore(persistence, privileges), configurationSource);
+    var manager = metaStoreManagerFactory.getOrCreateMetaStoreManager(grantsRealmContext);
+
+    var principal =
+        manager
+            .createPrincipal(
+                callCtx,
+                new PrincipalEntity.Builder()
+                    .setId(manager.generateNewEntityId(callCtx).getId())
+                    .setName("principal")
+                    .setCreateTimestamp(1L)
+                    .build())
+            .getPrincipal();
+
+    for (int i = 0; i < grantCount; i++) {
+      var principalRole =
+          new PolarisBaseEntity.Builder()
+              .catalogId(PolarisEntityConstants.getNullId())
+              .id(manager.generateNewEntityId(callCtx).getId())
+              .typeCode(PolarisEntityType.PRINCIPAL_ROLE.getCode())
+              .subTypeCode(PolarisEntitySubType.NULL_SUBTYPE.getCode())
+              .parentId(PolarisEntityConstants.getRootEntityId())
+              .name("principalRole_" + i)
+              .createTimestamp(1L)
+              .build();
+      principalRole = manager.createEntityIfNotExists(callCtx, null, principalRole).getEntity();
+      manager.grantUsageOnRoleToGrantee(callCtx, null, principalRole, principal);
+    }
+
+    counters.clear();
+    var grants = manager.loadGrantsToGrantee(callCtx, principal);
+
+    soft.assertThat(grants.getEntities())
+        .describedAs("every granted principal role is resolved")
+        .hasSize(grantCount);
+
+    return new FetchCounts(
+        counterValue(counters, "fetch"),
+        counterValue(counters, "fetchMany"),
+        counterValue(counters, "fetchReference"));
+  }
+
+  private static int counterValue(Map<String, AtomicInteger> counters, String method) {
+    var counter = counters.get(method);
+    return counter == null ? 0 : counter.get();
+  }
+
+  private static Persistence countingPersistence(
+      Persistence delegate, Map<String, AtomicInteger> counters) {
+    return (Persistence)
+        Proxy.newProxyInstance(
+            Persistence.class.getClassLoader(),
+            new Class<?>[] {Persistence.class},
+            (proxy, method, args) -> {
+              counters
+                  .computeIfAbsent(method.getName(), k -> new AtomicInteger())
+                  .incrementAndGet();
+              try {
+                return method.invoke(delegate, args);
+              } catch (InvocationTargetException e) {
+                throw e.getCause();
+              }
+            });
+  }
+
+  private record FetchCounts(int fetch, int fetchMany, int fetchReference) {}
 }

--- a/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
+++ b/persistence/nosql/persistence/metastore/src/test/java/org/apache/polaris/persistence/nosql/metastore/TestNoSqlMetaStoreManager.java
@@ -717,7 +717,7 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
     var few = loadGrantsForGrantee(UUID.randomUUID().toString(), 5);
     var many = loadGrantsForGrantee(UUID.randomUUID().toString(), 25);
 
-    soft.assertThat(many.fetchMany()).describedAs("grant targets are bulk-fetched").isPositive();
+    soft.assertThat(many.bulkFetches()).describedAs("grant targets are bulk-fetched").isPositive();
     soft.assertThat(many)
         .describedAs("every kind of backend round-trip is independent of the grant count")
         .isEqualTo(few);
@@ -772,7 +772,7 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
 
     return new FetchCounts(
         counterValue(counters, "fetch"),
-        counterValue(counters, "fetchMany"),
+        counterValue(counters, "bucketizedBulkFetches"),
         counterValue(counters, "fetchReference"));
   }
 
@@ -799,5 +799,5 @@ public class TestNoSqlMetaStoreManager extends BasePolarisMetaStoreManagerTest {
             });
   }
 
-  private record FetchCounts(int fetch, int fetchMany, int fetchReference) {}
+  private record FetchCounts(int fetch, int bulkFetches, int fetchReference) {}
 }


### PR DESCRIPTION
`loadGrants` resolves each grant's target with `indexedAccess.byId(targetId)`, which goes through
`IndexedContainerAccessImpl.objByRef` to `persistence.fetch(objRef, ObjBase.class)` - one
single-object backend round-trip per grant, so the cost is linear in grant count.

This is on the authentication path: `DefaultAuthenticator.loadPrincipalGrants` calls
`loadGrantsToGrantee`, so it runs for every authenticated request, and again for
`GET /api/management/v1/principals/{p}/principal-roles`,
`.../principal-roles/{r}/catalog-roles` and `.../catalog-roles/{r}/grants`.

Measured on the in-memory backend at default config, loading the grants of a principal with 25
grants:

    before:  fetch=27  fetchMany=0  fetchReference=26
    after:   fetch=2   fetchMany=1  fetchReference=2

which is the same cost as the 5-grant case, i.e. no longer linear.

The change follows the pattern this class already uses for listing. `listEntities` collects
`ObjRef`s into a buffer capped at `FETCH_PAGE_SIZE`, `listEntitiesBuildPagePart` resolves the
buffer in one `persistence.fetchMany(ObjBase.class, ...)`, and the result is then processed with
missing objects skipped. `loadGrants` now does the same four steps: collect the targets while
walking the ACL entries, resolve each to an `ObjRef` using only the already-loaded indexes,
`fetchMany` in `FETCH_PAGE_SIZE` batches, then process. Index work is unchanged - `byId()` resolves
the reference before fetching anyway, so collecting references first defers the fetches without
adding lookups.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
