### PR TITLE
fix(auth): avoid exceptions for non-Polaris tokens during verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   `PURGE_VIEW_METADATA_ON_DROP` defaulting to `true`, dropping any view failed with HTTP 403 under
   the default configuration. A view drop is now governed by `PURGE_VIEW_METADATA_ON_DROP` alone,
   while the guard continues to protect a client-requested Iceberg table purge.
+- `TokenBroker.verify` now returns `null` for tokens not issued by Polaris (checked via the issuer claim without signature verification) instead of failing with an authentication error, so mixed-mode deployments delegate foreign tokens to the external authentication mechanism. A Polaris-issued token that fails verification still fails authentication, now in MIXED mode as well.
 
 ### Deprecations
 
@@ -101,7 +102,6 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 - Iceberg REST: renaming a table or view with a missing `source` or `destination` now returns `400 Bad Request` instead of `500 Internal Server Error`.
 - Internal bearer authentication now returns service unavailable errors (HTTP 503) when token verification hits a metastore failure, instead of treating it as bad credentials.
-- `TokenBroker.verify` now returns `null` for tokens not issued by Polaris (checked via the issuer claim without signature verification) instead of failing with an authentication error, so mixed-mode deployments delegate foreign tokens to the external authentication mechanism. A Polaris-issued token that fails verification still fails authentication, now in MIXED mode as well.
 - Python CLI `catalogs create --type external` now validates `--storage-type` and `--default-base-location` up front, matching the behavior for internal catalogs and the flags' documented "(Required)" status. Previously, omitting either produced an opaque pydantic `ValidationError` at request-build time.
 - Iceberg REST: server-side JSON processing failures (HTTP 500) now return the standard Iceberg
   error envelope (`{"error": {...}}`) instead of a flat `{"code", "message"}` body, so Iceberg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 ### Fixes
 
 - Iceberg REST: renaming a table or view with a missing `source` or `destination` now returns `400 Bad Request` instead of `500 Internal Server Error`.
+- Internal bearer authentication now returns service unavailable errors (HTTP 503) when token verification hits a metastore failure, instead of treating it as bad credentials.
 - Python CLI `catalogs create --type external` now validates `--storage-type` and `--default-base-location` up front, matching the behavior for internal catalogs and the flags' documented "(Required)" status. Previously, omitting either produced an opaque pydantic `ValidationError` at request-build time.
 - Iceberg REST: server-side JSON processing failures (HTTP 500) now return the standard Iceberg
   error envelope (`{"error": {...}}`) instead of a flat `{"code", "message"}` body, so Iceberg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 - Iceberg REST: renaming a table or view with a missing `source` or `destination` now returns `400 Bad Request` instead of `500 Internal Server Error`.
 - Internal bearer authentication now returns service unavailable errors (HTTP 503) when token verification hits a metastore failure, instead of treating it as bad credentials.
+- `TokenBroker.verify` now returns `null` for tokens not issued by Polaris (checked via the issuer claim without signature verification) instead of failing with an authentication error, so mixed-mode deployments delegate foreign tokens to the external authentication mechanism. A Polaris-issued token that fails verification still fails authentication, now in MIXED mode as well.
 - Python CLI `catalogs create --type external` now validates `--storage-type` and `--default-base-location` up front, matching the behavior for internal catalogs and the flags' documented "(Required)" status. Previously, omitting either produced an opaque pydantic `ValidationError` at request-build time.
 - Iceberg REST: server-side JSON processing failures (HTTP 500) now return the standard Iceberg
   error envelope (`{"error": {...}}`) instead of a flat `{"code", "message"}` body, so Iceberg

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/InternalAuthenticationMechanism.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/InternalAuthenticationMechanism.java
@@ -36,7 +36,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Collections;
 import java.util.Set;
-import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
 import org.apache.polaris.service.auth.AuthenticationRealmConfiguration;
 import org.apache.polaris.service.auth.AuthenticationType;
 import org.apache.polaris.service.auth.PolarisCredential;
@@ -94,19 +93,17 @@ class InternalAuthenticationMechanism implements HttpAuthenticationMechanism {
     PolarisCredential token;
     try {
       token = tokenBroker.verify(credential);
-    } catch (PolarisServiceUnavailableException e) {
-      // Preserve auth-time metastore failures from token verify so they keep the shared 503
-      // contract (ErrorResponse + Retry-After) instead of looking like bad credentials or falling
-      // through to another auth mechanism.
-      return Uni.createFrom().failure(e);
     } catch (Exception e) {
-      return configuration.type() == AuthenticationType.MIXED
-          ? Uni.createFrom().nullItem() // let other auth mechanisms handle it
-          : Uni.createFrom().failure(new AuthenticationFailedException(e)); // stop here
+      // No special cases: invalid Polaris tokens and transient failures alike propagate as-is.
+      return Uni.createFrom().failure(e);
     }
 
     if (token == null) {
-      return Uni.createFrom().nullItem();
+      // Not a Polaris-issued token: delegate to other mechanisms in MIXED mode, fail otherwise.
+      return configuration.type() == AuthenticationType.MIXED
+          ? Uni.createFrom().nullItem() // let other auth mechanisms handle it
+          : Uni.createFrom()
+              .failure(new AuthenticationFailedException("Failed to verify the token"));
     }
 
     return identityProviderManager.authenticate(

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/InternalAuthenticationMechanism.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/InternalAuthenticationMechanism.java
@@ -36,6 +36,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Collections;
 import java.util.Set;
+import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
 import org.apache.polaris.service.auth.AuthenticationRealmConfiguration;
 import org.apache.polaris.service.auth.AuthenticationType;
 import org.apache.polaris.service.auth.PolarisCredential;
@@ -93,6 +94,11 @@ class InternalAuthenticationMechanism implements HttpAuthenticationMechanism {
     PolarisCredential token;
     try {
       token = tokenBroker.verify(credential);
+    } catch (PolarisServiceUnavailableException e) {
+      // Preserve auth-time metastore failures from token verify so they keep the shared 503
+      // contract (ErrorResponse + Retry-After) instead of looking like bad credentials or falling
+      // through to another auth mechanism.
+      return Uni.createFrom().failure(e);
     } catch (Exception e) {
       return configuration.type() == AuthenticationType.MIXED
           ? Uni.createFrom().nullItem() // let other auth mechanisms handle it

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/JWTBroker.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/JWTBroker.java
@@ -94,32 +94,35 @@ public class JWTBroker implements TokenBroker {
   public PolarisCredential verify(String token) {
     // Cheap pre-check without cryptographic verification: tokens not issued by Polaris are not
     // ours to verify; return null so the caller can delegate to other mechanisms (mixed mode).
-    if (!isPolarisToken(token)) {
+    // Undecodable tokens cannot be Polaris-issued, so they count as foreign.
+    final DecodedJWT decodedJWT;
+    try {
+      decodedJWT = JWT.decode(token);
+    } catch (JWTDecodeException e) {
       return null;
     }
-    return verifyInternal(token).token();
-  }
-
-  /**
-   * Checks the issuer claim without verifying the signature. Undecodable tokens cannot be
-   * Polaris-issued, so they count as foreign.
-   */
-  private static boolean isPolarisToken(String token) {
-    try {
-      return ISSUER_KEY.equals(JWT.decode(token).getIssuer());
-    } catch (JWTDecodeException e) {
-      return false;
+    if (!ISSUER_KEY.equals(decodedJWT.getIssuer())) {
+      return null;
     }
+    return verifyInternal(decodedJWT).token();
   }
 
   private VerifiedToken verifyInternal(String token) {
+    try {
+      return verifyInternal(JWT.decode(token));
+    } catch (JWTDecodeException e) {
+      throw (NotAuthorizedException)
+          new NotAuthorizedException("Failed to verify the token").initCause(e);
+    }
+  }
+
+  private VerifiedToken verifyInternal(DecodedJWT decodedJWT) {
     // Bearer verify is signature + claims only — no metastore IO. Credential-generation binding is
     // enforced on the token-exchange path. Token construction stays inside the try: a well-signed
     // token that misses a mandatory claim must not surface as a raw NPE.
-    final DecodedJWT decodedJWT;
     final InternalPolarisToken internalToken;
     try {
-      decodedJWT = verifier.verify(token);
+      verifier.verify(decodedJWT);
       internalToken =
           InternalPolarisToken.of(
               decodedJWT.getSubject(),

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/JWTBroker.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/JWTBroker.java
@@ -20,6 +20,7 @@ package org.apache.polaris.service.auth.internal.broker;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.JWTVerifier;
 import com.google.common.annotations.VisibleForTesting;
@@ -91,7 +92,24 @@ public class JWTBroker implements TokenBroker {
 
   @Override
   public PolarisCredential verify(String token) {
+    // Cheap pre-check without cryptographic verification: tokens not issued by Polaris are not
+    // ours to verify; return null so the caller can delegate to other mechanisms (mixed mode).
+    if (!isPolarisToken(token)) {
+      return null;
+    }
     return verifyInternal(token).token();
+  }
+
+  /**
+   * Checks the issuer claim without verifying the signature. Undecodable tokens cannot be
+   * Polaris-issued, so they count as foreign.
+   */
+  private static boolean isPolarisToken(String token) {
+    try {
+      return ISSUER_KEY.equals(JWT.decode(token).getIssuer());
+    } catch (JWTDecodeException e) {
+      return false;
+    }
   }
 
   private VerifiedToken verifyInternal(String token) {

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenBroker.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenBroker.java
@@ -20,6 +20,7 @@ package org.apache.polaris.service.auth.internal.broker;
 
 import org.apache.polaris.service.auth.PolarisCredential;
 import org.apache.polaris.service.types.TokenType;
+import org.jspecify.annotations.Nullable;
 
 /** A broker for generating and verifying tokens. */
 public interface TokenBroker {
@@ -60,5 +61,5 @@ public interface TokenBroker {
    * @throws org.apache.iceberg.exceptions.NotAuthorizedException if the token is Polaris-issued but
    *     invalid
    */
-  PolarisCredential verify(String token);
+  @Nullable PolarisCredential verify(String token);
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenBroker.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenBroker.java
@@ -56,10 +56,23 @@ public interface TokenBroker {
   /**
    * Decodes and verifies the token, then returns the associated {@link PolarisCredential}.
    *
-   * @return the credential for a valid Polaris-issued token, or {@code null} when the token was not
-   *     issued by Polaris (foreign tokens are left to other authentication mechanisms)
-   * @throws org.apache.iceberg.exceptions.NotAuthorizedException if the token is Polaris-issued but
-   *     invalid
+   * <p>Outcomes the caller relies on:
+   *
+   * <ul>
+   *   <li>{@code null} — the token is not recognized by this broker (for example it does not claim
+   *       to be Polaris-issued). In MIXED mode the authentication mechanism may delegate to other
+   *       mechanisms; otherwise authentication fails.
+   *   <li>a credential — the token is recognized and valid.
+   *   <li>{@link org.apache.iceberg.exceptions.NotAuthorizedException} — the token is recognized as
+   *       Polaris-issued but fails verification (invalid signature, claims, and so on). Callers
+   *       must not treat this as “not recognized”; it stops MIXED fallback.
+   *   <li>{@link org.apache.polaris.core.exceptions.PolarisServiceUnavailableException} — a
+   *       transient failure while verifying (for example metastore unavailable). Propagate so
+   *       clients see the shared HTTP 503 contract rather than an authentication failure.
+   * </ul>
+   *
+   * @return the credential for a valid token recognized by this broker, or {@code null} when the
+   *     token is not recognized
    */
   @Nullable PolarisCredential verify(String token);
 }

--- a/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenBroker.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/auth/internal/broker/TokenBroker.java
@@ -52,6 +52,13 @@ public interface TokenBroker {
       final String scope,
       TokenType requestedTokenType);
 
-  /** Decodes and verifies the token, then returns the associated {@link PolarisCredential}. */
+  /**
+   * Decodes and verifies the token, then returns the associated {@link PolarisCredential}.
+   *
+   * @return the credential for a valid Polaris-issued token, or {@code null} when the token was not
+   *     issued by Polaris (foreign tokens are left to other authentication mechanisms)
+   * @throws org.apache.iceberg.exceptions.NotAuthorizedException if the token is Polaris-issued but
+   *     invalid
+   */
   PolarisCredential verify(String token);
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/InternalAuthenticationMechanismTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/InternalAuthenticationMechanismTest.java
@@ -33,6 +33,7 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 import java.time.Duration;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
+import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
 import org.apache.polaris.service.auth.AuthenticationRealmConfiguration;
 import org.apache.polaris.service.auth.AuthenticationType;
 import org.apache.polaris.service.auth.PolarisCredential;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class InternalAuthenticationMechanismTest {
 
@@ -150,6 +152,26 @@ public class InternalAuthenticationMechanismTest {
 
     assertThat(result.await().atMost(AWAIT_TIMEOUT)).isNull();
     verify(tokenBroker).verify("invalidToken");
+    verify(identityProviderManager, never()).authenticate(any(InternalAuthenticationRequest.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = AuthenticationType.class,
+      names = {"INTERNAL", "MIXED"})
+  public void testAuthenticatePropagatesServiceUnavailable(AuthenticationType type) {
+    when(configuration.type()).thenReturn(type);
+    when(routingContext.request()).thenReturn(mock(io.vertx.core.http.HttpServerRequest.class));
+    when(routingContext.request().getHeader("Authorization")).thenReturn("Bearer someToken");
+
+    PolarisServiceUnavailableException cause =
+        new PolarisServiceUnavailableException(0, "Service unavailable");
+    when(tokenBroker.verify("someToken")).thenThrow(cause);
+
+    Uni<SecurityIdentity> result = mechanism.authenticate(routingContext, identityProviderManager);
+
+    assertThatThrownBy(() -> result.await().atMost(AWAIT_TIMEOUT)).isSameAs(cause);
+    verify(tokenBroker).verify("someToken");
     verify(identityProviderManager, never()).authenticate(any(InternalAuthenticationRequest.class));
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/InternalAuthenticationMechanismTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/InternalAuthenticationMechanismTest.java
@@ -128,9 +128,8 @@ public class InternalAuthenticationMechanismTest {
 
     Uni<SecurityIdentity> result = mechanism.authenticate(routingContext, identityProviderManager);
 
-    assertThatThrownBy(() -> result.await().atMost(AWAIT_TIMEOUT))
-        .isInstanceOf(AuthenticationFailedException.class)
-        .hasCause(cause);
+    // The broker's exception is forwarded as-is, no wrapping.
+    assertThatThrownBy(() -> result.await().atMost(AWAIT_TIMEOUT)).isSameAs(cause);
     verify(tokenBroker).verify("invalidToken");
     verify(identityProviderManager, never()).authenticate(any(InternalAuthenticationRequest.class));
   }
@@ -150,8 +149,43 @@ public class InternalAuthenticationMechanismTest {
 
     Uni<SecurityIdentity> result = mechanism.authenticate(routingContext, identityProviderManager);
 
-    assertThat(result.await().atMost(AWAIT_TIMEOUT)).isNull();
+    // A Polaris-issued but invalid token fails even in MIXED mode; only foreign tokens (null
+    // from the broker) delegate to other mechanisms.
+    assertThatThrownBy(() -> result.await().atMost(AWAIT_TIMEOUT)).isSameAs(cause);
     verify(tokenBroker).verify("invalidToken");
+    verify(identityProviderManager, never()).authenticate(any(InternalAuthenticationRequest.class));
+  }
+
+  @Test
+  public void testAuthenticateWithForeignTokenMixedAuth() {
+    when(configuration.type()).thenReturn(AuthenticationType.MIXED);
+    when(routingContext.request()).thenReturn(mock(io.vertx.core.http.HttpServerRequest.class));
+    when(routingContext.request().getHeader("Authorization")).thenReturn("Bearer foreignToken");
+
+    // The broker returns null for tokens that are not Polaris-issued.
+    when(tokenBroker.verify("foreignToken")).thenReturn(null);
+
+    Uni<SecurityIdentity> result = mechanism.authenticate(routingContext, identityProviderManager);
+
+    assertThat(result.await().atMost(AWAIT_TIMEOUT)).isNull();
+    verify(tokenBroker).verify("foreignToken");
+    verify(identityProviderManager, never()).authenticate(any(InternalAuthenticationRequest.class));
+  }
+
+  @Test
+  public void testAuthenticateWithForeignTokenInternalAuth() {
+    when(configuration.type()).thenReturn(AuthenticationType.INTERNAL);
+    when(routingContext.request()).thenReturn(mock(io.vertx.core.http.HttpServerRequest.class));
+    when(routingContext.request().getHeader("Authorization")).thenReturn("Bearer foreignToken");
+
+    // The broker returns null for tokens that are not Polaris-issued.
+    when(tokenBroker.verify("foreignToken")).thenReturn(null);
+
+    Uni<SecurityIdentity> result = mechanism.authenticate(routingContext, identityProviderManager);
+
+    assertThatThrownBy(() -> result.await().atMost(AWAIT_TIMEOUT))
+        .isInstanceOf(AuthenticationFailedException.class);
+    verify(tokenBroker).verify("foreignToken");
     verify(identityProviderManager, never()).authenticate(any(InternalAuthenticationRequest.class));
   }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/InternalAuthenticationServiceUnavailableTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/InternalAuthenticationServiceUnavailableTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.service.auth.internal;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.ws.rs.core.HttpHeaders;
+import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
+import org.apache.polaris.service.auth.internal.broker.TokenBroker;
+import org.junit.jupiter.api.Test;
+
+/**
+ * HTTP-level coverage for {@link InternalAuthenticationMechanism}: a transient failure from {@link
+ * TokenBroker#verify(String)} must surface as the shared auth-time 503 contract (ErrorResponse +
+ * Retry-After), not as an authentication failure.
+ */
+@QuarkusTest
+public class InternalAuthenticationServiceUnavailableTest {
+
+  @InjectMock TokenBroker tokenBroker;
+
+  @Test
+  void bearerAuthReturns503WhenTokenVerifyIsUnavailable() {
+    when(tokenBroker.verify(anyString()))
+        .thenThrow(new PolarisServiceUnavailableException(0, "Service unavailable"));
+
+    given()
+        .header("Authorization", "Bearer unused-token")
+        .header("Polaris-Realm", "POLARIS")
+        .when()
+        .get("/api/management/v1/principal-roles")
+        .then()
+        .statusCode(503)
+        .header(HttpHeaders.RETRY_AFTER, "0")
+        .body("error.message", is("Service unavailable"))
+        .body("error.type", is("PolarisServiceUnavailableException"))
+        .body("error.code", is(503));
+  }
+}

--- a/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/RSAKeyPairJWTBrokerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/auth/internal/broker/RSAKeyPairJWTBrokerTest.java
@@ -94,7 +94,7 @@ public class RSAKeyPairJWTBrokerTest {
   }
 
   @Test
-  public void testVerifyRejectsTokenWithWrongIssuer() throws Exception {
+  public void testVerifyReturnsNullForForeignIssuer() throws Exception {
     var keyPair = PemUtils.generateKeyPair();
 
     PolarisCallContext polarisCallContext = Mockito.mock(PolarisCallContext.class);
@@ -120,13 +120,12 @@ public class RSAKeyPairJWTBrokerTest {
                 Algorithm.RSA256(
                     (RSAPublicKey) provider.publicKey(), (RSAPrivateKey) provider.privateKey()));
 
-    assertThatThrownBy(() -> tokenBroker.verify(tokenWithWrongIssuer))
-        .isInstanceOf(org.apache.iceberg.exceptions.NotAuthorizedException.class)
-        .hasMessageContaining("Failed to verify the token");
+    // Foreign tokens are not ours to verify; the caller delegates to other mechanisms.
+    assertThat(tokenBroker.verify(tokenWithWrongIssuer)).isNull();
   }
 
   @Test
-  public void testVerifyRejectsTokenWithMissingIssuer() throws Exception {
+  public void testVerifyReturnsNullForMissingIssuer() throws Exception {
     var keyPair = PemUtils.generateKeyPair();
 
     PolarisCallContext polarisCallContext = Mockito.mock(PolarisCallContext.class);
@@ -151,7 +150,40 @@ public class RSAKeyPairJWTBrokerTest {
                 Algorithm.RSA256(
                     (RSAPublicKey) provider.publicKey(), (RSAPrivateKey) provider.privateKey()));
 
-    assertThatThrownBy(() -> tokenBroker.verify(tokenWithoutIssuer))
+    assertThat(tokenBroker.verify(tokenWithoutIssuer)).isNull();
+  }
+
+  @Test
+  public void testVerifyRejectsPolarisTokenWithBadSignature() throws Exception {
+    var keyPair = PemUtils.generateKeyPair();
+    var otherKeyPair = PemUtils.generateKeyPair();
+
+    PolarisCallContext polarisCallContext = Mockito.mock(PolarisCallContext.class);
+    PolarisMetaStoreManager metastoreManager = Mockito.mock(PolarisMetaStoreManager.class);
+    KeyProvider provider = new LocalRSAKeyProvider(keyPair);
+    Algorithm algorithm =
+        Algorithm.RSA256(
+            (RSAPublicKey) provider.publicKey(), (RSAPrivateKey) provider.privateKey());
+    TokenBroker tokenBroker =
+        new JWTBroker(
+            metastoreManager,
+            polarisCallContext,
+            420,
+            algorithm,
+            JWTBroker.buildVerifier(algorithm));
+
+    // Polaris-issued (issuer claim) but signed with a different key: still an auth failure.
+    String tokenWithBadSignature =
+        JWT.create()
+            .withIssuer("polaris")
+            .withSubject("principal")
+            .withClaim("active", true)
+            .sign(
+                Algorithm.RSA256(
+                    (RSAPublicKey) otherKeyPair.getPublic(),
+                    (RSAPrivateKey) otherKeyPair.getPrivate()));
+
+    assertThatThrownBy(() -> tokenBroker.verify(tokenWithBadSignature))
         .isInstanceOf(org.apache.iceberg.exceptions.NotAuthorizedException.class)
         .hasMessageContaining("Failed to verify the token");
   }


### PR DESCRIPTION
Internal bearer auth treated unrecognized / foreign tokens as auth failures (or MIXED fallback). `TokenBroker.verify` now returns `null` when the token is not recognized by this broker so MIXED can delegate, and exceptions from `verify` are forwarded as-is.

Stock `JWTBroker.verify` is signature and claims only (no metastore IO after credentials-generation binding moved to token exchange). Secrets-load service-unavailable on exchange is covered separately.