### PR TITLE
Preserve external catalog connection fields in Python clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 
+- Python client deserialization and CLI `setup export` now preserve the remote catalog name and
+  warehouse for Iceberg REST, Hadoop, and Hive external catalogs.
 - Python CLI `catalogs create --type external` now validates `--storage-type` and `--default-base-location` up front, matching the behavior for internal catalogs and the flags' documented "(Required)" status. Previously, omitting either produced an opaque pydantic `ValidationError` at request-build time.
 - Iceberg REST: server-side JSON processing failures (HTTP 500) now return the standard Iceberg
   error envelope (`{"error": {...}}`) instead of a flat `{"code", "message"}` body, so Iceberg

--- a/client/python/generate_clients.py
+++ b/client/python/generate_clients.py
@@ -88,6 +88,8 @@ def generate_polaris_management_client() -> None:
             PYTHON_VERSION,
             "--additional-properties=generateSourceCodeOnly=true",
             "--skip-validate-spec",
+            "--openapi-normalizer",
+            "REFACTOR_ALLOF_WITH_PROPERTIES_ONLY=true",
             "--ignore-file-override",
             OPEN_API_GENERATOR_IGNORE,
             "--global-property=apiDocs=false,modelDocs=false,modelTests=false,apiTests=false",

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -31,6 +31,7 @@ from apache_polaris.sdk.catalog.exceptions import NotFoundException
 from apache_polaris.sdk.management import (
     PolarisCatalog,
     CatalogProperties,
+    ConnectionConfigInfo,
     FileStorageConfigInfo,
     AzureStorageConfigInfo,
     AwsStorageConfigInfo,
@@ -321,6 +322,57 @@ class TestSetupCommand(CLITestBase):
         mock_client.list_catalogs.assert_called()
         mock_client.list_catalog_roles.assert_called_with("my_catalog")
         mock_client.get_catalog.assert_called_with("my_catalog")
+
+    def test_setup_export_preserves_external_catalog_connection_locations(self) -> None:
+        cases = [
+            (
+                {
+                    "connectionType": "ICEBERG_REST",
+                    "uri": "https://example.invalid",
+                    "remoteCatalogName": "prod",
+                },
+                {
+                    "type": "iceberg-rest",
+                    "uri": "https://example.invalid",
+                    "remote_catalog_name": "prod",
+                },
+            ),
+            (
+                {
+                    "connectionType": "HADOOP",
+                    "uri": "file:///warehouse",
+                    "warehouse": "/warehouse",
+                },
+                {
+                    "type": "hadoop",
+                    "uri": "file:///warehouse",
+                    "warehouse": "/warehouse",
+                },
+            ),
+            (
+                {
+                    "connectionType": "HIVE",
+                    "uri": "thrift://example.invalid:9083",
+                    "warehouse": "/warehouse",
+                },
+                {
+                    "type": "hive",
+                    "uri": "thrift://example.invalid:9083",
+                    "warehouse": "/warehouse",
+                },
+            ),
+        ]
+        command = SetupCommand(setup_subcommand=Subcommands.EXPORT)
+
+        self.assertEqual(
+            [
+                command._serialize_connection_info(
+                    ConnectionConfigInfo.from_dict(payload)
+                )
+                for payload, _ in cases
+            ],
+            [{"connection": expected} for _, expected in cases],
+        )
 
     def test_setup_exported_entity_properties_round_trip_through_apply(self) -> None:
         principal_properties = {"owner": "data-platform"}

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -947,32 +947,35 @@ components:
       description: Configuration necessary for connecting to an Iceberg REST Catalog
       allOf:
         - $ref: '#/components/schemas/ConnectionConfigInfo'
-      properties:
-        remoteCatalogName:
-          type: string
-          description: The name of a remote catalog instance within the remote catalog service; in some older systems
-            this is specified as the 'warehouse' when multiple logical catalogs are served under the same base
-            uri, and often translates into a 'prefix' added to all REST resource paths
+        - type: object
+          properties:
+            remoteCatalogName:
+              type: string
+              description: The name of a remote catalog instance within the remote catalog service; in some older systems
+                this is specified as the 'warehouse' when multiple logical catalogs are served under the same base
+                uri, and often translates into a 'prefix' added to all REST resource paths
 
     HadoopConnectionConfigInfo:
       type: object
       description: Configuration necessary for connecting to a Hadoop Catalog
       allOf:
         - $ref: '#/components/schemas/ConnectionConfigInfo'
-      properties:
-        warehouse:
-          type: string
-          description: The file path to where this catalog should store tables
+        - type: object
+          properties:
+            warehouse:
+              type: string
+              description: The file path to where this catalog should store tables
     
     HiveConnectionConfigInfo:
       type: object
       description: Configuration necessary for connecting to a Hive Catalog
       allOf:
         - $ref: '#/components/schemas/ConnectionConfigInfo'
-      properties:
-        warehouse:
-          type: string
-          description: The warehouse location for the hive catalog.
+        - type: object
+          properties:
+            warehouse:
+              type: string
+              description: The warehouse location for the hive catalog.
     
     BigQueryMetastoreConnectionConfigInfo:
       type: object

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -947,35 +947,32 @@ components:
       description: Configuration necessary for connecting to an Iceberg REST Catalog
       allOf:
         - $ref: '#/components/schemas/ConnectionConfigInfo'
-        - type: object
-          properties:
-            remoteCatalogName:
-              type: string
-              description: The name of a remote catalog instance within the remote catalog service; in some older systems
-                this is specified as the 'warehouse' when multiple logical catalogs are served under the same base
-                uri, and often translates into a 'prefix' added to all REST resource paths
+      properties:
+        remoteCatalogName:
+          type: string
+          description: The name of a remote catalog instance within the remote catalog service; in some older systems
+            this is specified as the 'warehouse' when multiple logical catalogs are served under the same base
+            uri, and often translates into a 'prefix' added to all REST resource paths
 
     HadoopConnectionConfigInfo:
       type: object
       description: Configuration necessary for connecting to a Hadoop Catalog
       allOf:
         - $ref: '#/components/schemas/ConnectionConfigInfo'
-        - type: object
-          properties:
-            warehouse:
-              type: string
-              description: The file path to where this catalog should store tables
+      properties:
+        warehouse:
+          type: string
+          description: The file path to where this catalog should store tables
     
     HiveConnectionConfigInfo:
       type: object
       description: Configuration necessary for connecting to a Hive Catalog
       allOf:
         - $ref: '#/components/schemas/ConnectionConfigInfo'
-        - type: object
-          properties:
-            warehouse:
-              type: string
-              description: The warehouse location for the hive catalog.
+      properties:
+        warehouse:
+          type: string
+          description: The warehouse location for the hive catalog.
     
     BigQueryMetastoreConnectionConfigInfo:
       type: object


### PR DESCRIPTION
## Summary

The generated Python management client currently loses subtype-specific connection fields for Iceberg REST, Hadoop, and Hive external catalogs. OpenAPI Generator does not merge schema properties declared as siblings of `allOf` by default, so `ConnectionConfigInfo.from_dict()` discards `remoteCatalogName` and `warehouse`; `polaris setup export` then writes those fields as `null`.

This change:

- enables the OpenAPI Generator `REFACTOR_ALLOF_WITH_PROPERTIES_ONLY` normalizer for Python management-client generation, leaving the source OpenAPI specification unchanged;
- adds a regression test that deserializes all three discriminator variants and verifies setup export retains their location fields; and
- documents the user-visible fix in the changelog.

The wire contract, source OpenAPI specification, and requiredness are unchanged; this corrects generated-client model composition.

Fixes #5409

## Validation

- `make client-regenerate`
- `make client-unit-test` — 198 passed
- `make client-lint`
- `make client-license-check`
- `make client-build`
- `./gradlew format compileAll` with Java 21

## AI assistance

AI assistance was used for investigation, reproduction, implementation, and validation. I reviewed the issue, generated diff, tests, and contribution text and understand the change end to end.

## Checklist

- [x] 🛡️ Do not disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #5409
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic (none needed for this generator configuration correction)
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (not needed; the API contract and usage are unchanged)