### PR TITLE
CLI: add storage-name support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Python CLI: `catalogs update` now supports `--no-sts` and `--no-kms` to toggle STS/KMS availability on an existing S3 catalog. Previously these were only settable at `catalogs create` time.
 - Python CLI: added `gcp` as an external catalog authentication type for Iceberg REST federation, enabling CLI creation of GCP-authenticated catalogs such as BigLake without passing Google credential secrets through command-line flags.
 - The database schema used by the Relational JDBC persistence backend is now configurable through standard datasource configuration: the JDBC driver's `currentSchema` connection property (defaulted to `POLARIS_SCHEMA` via `quarkus.datasource.jdbc.additional-jdbc-properties.currentSchema`) selects the schema, and the persistence layer is agnostic of the schema name. Also exposed as `persistence.relationalJdbc.additionalProperties.currentSchema` in the Helm chart.
-- Python CLI: `catalogs create` now supports `--storage-name` to set an optional name referencing a server-side storage configuration.
+- Python CLI: `catalogs create` and `catalogs update` now support `--storage-name` to set an optional name referencing a server-side storage configuration.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Python CLI: `catalogs update` now supports `--no-sts` and `--no-kms` to toggle STS/KMS availability on an existing S3 catalog. Previously these were only settable at `catalogs create` time.
 - Python CLI: added `gcp` as an external catalog authentication type for Iceberg REST federation, enabling CLI creation of GCP-authenticated catalogs such as BigLake without passing Google credential secrets through command-line flags.
 - The database schema used by the Relational JDBC persistence backend is now configurable through standard datasource configuration: the JDBC driver's `currentSchema` connection property (defaulted to `POLARIS_SCHEMA` via `quarkus.datasource.jdbc.additional-jdbc-properties.currentSchema`) selects the schema, and the persistence layer is agnostic of the schema name. Also exposed as `persistence.relationalJdbc.additionalProperties.currentSchema` in the Helm chart.
+- Python CLI: `catalogs create` now supports `--storage-name` to set an optional name referencing a server-side storage configuration.
 
 ### Changes
 

--- a/client/python/apache_polaris/cli/command/__init__.py
+++ b/client/python/apache_polaris/cli/command/__init__.py
@@ -53,6 +53,7 @@ class Command(ABC):
                 catalog_type=options_get(Arguments.TYPE),
                 default_base_location=options_get(Arguments.DEFAULT_BASE_LOCATION),
                 storage_type=options_get(Arguments.STORAGE_TYPE),
+                storage_name=options_get(Arguments.STORAGE_NAME),
                 allowed_locations=options_get(Arguments.ALLOWED_LOCATION),
                 role_arn=options_get(Arguments.ROLE_ARN),
                 external_id=options_get(Arguments.EXTERNAL_ID),

--- a/client/python/apache_polaris/cli/command/catalogs.py
+++ b/client/python/apache_polaris/cli/command/catalogs.py
@@ -81,6 +81,7 @@ class CatalogsCommand(Command):
     catalog_type: Optional[str] = None
     default_base_location: Optional[str] = None
     storage_type: Optional[str] = None
+    storage_name: Optional[str] = None
     allowed_locations: Optional[List[str]] = None
     role_arn: Optional[str] = None
     external_id: Optional[str] = None
@@ -243,8 +244,9 @@ class CatalogsCommand(Command):
                     f" {Argument.to_flag_name(Arguments.KMS_KEY_DECRYPTION)},"
                     f" {Argument.to_flag_name(Arguments.STS_ENDPOINT)},"
                     f" {Argument.to_flag_name(Arguments.STS_UNAVAILABLE)},"
-                    f" {Argument.to_flag_name(Arguments.KMS_UNAVAILABLE)}, and"
-                    f" {Argument.to_flag_name(Arguments.PATH_STYLE_ACCESS)}"
+                    f" {Argument.to_flag_name(Arguments.KMS_UNAVAILABLE)},"
+                    f" {Argument.to_flag_name(Arguments.PATH_STYLE_ACCESS)}, and"
+                    f" {Argument.to_flag_name(Arguments.STORAGE_NAME)}"
                 )
         elif self.storage_type == StorageType.AZURE.value:
             if not self.tenant_id:
@@ -256,14 +258,16 @@ class CatalogsCommand(Command):
                 raise CliError(
                     "Storage type 'azure' supports the options"
                     f" {Argument.to_flag_name(Arguments.TENANT_ID)},"
-                    f" {Argument.to_flag_name(Arguments.MULTI_TENANT_APP_NAME)}, and"
-                    f" {Argument.to_flag_name(Arguments.CONSENT_URL)}"
+                    f" {Argument.to_flag_name(Arguments.MULTI_TENANT_APP_NAME)}"
+                    f" {Argument.to_flag_name(Arguments.CONSENT_URL)}, and"
+                    f" {Argument.to_flag_name(Arguments.STORAGE_NAME)}"
                 )
         elif self.storage_type == StorageType.GCS.value:
             if self._has_aws_storage_info() or self._has_azure_storage_info():
                 raise CliError(
                     "Storage type 'gcs' supports the storage credential"
-                    f" {Argument.to_flag_name(Arguments.SERVICE_ACCOUNT)}"
+                    f" {Argument.to_flag_name(Arguments.SERVICE_ACCOUNT)} and"
+                    f" {Argument.to_flag_name(Arguments.STORAGE_NAME)}"
                 )
         elif self.storage_type == StorageType.FILE.value:
             if (
@@ -317,6 +321,7 @@ class CatalogsCommand(Command):
         if self.storage_type == StorageType.S3.value:
             config = AwsStorageConfigInfo(
                 storage_type=self.storage_type.upper(),
+                storage_name=self.storage_name,
                 allowed_locations=self.allowed_locations,
                 role_arn=self.role_arn,
                 external_id=self.external_id,
@@ -336,6 +341,7 @@ class CatalogsCommand(Command):
         elif self.storage_type == StorageType.AZURE.value:
             config = AzureStorageConfigInfo(
                 storage_type=self.storage_type.upper(),
+                storage_name=self.storage_name,
                 allowed_locations=self.allowed_locations,
                 tenant_id=self.tenant_id,
                 multi_tenant_app_name=self.multi_tenant_app_name,
@@ -345,12 +351,14 @@ class CatalogsCommand(Command):
         elif self.storage_type == StorageType.GCS.value:
             config = GcpStorageConfigInfo(
                 storage_type=self.storage_type.upper(),
+                storage_name=self.storage_name,
                 allowed_locations=self.allowed_locations,
                 gcs_service_account=self.service_account,
             )
         elif self.storage_type == StorageType.FILE.value:
             config = StorageConfigInfo(
                 storage_type=self.storage_type.upper(),
+                storage_name=self.storage_name,
                 allowed_locations=self.allowed_locations,
             )
         return config
@@ -524,6 +532,7 @@ class CatalogsCommand(Command):
                 or self._has_azure_storage_info()
                 or self._has_gcs_storage_info()
                 or self.allowed_locations
+                or self.storage_name
             ):
                 # We must first reconstitute local storage-config related settings from the existing
                 # catalog to properly construct the complete updated storage-config
@@ -533,6 +542,8 @@ class CatalogsCommand(Command):
                 # _build_storage_config_info helper; instead, each allowed updatable field defined
                 # in option_tree.py should be applied individually against the existing
                 # storage_config_info here.
+                if self.storage_name:
+                    updated_storage_info.storage_name = self.storage_name
                 if self.allowed_locations:
                     updated_storage_info.allowed_locations = (
                         updated_storage_info.allowed_locations or []

--- a/client/python/apache_polaris/cli/command/catalogs.py
+++ b/client/python/apache_polaris/cli/command/catalogs.py
@@ -531,8 +531,8 @@ class CatalogsCommand(Command):
                 self._has_aws_storage_info()
                 or self._has_azure_storage_info()
                 or self._has_gcs_storage_info()
-                or self.allowed_locations if not None
-                or self.storage_name
+                or self.allowed_locations
+                or self.storage_name is not None
             ):
                 # We must first reconstitute local storage-config related settings from the existing
                 # catalog to properly construct the complete updated storage-config

--- a/client/python/apache_polaris/cli/command/catalogs.py
+++ b/client/python/apache_polaris/cli/command/catalogs.py
@@ -258,7 +258,7 @@ class CatalogsCommand(Command):
                 raise CliError(
                     "Storage type 'azure' supports the options"
                     f" {Argument.to_flag_name(Arguments.TENANT_ID)},"
-                    f" {Argument.to_flag_name(Arguments.MULTI_TENANT_APP_NAME)}"
+                    f" {Argument.to_flag_name(Arguments.MULTI_TENANT_APP_NAME)},"
                     f" {Argument.to_flag_name(Arguments.CONSENT_URL)}, and"
                     f" {Argument.to_flag_name(Arguments.STORAGE_NAME)}"
                 )
@@ -531,7 +531,7 @@ class CatalogsCommand(Command):
                 self._has_aws_storage_info()
                 or self._has_azure_storage_info()
                 or self._has_gcs_storage_info()
-                or self.allowed_locations
+                or self.allowed_locations if not None
                 or self.storage_name
             ):
                 # We must first reconstitute local storage-config related settings from the existing

--- a/client/python/apache_polaris/cli/constants.py
+++ b/client/python/apache_polaris/cli/constants.py
@@ -166,6 +166,7 @@ class Arguments:
     TYPE = "type"
     DEFAULT_BASE_LOCATION = "default_base_location"
     STORAGE_TYPE = "storage_type"
+    STORAGE_NAME = "storage_name"
     ALLOWED_LOCATION = "allowed_location"
     ROLE_ARN = "role_arn"
     EXTERNAL_ID = "external_id"

--- a/client/python/apache_polaris/cli/options/option_tree.py
+++ b/client/python/apache_polaris/cli/options/option_tree.py
@@ -236,6 +236,11 @@ class OptionTree:
                             choices=[st.value for st in StorageType],
                         ),
                         Argument(
+                            Arguments.STORAGE_NAME,
+                            str,
+                            "An optional name referencing a server-side storage configuration",
+                        ),
+                        Argument(
                             Arguments.DEFAULT_BASE_LOCATION,
                             str,
                             "(Required) Default base location for the catalog",
@@ -395,6 +400,11 @@ class OptionTree:
                     Subcommands.UPDATE,
                     hint="Update properties of a catalog",
                     args=[
+                        Argument(
+                            Arguments.STORAGE_NAME,
+                            str,
+                            "A new storage name referencing a server-side storage configuration",
+                        ),
                         Argument(
                             Arguments.DEFAULT_BASE_LOCATION,
                             str,

--- a/client/python/tests/test_catalogs_command.py
+++ b/client/python/tests/test_catalogs_command.py
@@ -332,6 +332,28 @@ class TestCatalogsCommand(CLITestBase):
             "https://sts.amazonaws.com",
         )
 
+    def test_catalog_create_s3_storage_name(self) -> None:
+        mock_client = self.build_mock_client()
+        self.mock_execute(
+            mock_client,
+            [
+                "catalogs",
+                "create",
+                "s3-catalog",
+                "--storage-type",
+                "s3",
+                "--default-base-location",
+                "s3://bucket/path",
+                "--storage-name",
+                "analytics-prod",
+            ],
+        )
+        call_args = mock_client.create_catalog.call_args[0][0]
+        self.assertEqual(call_args.catalog.name, "s3-catalog")
+        self.assertEqual(
+            call_args.catalog.storage_config_info.storage_name, "analytics-prod"
+        )
+
     def test_catalog_create_gcs_options(self) -> None:
         mock_client = self.build_mock_client()
         self.mock_execute(
@@ -620,6 +642,26 @@ class TestCatalogsCommand(CLITestBase):
             ),
             "--no-kms requires S3 storage_type",
         )
+
+    def test_catalog_update_storage_name(self) -> None:
+        mock_client = self.build_mock_client()
+        mock_client.get_catalog.return_value = PolarisCatalog(
+            type="INTERNAL",
+            name="s3-catalog",
+            entity_version=1,
+            properties=CatalogProperties(
+                default_base_location="s3://bucket/path", additional_properties={}
+            ),
+            storage_config_info=AwsStorageConfigInfo(
+                storage_type="S3", allowed_locations=[]
+            ),
+        )
+        self.mock_execute(
+            mock_client,
+            ["catalogs", "update", "s3-catalog", "--storage-name", "analytics-prod"],
+        )
+        call_args = mock_client.update_catalog.call_args[0][1]
+        self.assertEqual(call_args.storage_config_info.storage_name, "analytics-prod")
 
     def test_catalog_list(self) -> None:
         mock_client = self.build_mock_client()

--- a/site/content/in-dev/unreleased/command-line-interface.md
+++ b/site/content/in-dev/unreleased/command-line-interface.md
@@ -351,6 +351,7 @@ options:
   -h, --help                                     show this help message and exit
 
 Command Options:
+  --storage-name STORAGE_NAME                    A new storage name referencing a server-side storage configuration
   --default-base-location DEFAULT_BASE_LOCATION  A new default base location for the catalog
   --allowed-location ALLOWED_LOCATION            An additional allowed location for files
   --set-property SET_PROPERTY                    A key/value pair such as: tag=value. Merges the specified key/value into an existing properties map by updating the value if the key already exists or creating a new entry if not. Multiple can be provided by specifying this option more than once. Do not put passwords, tokens, access keys, or other secrets into the client-visible catalog properties.

--- a/site/content/in-dev/unreleased/command-line-interface.md
+++ b/site/content/in-dev/unreleased/command-line-interface.md
@@ -172,6 +172,7 @@ options:
 Command Options:
   --type {internal,external}                                           The type of catalog [INTERNAL, EXTERNAL]
   --storage-type {s3,azure,gcs,file}                                   (Required) The storage type [S3, AZURE, GCS, FILE]
+  --storage-name STORAGE_NAME                                          An optional name referencing a server-side storage configuration
   --default-base-location DEFAULT_BASE_LOCATION                        (Required) Default base location for the catalog
   --allowed-location ALLOWED_LOCATION                                  An allowed location for files tracked by the catalog
   --property PROPERTY                                                  A key/value pair such as: tag=value. Multiple can be provided by specifying this option more than once. Do not put passwords, tokens, access keys, or other secrets into the client-visible catalog properties.


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Follow up PR for https://github.com/apache/polaris/pull/5345#pullrequestreview-5060038176 where `storage_name` is preserved round trip but only accessible via setup. This PR close the gap by allowing this to be set via standard `catalog create` and `catalog update` commands.

Now there is one thing which I do want to bring it up here as well (also commented in the original PR), the storage name is only relevant to AWS as of today (https://github.com/apache/polaris/blob/main/runtime/service/src/main/java/org/apache/polaris/service/storage/PolarisStorageIntegrationProviderImpl.java#L87). The changes purposed by this change is safe (as this settings can be preserved for all storage types. I am assuming we don't want to over engineering and do a check to ensure it is AWS only on setup here.


## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
