### PR TITLE
Clarify default table-like location documentation

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -510,6 +510,11 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     return newTableOps(tableIdentifier, makeMetadataCurrentOnCommit);
   }
 
+  /**
+   * Please note: This method does NOT return the catalog's default warehouse location. It returns
+   * the table-like entity's location, derived from its namespace or the catalog warehouse. The
+   * method name is inherited from Iceberg and cannot be changed by this implementation.
+   */
   @Override
   protected String defaultWarehouseLocation(TableIdentifier tableIdentifier) {
     String prefixedLocation = applyDefaultLocationObjectStoragePrefix(tableIdentifier, null);


### PR DESCRIPTION
`defaultWarehouseLocation` does not return the catalog's default warehouse location. It returns the table-like entity's location, derived from its namespace or the catalog warehouse. The method name cannot be changed because it overrides Iceberg's inherited method.

This adds Javadoc that makes that distinction explicit.

## Checklist

- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed above; no related issue
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (not needed; Javadoc-only clarification)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (not needed; internal Javadoc only)
