### PR TITLE
Site: redesign shortcodes and partials producing GitHub links

### DIFF
--- a/site/layouts/partials/githubPolarisUrl.html
+++ b/site/layouts/partials/githubPolarisUrl.html
@@ -17,4 +17,13 @@ specific language governing permissions and limitations
 under the License.
 */}}
 
-{{- partial "githubPolarisUrl.html" (dict "page" . "path" (.Get 0)) -}}
+{{/*
+Returns a GitHub URL pointing to the given path in the apache/polaris repository,
+resolved to the correct branch or tag for the current page's release version.
+
+Usage: {{ partial "githubPolarisUrl.html" (dict "page" . "path" "path/to/file") }}
+*/}}
+
+{{- $gitRef := partial "polarisGitRef.html" .page -}}
+{{- $url := printf "https://github.com/apache/polaris/blob/%s/%s" $gitRef.ref .path -}}
+{{- return $url -}}

--- a/site/layouts/partials/incubatingSuffix.html
+++ b/site/layouts/partials/incubatingSuffix.html
@@ -17,4 +17,20 @@ specific language governing permissions and limitations
 under the License.
 */}}
 
-{{- partial "githubPolarisUrl.html" (dict "page" . "path" (.Get 0)) -}}
+{{/*
+Returns "-incubating" if the given release version predates graduation (< 1.4.0),
+or "" otherwise. Pass "[unreleased]" to get "".
+
+Usage: {{ partial "incubatingSuffix.html" $ver }}
+*/}}
+
+{{- $suffix := "" -}}
+{{- if ne . "[unreleased]" -}}
+{{- $parts := split . "." -}}
+{{- $vMajor := index $parts 0 | int -}}
+{{- $vMinor := index $parts 1 | int -}}
+{{- if or (lt $vMajor 1) (and (eq $vMajor 1) (lt $vMinor 4)) -}}
+{{- $suffix = "-incubating" -}}
+{{- end -}}
+{{- end -}}
+{{- return $suffix -}}

--- a/site/layouts/partials/polarisGitRef.html
+++ b/site/layouts/partials/polarisGitRef.html
@@ -17,4 +17,19 @@ specific language governing permissions and limitations
 under the License.
 */}}
 
-{{- partial "githubPolarisUrl.html" (dict "page" . "path" (.Get 0)) -}}
+{{/*
+Returns a dict describing the git ref for the current page's release version:
+  - ref:        "main" for unreleased, or "apache-polaris-{ver}{incubating}" for a release
+  - isReleased: false for unreleased, true for a release
+
+Usage: {{ $gitRef := partial "polarisGitRef.html" . }}
+*/}}
+
+{{- $ver := partial "releaseVersion.html" . -}}
+{{- $result := dict "isReleased" false "ref" "main" -}}
+{{- if ne $ver "[unreleased]" -}}
+{{- $incubating := partial "incubatingSuffix.html" $ver -}}
+{{- $ref := printf "apache-polaris-%s%s" $ver $incubating -}}
+{{- $result = dict "isReleased" true "ref" $ref -}}
+{{- end -}}
+{{- return $result -}}

--- a/site/layouts/partials/rawGithubPolarisUrl.html
+++ b/site/layouts/partials/rawGithubPolarisUrl.html
@@ -16,16 +16,18 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 */}}
-{{- $ver := partial "releaseVersion.html" . -}}
-{{- $spec := ( .Get 0 ) -}}
-{{- $url := "" -}}
-{{- $incubating := "" -}}
-{{- if lt $ver "1.4.0" -}}
-{{- $incubating = "-incubating" -}}
-{{- end -}}
-{{- if eq $ver "[unreleased]" -}}
-{{- $url = printf "https://github.com/apache/polaris/raw/refs/heads/main/spec/%s" $spec }}
-{{- else -}}
-{{- $url = printf "https://github.com/apache/polaris/raw/refs/tags/apache-polaris-%s%s/spec/%s" $ver $incubating $spec }}
+
+{{/*
+Returns a raw.githubusercontent.com URL pointing to the given path in the
+apache/polaris repository, resolved to the correct branch or tag for the
+current page's release version.
+
+Usage: {{ partial "rawGithubPolarisUrl.html" (dict "page" . "path" "path/to/file") }}
+*/}}
+
+{{- $gitRef := partial "polarisGitRef.html" .page -}}
+{{- $url := printf "https://raw.githubusercontent.com/apache/polaris/refs/heads/%s/%s" $gitRef.ref .path -}}
+{{- if $gitRef.isReleased -}}
+{{- $url = printf "https://raw.githubusercontent.com/apache/polaris/refs/tags/%s/%s" $gitRef.ref .path -}}
 {{- end -}}
 {{- return $url -}}

--- a/site/layouts/shortcodes/raw-github-polaris.html
+++ b/site/layouts/shortcodes/raw-github-polaris.html
@@ -17,4 +17,4 @@ specific language governing permissions and limitations
 under the License.
 */}}
 
-{{- partial "githubPolarisUrl.html" (dict "page" . "path" (.Get 0)) -}}
+{{- partial "rawGithubPolarisUrl.html" (dict "page" . "path" (.Get 0)) -}}

--- a/site/layouts/shortcodes/redoc-polaris.html
+++ b/site/layouts/shortcodes/redoc-polaris.html
@@ -13,20 +13,7 @@ Copied from Docsy shortcodes/redoc.html.
 
 {{- $spec := .Get 0 -}}
 {{- $otheroptions := .Get 1 -}}
-{{- $url := "" -}}
-
-{{- $ver := partial "releaseVersion.html" . -}}
-{{- $spec := ( .Get 0 ) -}}
-{{- $url := "" -}}
-{{- $incubating := "" -}}
-{{- if lt $ver "1.4.0" -}}
-{{- $incubating = "-incubating" -}}
-{{- end -}}
-{{- if eq $ver "[unreleased]" -}}
-{{- $url = printf "https://raw.githubusercontent.com/apache/polaris/refs/heads/main/spec/%s" $spec }}
-{{- else -}}
-{{- $url = printf "https://raw.githubusercontent.com/apache/polaris/refs/tags/apache-polaris-%s%s/spec/%s" $ver $incubating $spec }}
-{{- end -}}
+{{- $url := partial "rawGithubPolarisUrl.html" (dict "page" . "path" (printf "spec/%s" $spec)) -}}
 
 <!-- CSS style overrides for Redoc API docs -->
 <style>


### PR DESCRIPTION
The existing partials and shortcodes generally had bugs:

- Incorrect handling of the `-incubating` suffix
- Incorrect naming of release tags
- Duplicated logic in many places

This PR introduces new partials:

- A new `incubatingSuffix.html` partial that correctly outputs the `-incubating` suffix when appropriate;
- A new `polarisGitRef.html` partial that outputs a dict with info about a Git ref;
- A new `githubPolarisUrl.html` partial that outputs standard GitHub URLs for a given ref;
- A new `rawGithubPolarisUrl.html` partial that outputs raw-style GitHub URLs for a given ref.

It also introduces a new `raw-github-polaris.html` shortcode that just calls the `rawGithubPolarisUrl.html` partial.

The existing `github-polaris.html` shortcode is modified to just call the `githubPolarisUrl.html` partial.

The old `openapiUrl.html` partial is removed. It seems to represent an old state of the URL-computing logic found in `redoc-polaris.html`. It is now superseded by `rawGithubPolarisUrl.html`.

Finally, the `redoc-polaris.html` shortcode is modified to call the `rawGithubPolarisUrl.html` partial.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
