### PR TITLE
Skip metadata loads for table, view, and namespace existence checks

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandler.java
@@ -23,6 +23,7 @@ import static org.apache.polaris.core.config.FeatureConfiguration.ALLOW_FEDERATE
 import static org.apache.polaris.core.config.FeatureConfiguration.LIST_PAGINATION_ENABLED;
 import static org.apache.polaris.service.catalog.AccessDelegationMode.VENDED_CREDENTIALS;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.alreadyExistsExceptionForTableLikeEntity;
+import static org.apache.polaris.service.catalog.common.ExceptionUtils.noSuchNamespaceException;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.notFoundExceptionForTableLikeEntity;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -48,6 +49,7 @@ import java.util.UUID;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RetryableValidationException;
@@ -340,8 +342,14 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     // existence is also missing.
     authorizeBasicNamespaceOperationOrThrow(op, namespace);
 
-    // TODO: Just skip CatalogHandlers for this one maybe
-    catalogHandlerUtils().loadNamespace(namespaceCatalog, namespace);
+    // Resolution above already established that the namespace exists, so a local catalog needs
+    // no further check. A federated catalog serves it from the remote system, which therefore
+    // has to answer.
+    if (!(baseCatalog instanceof LocalIcebergCatalog)) {
+      if (!namespaceCatalog.namespaceExists(namespace)) {
+        throw noSuchNamespaceException(namespace);
+      }
+    }
   }
 
   public void dropNamespace(Namespace namespace) {
@@ -1384,8 +1392,22 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     resolveAndAuthorizeBasicTableLikeOperationOrThrow(
         op, PolarisEntitySubType.ICEBERG_TABLE, tableIdentifier);
 
-    // TODO: Just skip CatalogHandlers for this one maybe
-    catalogHandlerUtils().loadTable(baseCatalog, tableIdentifier);
+    // Resolution above already established that the table exists, so a local catalog needs no
+    // further check. A federated catalog serves it from the remote system, which therefore has
+    // to answer.
+    if (!(baseCatalog instanceof LocalIcebergCatalog)) {
+      // tableExists cannot answer for an identifier that could name a synthetic metadata table:
+      // Hadoop and Hive report ns.orders.snapshots as present while loadTable rejects it as not
+      // found, so HEAD would answer 204 where GET answers 404. A metadata table always ends in a
+      // MetadataTableType name, and nothing stops an ordinary table from carrying one of those
+      // names too, so only a load can tell the two apart.
+      if (MetadataTableType.from(tableIdentifier.name()) != null) {
+        catalogHandlerUtils().loadTable(baseCatalog, tableIdentifier);
+      } else if (!baseCatalog.tableExists(tableIdentifier)) {
+        throw notFoundExceptionForTableLikeEntity(
+            tableIdentifier, PolarisEntitySubType.ICEBERG_TABLE);
+      }
+    }
   }
 
   public void renameTable(RenameTableRequest request) {
@@ -1656,8 +1678,15 @@ public abstract class IcebergCatalogHandler extends CatalogHandler implements Au
     resolveAndAuthorizeBasicTableLikeOperationOrThrow(
         op, PolarisEntitySubType.ICEBERG_VIEW, viewIdentifier);
 
-    // TODO: Just skip CatalogHandlers for this one maybe
-    catalogHandlerUtils().loadView(viewCatalog, viewIdentifier);
+    // Resolution above already established that the view exists, so a local catalog needs no
+    // further check. A federated catalog serves it from the remote system, which therefore has
+    // to answer.
+    if (!(baseCatalog instanceof LocalIcebergCatalog)) {
+      if (!viewCatalog.viewExists(viewIdentifier)) {
+        throw notFoundExceptionForTableLikeEntity(
+            viewIdentifier, PolarisEntitySubType.ICEBERG_VIEW);
+      }
+    }
   }
 
   public void renameView(RenameTableRequest request) {

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergCatalogHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.polaris.service.catalog.iceberg;
 
 import static org.apache.polaris.service.catalog.AccessDelegationMode.VENDED_CREDENTIALS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import jakarta.enterprise.inject.Instance;
 import java.time.Clock;
@@ -46,7 +48,12 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewCatalog;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.rest.credentials.Credential;
 import org.apache.iceberg.rest.requests.ImmutableRegisterTableRequest;
 import org.apache.iceberg.rest.requests.RegisterTableRequest;
@@ -673,5 +680,135 @@ class IcebergCatalogHandlerTest {
     assertThat(handler.filterResponseToSnapshots(response, null))
         .as("no snapshots param must be a pure passthrough, same as snapshots=all")
         .isSameAs(response);
+  }
+
+  private Catalog federatedCatalog() {
+    Catalog federated =
+        mock(
+            Catalog.class,
+            withSettings().extraInterfaces(ViewCatalog.class, SupportsNamespaces.class));
+    when(localCatalogFactory.createCatalog(any())).thenReturn(federated);
+    return federated;
+  }
+
+  @Test
+  void tableExistsSkipsLoadTableOnLocalCatalog() {
+    LocalIcebergCatalog icebergCatalog = mock(LocalIcebergCatalog.class);
+    when(localCatalogFactory.createCatalog(any())).thenReturn(icebergCatalog);
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+
+    assertThatCode(() -> handler.tableExists(TABLE2)).doesNotThrowAnyException();
+
+    verify(catalogHandlerUtils, never()).loadTable(any(), any());
+    verify(icebergCatalog, never()).loadTable(any());
+  }
+
+  @Test
+  void viewExistsSkipsLoadViewOnLocalCatalog() {
+    LocalIcebergCatalog icebergCatalog = mock(LocalIcebergCatalog.class);
+    when(localCatalogFactory.createCatalog(any())).thenReturn(icebergCatalog);
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+
+    assertThatCode(() -> handler.viewExists(TABLE2)).doesNotThrowAnyException();
+
+    verify(catalogHandlerUtils, never()).loadView(any(), any());
+    verify(icebergCatalog, never()).loadView(any());
+  }
+
+  @Test
+  void namespaceExistsSkipsLoadNamespaceOnLocalCatalog() {
+    LocalIcebergCatalog icebergCatalog = mock(LocalIcebergCatalog.class);
+    when(localCatalogFactory.createCatalog(any())).thenReturn(icebergCatalog);
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+
+    assertThatCode(() -> handler.namespaceExists(NS1)).doesNotThrowAnyException();
+
+    verify(catalogHandlerUtils, never()).loadNamespace(any(), any());
+    verify(icebergCatalog, never()).loadNamespaceMetadata(any());
+  }
+
+  @Test
+  void tableExistsAsksFederatedCatalogAndThrowsWhenAbsent() {
+    Catalog federated = federatedCatalog();
+    when(federated.tableExists(TABLE2)).thenReturn(false);
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+
+    assertThatThrownBy(() -> handler.tableExists(TABLE2)).isInstanceOf(NoSuchTableException.class);
+
+    verify(federated).tableExists(TABLE2);
+    verify(catalogHandlerUtils, never()).loadTable(any(), any());
+  }
+
+  @Test
+  void tableExistsLoadsFederatedTableNamedAfterMetadataTable() {
+    // "files" is a MetadataTableType name, but ns1.files is an ordinary table here: Iceberg
+    // resolves a real table ahead of a metadata table, so the load must answer, not tableExists
+    TableIdentifier tableNamedFiles = TableIdentifier.of(NS1, "files");
+    Catalog federated = federatedCatalog();
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+
+    assertThatCode(() -> handler.tableExists(tableNamedFiles)).doesNotThrowAnyException();
+
+    verify(catalogHandlerUtils).loadTable(federated, tableNamedFiles);
+    verify(federated, never()).tableExists(any());
+  }
+
+  @Test
+  void tableExistsRejectsMetadataTableReportedByFederatedCatalog() {
+    TableIdentifier metadataTable =
+        TableIdentifier.of(Namespace.of(NS1.level(0), "table2"), "snapshots");
+    Catalog federated = federatedCatalog();
+    when(federated.tableExists(metadataTable)).thenReturn(true);
+    when(catalogHandlerUtils.loadTable(federated, metadataTable))
+        .thenThrow(new NoSuchTableException("Table does not exist: %s", metadataTable));
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+
+    // the federated catalog reports the synthetic metadata table as present; the load decides
+    assertThatThrownBy(() -> handler.tableExists(metadataTable))
+        .isInstanceOf(NoSuchTableException.class);
+
+    verify(catalogHandlerUtils).loadTable(federated, metadataTable);
+    verify(federated, never()).tableExists(any());
+  }
+
+  @Test
+  void viewExistsAsksFederatedCatalogAndThrowsWhenAbsent() {
+    Catalog federated = federatedCatalog();
+    when(((ViewCatalog) federated).viewExists(TABLE2)).thenReturn(false);
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+
+    assertThatThrownBy(() -> handler.viewExists(TABLE2)).isInstanceOf(NoSuchViewException.class);
+
+    verify((ViewCatalog) federated).viewExists(TABLE2);
+    verify(catalogHandlerUtils, never()).loadView(any(), any());
+  }
+
+  @Test
+  void namespaceExistsAsksFederatedCatalogAndThrowsWhenAbsent() {
+    Catalog federated = federatedCatalog();
+    when(((SupportsNamespaces) federated).namespaceExists(NS1)).thenReturn(false);
+
+    @SuppressWarnings("resource")
+    IcebergCatalogHandler handler = newHandler();
+
+    assertThatThrownBy(() -> handler.namespaceExists(NS1))
+        .isInstanceOf(NoSuchNamespaceException.class);
+
+    verify((SupportsNamespaces) federated).namespaceExists(NS1);
+    verify(catalogHandlerUtils, never()).loadNamespace(any(), any());
   }
 }


### PR DESCRIPTION
`tableExists`, `viewExists` and `namespaceExists` each resolve and authorize the entity, then load it in full and discard the result. All three methods return void — the adapter turns a normal return into a `204` with no body — and all three carried a 
```
// TODO: Just skip CatalogHandlers for this one maybe.
```

Resolution has already done what the endpoint asks. `resolveAndAuthorizeBasicTableLikeOperationOrThrow` throws `notFoundExceptionForTableLikeEntity` when the resolved leaf is absent or of the wrong subtype, so everything after it re-establishes a fact already in hand.

 * What a local table or view check cost

`loadTable` reaches `newTableOps(ident).current()` → `doRefresh()`, which spends two things per request:

- A second resolution of the path. `doRefresh` calls `getPassthroughResolvedPath(...)`, deliberately bypassing the authz resolution set the request just built, so the entity is resolved from the metastore twice.
- A read and parse of the whole metadata file. `refreshFromMetadataLocation(...)` → `TableMetadataParser.read(fileIO, location)`: an object-storage GET plus a full` JSON` parse of metadata that is then discarded. `loadView` is the same shape through `ViewMetadataParser`.

* What a local namespace check cost

Much less, stated plainly. `LocalIcebergCatalog.loadNamespaceMetadata` reads the already-resolved path via `getResolvedPath(...)` and returns the entity's properties — no storage access, no second resolution. Removing it saves a lookup and a map copy. It is included for consistency across the three endpoints and for the federated benefit below, not for a local performance win.

* What every federated check saves

Federated catalogs are passthrough, so a Polaris record does not guarantee the entity is still on the remote and the remote must still be consulted. It is now asked whether the entity `exists` rather than made to `load` it.

Against a REST-backed catalog that is a `HEAD` in place of a `GET` returning full metadata — `RESTSessionCatalog.tableExists issues client.head(...)`. A catalog that does not override exists falls through to the `Catalog/ViewCatalog` interface default, which loads and catches: the same cost as before, never worse.

Because `exists` returns `false` where `load` threw, the not-found is now raised explicitly — `notFoundExceptionForTableLikeEntity` for tables and views, `noSuchNamespaceException` for namespaces — so response statuses for them stay unchanged.

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
