### PR TITLE
Return 400 for rename requests missing source or destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 
+- Iceberg REST: renaming a table or view with a missing `source` or `destination` now returns `400 Bad Request` instead of `500 Internal Server Error`.
 - Python CLI `catalogs create --type external` now validates `--storage-type` and `--default-base-location` up front, matching the behavior for internal catalogs and the flags' documented "(Required)" status. Previously, omitting either produced an opaque pydantic `ValidationError` at request-build time.
 - Iceberg REST: server-side JSON processing failures (HTTP 500) now return the standard Iceberg
   error envelope (`{"error": {...}}`) instead of a flat `{"code", "message"}` body, so Iceberg

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapter.java
@@ -465,7 +465,7 @@ public class IcebergCatalogAdapter
       UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    EntityNameValidator.validateIdentifier(renameTableRequest.destination());
+    validateRenameRequest(renameTableRequest);
     return withCatalog(
         securityContext,
         prefix,
@@ -652,7 +652,7 @@ public class IcebergCatalogAdapter
       UUID idempotencyKey,
       RealmContext realmContext,
       SecurityContext securityContext) {
-    EntityNameValidator.validateIdentifier(renameTableRequest.destination());
+    validateRenameRequest(renameTableRequest);
     return withCatalog(
         securityContext,
         prefix,
@@ -660,6 +660,24 @@ public class IcebergCatalogAdapter
           catalog.renameView(renameTableRequest);
           return Response.status(Response.Status.NO_CONTENT).build();
         });
+  }
+
+  /**
+   * Validates a rename request before it reaches the catalog. The {@code source} and {@code
+   * destination} identifiers are optional in the wire format (bean validation is disabled for the
+   * Iceberg REST models), so a missing identifier must be rejected here with a 400 rather than
+   * surfacing later as an opaque {@link NullPointerException}. Only the destination is subject to
+   * the entity-name character policy; the source is left unchecked so that objects created before
+   * the policy existed can still be renamed away.
+   */
+  private static void validateRenameRequest(RenameTableRequest renameTableRequest) {
+    if (renameTableRequest.source() == null) {
+      throw new IllegalArgumentException("Rename request is missing the source identifier");
+    }
+    if (renameTableRequest.destination() == null) {
+      throw new IllegalArgumentException("Rename request is missing the destination identifier");
+    }
+    EntityNameValidator.validateIdentifier(renameTableRequest.destination());
   }
 
   @Override

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapterTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapterTest.java
@@ -240,55 +240,49 @@ public class IcebergCatalogAdapterTest {
     }
   }
 
-  @Test
-  void testRenameTableRejectsMissingSource() throws IOException {
-    RenameTableRequest request =
-        renameRequest("{\"destination\":{\"namespace\":[\"ns\"],\"name\":\"newtable\"}}");
-    Assertions.assertThat(request.source()).isNull();
+  static Stream<Arguments> renameRequestsMissingIdentifier() {
+    // operation x which identifier is omitted; the request carries only the other identifier.
+    return Stream.of(
+        Arguments.of(
+            "table", "source", "{\"destination\":{\"namespace\":[\"ns\"],\"name\":\"newtable\"}}"),
+        Arguments.of(
+            "table", "destination", "{\"source\":{\"namespace\":[\"ns\"],\"name\":\"oldtable\"}}"),
+        Arguments.of(
+            "view", "source", "{\"destination\":{\"namespace\":[\"ns\"],\"name\":\"newview\"}}"),
+        Arguments.of(
+            "view", "destination", "{\"source\":{\"namespace\":[\"ns\"],\"name\":\"oldview\"}}"));
+  }
+
+  @ParameterizedTest(name = "rename {0} missing {1} -> 400")
+  @MethodSource("renameRequestsMissingIdentifier")
+  void testRenameRejectsMissingIdentifier(String operation, String missing, String json)
+      throws IOException {
+    RenameTableRequest request = renameRequest(json);
+    if ("source".equals(missing)) {
+      Assertions.assertThat(request.source()).isNull();
+    } else {
+      Assertions.assertThat(request.destination()).isNull();
+    }
     Assertions.assertThatThrownBy(
-            () ->
+            () -> {
+              if ("table".equals(operation)) {
                 catalogAdapter.renameTable(
                     FEDERATED_CATALOG_NAME,
                     request,
                     null,
                     testServices.realmContext(),
-                    testServices.securityContext()))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("source");
-  }
-
-  @Test
-  void testRenameTableRejectsMissingDestination() throws IOException {
-    RenameTableRequest request =
-        renameRequest("{\"source\":{\"namespace\":[\"ns\"],\"name\":\"oldtable\"}}");
-    Assertions.assertThat(request.destination()).isNull();
-    Assertions.assertThatThrownBy(
-            () ->
-                catalogAdapter.renameTable(
-                    FEDERATED_CATALOG_NAME,
-                    request,
-                    null,
-                    testServices.realmContext(),
-                    testServices.securityContext()))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("destination");
-  }
-
-  @Test
-  void testRenameViewRejectsMissingSource() throws IOException {
-    RenameTableRequest request =
-        renameRequest("{\"destination\":{\"namespace\":[\"ns\"],\"name\":\"newview\"}}");
-    Assertions.assertThat(request.source()).isNull();
-    Assertions.assertThatThrownBy(
-            () ->
+                    testServices.securityContext());
+              } else {
                 catalogAdapter.renameView(
                     FEDERATED_CATALOG_NAME,
                     request,
                     null,
                     testServices.realmContext(),
-                    testServices.securityContext()))
+                    testServices.securityContext());
+              }
+            })
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("source");
+        .hasMessageContaining(missing);
   }
 
   /**

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapterTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogAdapterTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.polaris.service.catalog.iceberg;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.polaris.core.admin.model.AuthenticationParameters;
@@ -45,6 +47,7 @@ import org.apache.polaris.core.admin.model.IcebergRestConnectionConfigInfo;
 import org.apache.polaris.core.admin.model.StorageConfigInfo;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.service.TestServices;
+import org.apache.polaris.service.config.PolarisIcebergObjectMapperCustomizer;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -235,6 +238,68 @@ public class IcebergCatalogAdapterTest {
         remain -= expectedSize;
       }
     }
+  }
+
+  @Test
+  void testRenameTableRejectsMissingSource() throws IOException {
+    RenameTableRequest request =
+        renameRequest("{\"destination\":{\"namespace\":[\"ns\"],\"name\":\"newtable\"}}");
+    Assertions.assertThat(request.source()).isNull();
+    Assertions.assertThatThrownBy(
+            () ->
+                catalogAdapter.renameTable(
+                    FEDERATED_CATALOG_NAME,
+                    request,
+                    null,
+                    testServices.realmContext(),
+                    testServices.securityContext()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("source");
+  }
+
+  @Test
+  void testRenameTableRejectsMissingDestination() throws IOException {
+    RenameTableRequest request =
+        renameRequest("{\"source\":{\"namespace\":[\"ns\"],\"name\":\"oldtable\"}}");
+    Assertions.assertThat(request.destination()).isNull();
+    Assertions.assertThatThrownBy(
+            () ->
+                catalogAdapter.renameTable(
+                    FEDERATED_CATALOG_NAME,
+                    request,
+                    null,
+                    testServices.realmContext(),
+                    testServices.securityContext()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("destination");
+  }
+
+  @Test
+  void testRenameViewRejectsMissingSource() throws IOException {
+    RenameTableRequest request =
+        renameRequest("{\"destination\":{\"namespace\":[\"ns\"],\"name\":\"newview\"}}");
+    Assertions.assertThat(request.source()).isNull();
+    Assertions.assertThatThrownBy(
+            () ->
+                catalogAdapter.renameView(
+                    FEDERATED_CATALOG_NAME,
+                    request,
+                    null,
+                    testServices.realmContext(),
+                    testServices.securityContext()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("source");
+  }
+
+  /**
+   * Deserializes a rename request the same way the server does, i.e. with field-level visibility
+   * and without invoking {@link RenameTableRequest#validate()}. This is the only way to obtain a
+   * request whose {@code source} or {@code destination} is null, since the builder rejects nulls.
+   */
+  private static RenameTableRequest renameRequest(String json) throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    new PolarisIcebergObjectMapperCustomizer("1M").customize(mapper);
+    return mapper.readValue(json, RenameTableRequest.class);
   }
 
   private void mockCatalogAdapter(org.apache.iceberg.catalog.Catalog catalog) {


### PR DESCRIPTION

Bean validation is disabled for the Iceberg REST models (`useBeanValidation = false`), so a `renameTable`/`renameView` request that omits `source` or `destination` deserializes to a `null` identifier — `RenameTableRequest.validate()` is skipped on the Jackson field-access path. The null then surfaces as a `NullPointerException` deep in the handler (`PolarisCatalogHelpers.tableIdentifierToList`), returned to the client as an opaque `500 Internal Server Error`.

This guards both identifiers at the REST adapter and rejects a missing one with `400 Bad Request`. The destination keeps its existing entity-name character validation; the source is left unchecked so objects created before that policy can still be renamed away.