### PR TITLE
Core: Clarify catalog path requirements

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
@@ -119,8 +119,8 @@ public interface PolarisMetaStoreManager
    * the entity are required,use {@link #listFullEntities} instead.
    *
    * @param callCtx call context
-   * @param catalogPath path inside a catalog. If null or empty, the entities to list are top-level,
-   *     like catalogs
+   * @param catalogPath path inside a catalog. If null, the entities to list are top-level, like
+   *     catalogs. Otherwise, the path must be non-empty and start with the catalog
    * @param entityType entity type
    * @param entitySubType entity subtype. Can be the special value ANY_SUBTYPE to match any subtype.
    *     Else exact match will be performed.
@@ -139,8 +139,8 @@ public interface PolarisMetaStoreManager
    * #listFullEntitiesAll} instead.
    *
    * @param callCtx call context
-   * @param catalogPath path inside a catalog. If null or empty, the entities to list are top-level,
-   *     like catalogs
+   * @param catalogPath path inside a catalog. If null, the entities to list are top-level, like
+   *     catalogs. Otherwise, the path must be non-empty and start with the catalog
    * @param entityType type of entities to list
    * @param entitySubType subType of entities to list (or ANY_SUBTYPE)
    * @return paged list of matching entities
@@ -158,8 +158,8 @@ public interface PolarisMetaStoreManager
    * #listEntities} instead.
    *
    * @param callCtx call context
-   * @param catalogPath path inside a catalog. If null or empty, the entities to list are top-level,
-   *     like catalogs
+   * @param catalogPath path inside a catalog. If null, the entities to list are top-level, like
+   *     catalogs. Otherwise, the path must be non-empty and start with the catalog
    * @param entityType type of entities to list
    * @param entitySubType subType of entities to list (or ANY_SUBTYPE)
    * @return list of all matching entities
@@ -289,7 +289,8 @@ public interface PolarisMetaStoreManager
    * Rename an entity, potentially re-parenting it.
    *
    * @param callCtx call context
-   * @param catalogPath path to that entity. Could be an empty list of the entity is a catalog.
+   * @param catalogPath path to the entity's parent. Must be null if the entity is top-level;
+   *     otherwise, it must be non-empty and start with the catalog
    * @param entityToRename entity to rename. This entity should have been resolved by the client
    * @param newCatalogPath if not null, new catalog path
    * @param renamedEntity the new renamed entity we need to persist. We will use this argument to
@@ -308,7 +309,8 @@ public interface PolarisMetaStoreManager
    * Drop the specified entity assuming it exists
    *
    * @param callCtx call context
-   * @param catalogPath path to that entity. Could be an empty list of the entity is a catalog.
+   * @param catalogPath path to the entity's parent. Must be null if the entity is top-level;
+   *     otherwise, it must be non-empty and start with the catalog
    * @param entityToDrop entity to drop, must have been resolved by the client
    * @param cleanupProperties if not null, properties that will be persisted with the cleanup task
    * @param cleanup true if resources owned by this entity should be deleted as well

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/PolarisEntityResolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/transactional/PolarisEntityResolver.java
@@ -69,7 +69,8 @@ public class PolarisEntityResolver {
    *
    * @param callCtx call context
    * @param ms meta store in read mode
-   * @param catalogPath path within the catalog. The first element MUST be a catalog entity.
+   * @param catalogPath path within the catalog; must be null or non-empty. The first element of a
+   *     non-empty path MUST be a catalog entity
    * @param resolvedEntity optional entity to resolve under that catalog path. If a non-null value
    *     is supplied, we will resolve it with the rest, as if it had been concatenated to the input
    *     path. If catalogPath is null, this MUST be a top-level entity
@@ -145,8 +146,8 @@ public class PolarisEntityResolver {
    *
    * @param callCtx call context
    * @param ms meta store in read mode
-   * @param catalogPath input path, can be null or empty list if the entity is a top-level entity
-   *     like a catalog.
+   * @param catalogPath input path; must be null or non-empty. A non-empty path must start with the
+   *     catalog
    */
   PolarisEntityResolver(
       @NonNull PolarisDiagnostics diagnostics,
@@ -161,8 +162,8 @@ public class PolarisEntityResolver {
    *
    * @param callCtx call context
    * @param ms meta store in read mode
-   * @param catalogPath input path, can be null or empty list if the entity is a top-level entity
-   *     like a catalog.
+   * @param catalogPath input path; must be null or non-empty. A non-empty path must start with the
+   *     catalog
    * @param resolvedEntityDto resolved entity DTO
    */
   PolarisEntityResolver(
@@ -179,8 +180,8 @@ public class PolarisEntityResolver {
    *
    * @param callCtx call context
    * @param ms meta store in read mode
-   * @param catalogPath input path, can be null or empty list if the entity is a top-level entity
-   *     like a catalog.
+   * @param catalogPath input path; must be null or non-empty. A non-empty path must start with the
+   *     catalog
    * @param entity Polaris base entity
    */
   PolarisEntityResolver(
@@ -229,8 +230,8 @@ public class PolarisEntityResolver {
    *
    * @param callCtx call context
    * @param ms meta store in read mode
-   * @param catalogPath path within the catalog. The first element MUST be a catalog. Null or empty
-   *     for top-level entities like catalog
+   * @param catalogPath path within the catalog; must be null or non-empty. The first element of a
+   *     non-empty path MUST be a catalog
    * @param resolvedEntity optional entity to resolve under that catalog path. If a non-null value
    *     is supplied, we will resolve it with the rest, as if it had been concatenated to the input
    *     path.


### PR DESCRIPTION
## Summary

`PolarisMetaStoreManager` documented non-null empty source paths as valid for top-level entities, while the transactional resolver rejects every non-null empty path. That mismatch could lead callers to inputs that are guaranteed to fail validation.

This change clarifies that:

- `null` represents a top-level path
- a supplied path must be non-empty and begin with a catalog

The clarification is applied consistently to listing, rename/drop, and transactional resolver Javadocs. There is no runtime behavior change.

## Checklist

- [x] I have not included any security-sensitive information.
- [x] I have explained why this change is needed.
- [x] I have verified the documentation change with formatting, compilation, and the `polaris-core` checks.
- [x] No tests are added because this change only corrects Javadocs and does not alter behavior.
- [x] No changelog entry is needed because this does not change user-facing behavior.
- [x] No site documentation update is needed because the affected contract is documented in source Javadocs.