### PR TITLE
Skip the default-location check when the namespace location was not requested

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -702,7 +702,9 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     }
     if (!realmConfig.getConfig(
         BehaviorChangeConfiguration.ALLOW_NAMESPACE_CUSTOM_LOCATION, catalogEntity)) {
-      validateNamespaceUsesDefaultLocation(entity, resolvedParent);
+      if (metadata.containsKey(PolarisEntityConstants.ENTITY_BASE_LOCATION)) {
+        validateNamespaceUsesDefaultLocation(entity, resolvedParent);
+      }
     }
     EntityResult result =
         getMetaStoreManager()

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
@@ -730,6 +730,67 @@ public class IcebergAllowedLocationTest {
         .hasMessageContaining("has a custom location");
   }
 
+  /**
+   * The four namespace-location cases, with ALLOW_NAMESPACE_CUSTOM_LOCATION off for the first three
+   * and on for the last.
+   */
+  @Test
+  void testNamespaceCustomLocationRules(@TempDir Path tmpDir) {
+    Map<String, Object> baseConfig =
+        Map.of(
+            "ALLOW_INSECURE_STORAGE_TYPES",
+            "true",
+            "SUPPORTED_CATALOG_STORAGE_TYPES",
+            List.of("FILE"));
+    String catalogLocation = tmpDir.toAbsolutePath().toUri().toString();
+
+    TestServices strict = TestServices.builder().config(baseConfig).build();
+    createCatalog(strict, Map.of(), catalogLocation, List.of(catalogLocation));
+    String defaultBase = String.format("%s/%s", catalogLocation, catalog);
+
+    // 1. No location requested: the default is derived and used.
+    assertThat(createNamespaceStatus(strict, "ns1", null))
+        .isEqualTo(Response.Status.OK.getStatusCode());
+
+    // 2. The default location, stated explicitly: allowed, it is explicit but not custom.
+    assertThat(createNamespaceStatus(strict, "ns2", defaultBase + "/ns2"))
+        .isEqualTo(Response.Status.OK.getStatusCode());
+
+    // 3. A location other than the default: rejected as custom.
+    assertThatThrownBy(() -> createNamespaceStatus(strict, "ns3", catalogLocation + "elsewhere"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("has a custom location");
+
+    // 4. With custom locations enabled, the same request is allowed.
+    Map<String, Object> permissive = new HashMap<>(baseConfig);
+    permissive.put("ALLOW_NAMESPACE_CUSTOM_LOCATION", "true");
+    TestServices lenient = TestServices.builder().config(permissive).build();
+    createCatalog(lenient, Map.of(), catalogLocation, List.of(catalogLocation));
+    assertThat(createNamespaceStatus(lenient, "ns4", catalogLocation + "elsewhere"))
+        .isEqualTo(Response.Status.OK.getStatusCode());
+  }
+
+  private int createNamespaceStatus(TestServices services, String name, String location) {
+    CreateNamespaceRequest.Builder request =
+        CreateNamespaceRequest.builder().withNamespace(Namespace.of(name));
+    if (location != null) {
+      Map<String, String> properties = new HashMap<>();
+      properties.put("location", location);
+      request.setProperties(properties);
+    }
+    try (Response response =
+        services
+            .restApi()
+            .createNamespace(
+                catalog,
+                request.build(),
+                IDEMPOTENCY_KEY,
+                services.realmContext(),
+                services.securityContext())) {
+      return response.getStatus();
+    }
+  }
+
   private void createCatalog(
       TestServices services,
       Map<String, String> catalogConfig,


### PR DESCRIPTION
`createNamespaceInternal` validates the namespace location against the default derived from its parent even when the request specified no location. In that case the location being checked is the one Polaris just derived: `setBaseLocation` stores it in the entity's properties, so the validator reads that value back and compares it against the same derivation, and it can only pass. `setProperties` already guards the same call on whether the request carried a location, so this makes create consistent with it.

No behaviour change. Added tests for sanity which covers the four location cases - no location, the default stated explicitly, a different location, and a different location with `ALLOW_NAMESPACE_CUSTOM_LOCATION` enabled - and passes with and without the guard.

This fixes the follow-up suggestion along with test covering all the 4 cases from @flyrain here: https://github.com/apache/polaris/pull/5357#issuecomment-5481307673

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
