### PR TITLE
Site: restore inline Redoc rendering for API spec pages

### DIFF
--- a/site/content/in-dev/unreleased/polaris-api-specs/polaris-catalog-api.md
+++ b/site/content/in-dev/unreleased/polaris-api-specs/polaris-catalog-api.md
@@ -18,7 +18,7 @@
 # under the License.
 #
 title: 'Apache Polaris Catalog Service OpenAPI Specification'
-linkTitle: 'Catalog API ↗'
+linkTitle: 'Catalog API'
 weight: 200
 params:
   show_page_toc: false

--- a/site/content/in-dev/unreleased/polaris-api-specs/polaris-management-api.md
+++ b/site/content/in-dev/unreleased/polaris-api-specs/polaris-management-api.md
@@ -18,7 +18,7 @@
 # under the License.
 #
 title: 'Apache Polaris Management Service OpenAPI Specification'
-linkTitle: 'Management API ↗'
+linkTitle: 'Management API'
 weight: 100
 params:
   show_page_toc: false

--- a/site/layouts/shortcodes/redoc-polaris.html
+++ b/site/layouts/shortcodes/redoc-polaris.html
@@ -4,10 +4,11 @@ Apache Polaris custom redoc shortcode that takes just the file of the OpenAPI sp
 either the in-development version from the `main` branch or a released version from the corresponding
 Git tag.
 
-This is a copy of the original Docsy redoc shortcode, except the part to calculate the URL is adopted
-for Polaris in-dev/releases docs.
+This is a copy of the Docsy redoc shortcode (v0.14.3), except the URL resolution block is replaced
+with a Polaris-specific partial that resolves the spec to the correct raw GitHub URL.
 
-Copied from Docsy shortcodes/redoc.html.
+Copied from Docsy:
+https://github.com/google/docsy/blob/v0.14.3/layouts/_shortcodes/redoc.html
 
 */}}
 
@@ -83,11 +84,11 @@ Redoc doesn't change outer page styles
 <!--
 Redoc element with link to your OpenAPI definition
 -->
+<p><a href="http://editor-next.swagger.io/?url={{ $url }}" target="_blank" rel="noopener">Open in Swagger Editor ↗</a></p>
 <div id="redoc-container">
 <redoc spec-url='{{ $url }}' hide-hostname="true" suppress-warnings="true" lazy-rendering  native-scrollbars scroll-y-offset=".js-navbar-scroll" {{ $otheroptions }}></redoc>
 </div>
 <!--
 Link to Redoc JavaScript on CDN for rendering standalone element
 -->
-
-<meta http-equiv="refresh" content="0; url=http://editor-next.swagger.io/?url={{ $url }}" />
+<script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"></script>

--- a/site/layouts/shortcodes/redoc-polaris.html
+++ b/site/layouts/shortcodes/redoc-polaris.html
@@ -84,7 +84,7 @@ Redoc doesn't change outer page styles
 <!--
 Redoc element with link to your OpenAPI definition
 -->
-<p><a href="http://editor-next.swagger.io/?url={{ $url }}" target="_blank" rel="noopener">Open in Swagger Editor ↗</a></p>
+<p><a href="https://editor-next.swagger.io/?url={{ $url | urlquery }}" target="_blank" rel="noopener">Open in Swagger Editor ↗</a></p>
 <div id="redoc-container">
 <redoc spec-url='{{ $url }}' hide-hostname="true" suppress-warnings="true" lazy-rendering  native-scrollbars scroll-y-offset=".js-navbar-scroll" {{ $otheroptions }}></redoc>
 </div>


### PR DESCRIPTION
The `redoc-polaris` shortcode was originally designed to render the OpenAPI spec inline using the Redoc component. A later change (c3f0681354c8e31f31de5ecf6a69ee68d680aa38) replaced the Redoc `<script>` tag with a `<meta http-equiv="refresh">`, causing the page to immediately redirect to the Swagger editor instead, leaving the Redoc component output unreachable and producing an abrupt browser experience.

This commit restores inline rendering by bringing the shortcode back in line with the Docsy v0.14.3 original it was copied from, substituting only the URL resolution block with the Polaris-specific `rawGithubPolarisUrl` partial.

A separate "Open in Swagger Editor ↗" link is added for users who prefer the editor, and the ↗ suffix is removed from the sidebar link titles since the pages no longer redirect.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
