### PR TITLE
Fix TestAddressResolver#resolveGoodName to avoid failing due to projectnessie.org

### DIFF
--- a/persistence/nosql/persistence/cdi/quarkus-distcache/src/test/java/org/apache/polaris/persistence/nosql/quarkus/distcache/TestAddressResolver.java
+++ b/persistence/nosql/persistence/cdi/quarkus-distcache/src/test/java/org/apache/polaris/persistence/nosql/quarkus/distcache/TestAddressResolver.java
@@ -90,7 +90,7 @@ public class TestAddressResolver {
 
     List<String> withoutSearchList =
         addressResolver
-            .resolveAll(singletonList("projectnessie.org"))
+            .resolveAll(singletonList("polaris.apache.org"))
             .toCompletionStage()
             .toCompletableFuture()
             .get(1, TimeUnit.MINUTES);
@@ -98,7 +98,7 @@ public class TestAddressResolver {
 
     List<String> withSearchList1 =
         addressResolverWithSearch
-            .resolveAll(singletonList("projectnessie.org"))
+            .resolveAll(singletonList("polaris.apache.org"))
             .toCompletionStage()
             .toCompletableFuture()
             .get(1, TimeUnit.MINUTES);
@@ -108,7 +108,7 @@ public class TestAddressResolver {
 
     List<String> withSearchList2 =
         addressResolverWithSearch
-            .resolveAll(singletonList("projectnessie"))
+            .resolveAll(singletonList("polaris.apache"))
             .toCompletionStage()
             .toCompletableFuture()
             .get(1, TimeUnit.MINUTES);
@@ -117,7 +117,7 @@ public class TestAddressResolver {
 
     List<String> withSearchListQualified =
         addressResolverWithSearch
-            .resolveAll(singletonList("projectnessie.org."))
+            .resolveAll(singletonList("polaris.apache.org."))
             .toCompletionStage()
             .toCompletableFuture()
             .get(1, TimeUnit.MINUTES);


### PR DESCRIPTION
The test relies on `projectnessie.org` which is outside the control of ASF and is currently leading to test failures

```
> Task :polaris-persistence-nosql-cdi-quarkus-distcache:test

TestAddressResolver > resolveGoodName() FAILED
    java.util.concurrent.ExecutionException at TestAddressResolver.java:96
        Caused by: io.vertx.core.dns.DnsException
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
```
Ref: main
1. https://github.com/apache/polaris/actions/runs/32934513455/job/98073057593#step:6:1960
2. https://github.com/apache/polaris/actions/runs/32903729145/job/97987525145#step:6:1949
3. https://github.com/apache/polaris/actions/runs/32914853205/job/98016333414#step:6:1951


Ref: PR
https://github.com/apache/polaris/actions/runs/32931367337/job/98064201293?pr=5383#step:6:1953

```
ayushsaxena@Q3NW54Y0C5 polaris % ping projectnessie.org
ping: cannot resolve projectnessie.org: Unknown host
ayushsaxena@Q3NW54Y0C5 polaris % 
```
The website seems down, better to use the polaris own website, which is in projects control

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
