### PR TITLE
Doc: Added missing instructions for schema upgrade from v4 to v5 in 1.7.0 doc

### DIFF
--- a/1.7.0/metastores/relational-jdbc.md
+++ b/1.7.0/metastores/relational-jdbc.md
@@ -122,7 +122,10 @@ that are not catalog-scoped. To upgrade an existing v3/v4 database, run the foll
 CockroachDB, and H2), then restart Polaris:
 
 ```sql
+DROP INDEX IF EXISTS polaris_schema.idx_idemp_realm_expires;
+DROP TABLE IF EXISTS polaris_schema.idempotency_records;
 ALTER TABLE polaris_schema.events ALTER COLUMN catalog_id DROP NOT NULL;
 UPDATE polaris_schema.events SET catalog_id = NULL WHERE catalog_id = '__realm__';
+DROP TABLE IF EXISTS polaris_schema.idempotency_records;
 UPDATE polaris_schema.version SET version_value = 5 WHERE version_key = 'version';
 ```

--- a/1.7.0/metastores/relational-jdbc.md
+++ b/1.7.0/metastores/relational-jdbc.md
@@ -122,8 +122,6 @@ that are not catalog-scoped. To upgrade an existing v3/v4 database, run the foll
 CockroachDB, and H2), then restart Polaris:
 
 ```sql
-DROP INDEX IF EXISTS polaris_schema.idx_idemp_realm_expires;
-DROP TABLE IF EXISTS polaris_schema.idempotency_records;
 ALTER TABLE polaris_schema.events ALTER COLUMN catalog_id DROP NOT NULL;
 UPDATE polaris_schema.events SET catalog_id = NULL WHERE catalog_id = '__realm__';
 DROP TABLE IF EXISTS polaris_schema.idempotency_records;

--- a/1.7.0/metastores/relational-jdbc.md
+++ b/1.7.0/metastores/relational-jdbc.md
@@ -122,6 +122,8 @@ that are not catalog-scoped. To upgrade an existing v3/v4 database, run the foll
 CockroachDB, and H2), then restart Polaris:
 
 ```sql
+DROP INDEX IF EXISTS polaris_schema.idx_idemp_realm_expires;
+DROP INDEX IF EXISTS polaris_schema.idempotency_records;
 ALTER TABLE polaris_schema.events ALTER COLUMN catalog_id DROP NOT NULL;
 UPDATE polaris_schema.events SET catalog_id = NULL WHERE catalog_id = '__realm__';
 DROP TABLE IF EXISTS polaris_schema.idempotency_records;


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Follow up on https://github.com/apache/polaris/pull/5349 where the current SQL instructions missed the drop for table idempotency_records and its indices. 

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
