### PR TITLE
Fix STS AssumeRole 501 error on S3-compatible storage by making inline policy optional

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsCredentialsStorageIntegration.java
@@ -222,15 +222,18 @@ public class AwsCredentialsStorageIntegration
               .externalId(awsStorageConfig.getExternalId())
               .roleArn(awsStorageConfig.getRoleARN())
               .roleSessionName(roleSessionName)
-              .policy(
-                  policyString(
-                          awsStorageConfig,
-                          key.allowedReadLocations(),
-                          key.allowedListLocations(),
-                          key.allowedWriteLocations(),
-                          region)
-                      .toJson())
               .durationSeconds(storageCredentialDurationSeconds);
+
+      if (!Boolean.TRUE.equals(awsStorageConfig.getNoInlinePolicy())) {
+        request.policy(
+            policyString(
+                    awsStorageConfig,
+                    key.allowedReadLocations(),
+                    key.allowedListLocations(),
+                    key.allowedWriteLocations(),
+                    region)
+                .toJson());
+      }
 
       List<Tag> sessionTags = key.sessionTags();
       if (!sessionTags.isEmpty()) {

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/aws/AwsStorageConfigurationInfo.java
@@ -154,6 +154,14 @@ public abstract class AwsStorageConfigurationInfo extends PolarisStorageConfigur
    */
   public abstract @Nullable Boolean getKmsUnavailable();
 
+  /**
+   * Flag indicating whether to omit the inline session policy from STS AssumeRole requests. Set to
+   * {@code true} for S3-compatible STS implementations (e.g. VAST Data) that do not support inline
+   * session policies. When enabled, the temporary credentials inherit the full permissions of the
+   * assumed role; ensure the IAM role has appropriate permissions for the required operations.
+   */
+  public abstract @Nullable Boolean getNoInlinePolicy();
+
   /** Endpoint URI for STS API calls */
   @Nullable
   public abstract String getStsEndpoint();


### PR DESCRIPTION
Fixes #5099: STS AssumeRole fails with 501 on VAST Data and other S3-compatible storage that does not support inline session policies.

### Root Cause

Polaris always includes an inline Policy parameter in STS AssumeRole requests. VAST Data STS implementation returns 501 for this parameter.

### Fix

Added noInlinePolicy config option to AwsStorageConfigurationInfo. When true, the inline session policy is omitted from the AssumeRole request.