### PR TITLE
Fix: StorageUtil.removeRedundantLocations incorrectly drop all equivalent locations when only scheme differed

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/StorageUtil.java
@@ -90,11 +90,24 @@ public class StorageUtil {
     for (String potentialParent : locationStrings) {
       StorageLocation potentialParentLocation = StorageLocation.of(potentialParent);
       for (String potentialChild : locationStrings) {
-        if (!potentialParent.equals(potentialChild)) {
-          StorageLocation potentialChildLocation = StorageLocation.of(potentialChild);
-          if (potentialChildLocation.isChildOf(potentialParentLocation)) {
-            result.remove(potentialChild);
-          }
+        if (potentialParent.equals(potentialChild)) {
+          continue;
+        }
+        StorageLocation potentialChildLocation = StorageLocation.of(potentialChild);
+        boolean childIsChildOfParent = potentialChildLocation.isChildOf(potentialParentLocation);
+        boolean parentIsChildOfChild = potentialParentLocation.isChildOf(potentialChildLocation);
+        if (childIsChildOfParent && parentIsChildOfChild) {
+          // The two raw strings denote the same location once isChildOf's normalization is
+          // applied (e.g. they differ only by a trailing slash, or by an equivalent scheme like
+          // s3/s3a or abfs/abfss), rather than one being a proper sub-location of the other.
+          // Keep exactly one of them -- which one doesn't matter, downstream credential scoping
+          // strips scheme/slash the same way isChildOf does -- via a tie-break that both
+          // orderings of this pair agree on, rather than removing both sides independently.
+          String toRemove =
+              potentialParent.compareTo(potentialChild) > 0 ? potentialParent : potentialChild;
+          result.remove(toRemove);
+        } else if (childIsChildOfParent) {
+          result.remove(potentialChild);
         }
       }
     }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageUtilTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/StorageUtilTest.java
@@ -107,4 +107,35 @@ public class StorageUtilTest {
                     IcebergTableLikeEntity.USER_SPECIFIED_WRITE_METADATA_LOCATION_KEY, "/3/")))
         .contains("/1/", "/2/", "/3/");
   }
+
+  @Test
+  public void getLocationsUsedByTable_trailingSlashOnlyMismatchIsDeduped() {
+    // baseLocation and write.data.path are the same path, differing only by a trailing slash.
+    // They are distinct raw strings, so they do NOT collapse in the HashSet, but they are
+    // mutually isChildOf each other once isChildOf's trailing-slash normalization is applied.
+    // removeRedundantLocations must treat that as equivalence and keep exactly one, not drop both.
+    Assertions.assertThat(
+            StorageUtil.getLocationsUsedByTable(
+                "s3://bucket/a/b/c",
+                Map.of(
+                    IcebergTableLikeEntity.USER_SPECIFIED_WRITE_DATA_LOCATION_KEY,
+                    "s3://bucket/a/b/c/")))
+        .hasSize(1);
+  }
+
+  @Test
+  public void getLocationsUsedByTable_schemeOnlyMismatchIsDeduped() {
+    // Same container/account/file path, but "abfss" (secure) vs "abfs" (non-secure) schemes.
+    // AzureLocation.isChildOf never inspects scheme, so this hits the same bug class as the
+    // trailing-slash case above, with no trailing slash involved at all -- confirming the defect
+    // is in the general mutual-containment handling in removeRedundantLocations, not specific to
+    // trailing slashes.
+    Assertions.assertThat(
+            StorageUtil.getLocationsUsedByTable(
+                "abfss://container@account.dfs.core.windows.net/a/b/c",
+                Map.of(
+                    IcebergTableLikeEntity.USER_SPECIFIED_WRITE_DATA_LOCATION_KEY,
+                    "abfs://container@account.dfs.core.windows.net/a/b/c")))
+        .hasSize(1);
+  }
 }


### PR DESCRIPTION
## Problem

`removeRedundantLocations` drops a location if it's a "child" of another location in the same set:

```java
for (String potentialParent : locationStrings) {
  StorageLocation potentialParentLocation = StorageLocation.of(potentialParent);
  for (String potentialChild : locationStrings) {
    if (!potentialParent.equals(potentialChild)) {
      StorageLocation potentialChildLocation = StorageLocation.of(potentialChild);
      if (potentialChildLocation.isChildOf(potentialParentLocation)) {
        result.remove(potentialChild);
      }
    }
  }
}
```

The self-comparison guard (`!potentialParent.equals(potentialChild)`) compares **raw strings**, but the actual containment check (`StorageLocation.isChildOf`) compares **normalized** strings: it always adds a trailing slash, and `S3Location`/`AzureLocation` also ignore the scheme.

So two raw strings that look different but denote the same location skip the guard, then test as children of *each other*, and both get removed instead of one.

Example — `location` uses the secure Azure scheme, `write.data.path` uses the non-secure one, for the same path:
```
location:        abfss://acct@host.dfs.core.windows.net/mytable
write.data.path: abfs://acct@host.dfs.core.windows.net/mytable
```

Walking the loop with these two strings as `locationStrings`:
- `potentialParent = location`, `potentialChild = write.data.path`: raw strings differ → guard passes → `isChildOf` ignores scheme, so `write.data.path` is a child of `location` → **`write.data.path` removed**.
- `potentialParent = write.data.path`, `potentialChild = location`: same reasoning, symmetrically → **`location` removed**.

Both entries are gone. With only these two in the set, `getLocationsUsedByTable` returns an **empty set**, which fails credential vending (no allowed read/write locations). The same thing happens with a trailing-slash-only mismatch, e.g. `s3://bucket/table` vs `s3://bucket/table/`.

## Fix

Check `isChildOf` in both directions. If it's true both ways, the two strings are the same location (not one containing the other), so keep exactly one instead of removing both:

```java
boolean childIsChildOfParent = potentialChildLocation.isChildOf(potentialParentLocation);
boolean parentIsChildOfChild = potentialParentLocation.isChildOf(potentialChildLocation);
if (childIsChildOfParent && parentIsChildOfChild) {
  String toRemove =
      potentialParent.compareTo(potentialChild) > 0 ? potentialParent : potentialChild;
  result.remove(toRemove);
} else if (childIsChildOfParent) {
  result.remove(potentialChild);
}
```

For the example above, `isChildOf` is now true both ways, so exactly one of `location`/`write.data.path` is removed instead of both. Which one doesn't matter: the AWS/Azure credential integrations strip the scheme before building the actual IAM policy/SAS scope either way.

## Testing

Added two tests to `StorageUtilTest`: one for a scheme-only mismatch, one for a trailing-slash-only mismatch. Both reproduce an empty set on the pre-fix code and pass with the fix.
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
