### PR TITLE
Reduce log verbosity of NoSQL persistence tests

### DIFF
--- a/persistence/nosql/persistence/cdi/quarkus-distcache/src/test/java/org/apache/polaris/persistence/nosql/quarkus/distcache/TestCacheInvalidationReceiver.java
+++ b/persistence/nosql/persistence/cdi/quarkus-distcache/src/test/java/org/apache/polaris/persistence/nosql/quarkus/distcache/TestCacheInvalidationReceiver.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
@@ -180,6 +181,8 @@ public class TestCacheInvalidationReceiver {
     var appender = new ListAppender<ILoggingEvent>();
     appender.start();
     logger.addAppender(appender);
+    Level oldLevel = logger.getLevel();
+    logger.setLevel(Level.WARN);
     try {
       receiver.cacheInvalidations(
           rc,
@@ -187,6 +190,7 @@ public class TestCacheInvalidationReceiver {
           senderId.instanceId(),
           differentToken);
     } finally {
+      logger.setLevel(oldLevel);
       logger.detachAppender(appender);
       appender.stop();
     }

--- a/persistence/nosql/persistence/cdi/quarkus-distcache/src/test/resources/logback-test.xml
+++ b/persistence/nosql/persistence/cdi/quarkus-distcache/src/test/resources/logback-test.xml
@@ -24,11 +24,11 @@
       <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
-  <root level="INFO">
+  <root level="${test.log.level:-ERROR}">
     <appender-ref ref="console"/>
   </root>
-  <logger name="org.jboss" level="INFO"/>
-  <logger name="org.apache.polaris" level="DEBUG"/>
-  <logger name="org.apache.polaris.persistence.nosql.metastore" level="TRACE"/>
-  <logger name="org.apache.polaris.persistence.nosql.quarkus.distcache" level="TRACE"/>
+  <logger name="org.jboss" level="ERROR"/>
+  <logger name="org.apache.polaris" level="ERROR"/>
+  <logger name="org.apache.polaris.persistence.nosql.metastore" level="ERROR"/>
+  <logger name="org.apache.polaris.persistence.nosql.quarkus.distcache" level="ERROR"/>
 </configuration>

--- a/persistence/nosql/persistence/metastore-maintenance/src/test/resources/logback-test.xml
+++ b/persistence/nosql/persistence/metastore-maintenance/src/test/resources/logback-test.xml
@@ -26,9 +26,9 @@
       <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
-  <root level="DEBUG">
+  <root level="${test.log.level:-ERROR}">
     <appender-ref ref="console"/>
   </root>
-  <logger name="org.jboss" level="INFO"/>
-  <logger name="org.apache.polaris" level="DEBUG"/>
+  <logger name="org.jboss" level="ERROR"/>
+  <logger name="org.apache.polaris" level="ERROR"/>
 </configuration>

--- a/persistence/nosql/persistence/metastore-types/src/test/resources/logback-test.xml
+++ b/persistence/nosql/persistence/metastore-types/src/test/resources/logback-test.xml
@@ -26,9 +26,9 @@
       <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
-  <root level="DEBUG">
+  <root level="${test.log.level:-ERROR}">
     <appender-ref ref="console"/>
   </root>
-  <logger name="org.jboss" level="INFO"/>
-  <logger name="org.apache.polaris" level="DEBUG"/>
+  <logger name="org.jboss" level="ERROR"/>
+  <logger name="org.apache.polaris" level="ERROR"/>
 </configuration>

--- a/persistence/nosql/persistence/metastore/src/test/resources/logback-test.xml
+++ b/persistence/nosql/persistence/metastore/src/test/resources/logback-test.xml
@@ -26,10 +26,10 @@
       <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
-  <root level="TRACE">
+  <root level="${test.log.level:-ERROR}">
     <appender-ref ref="console"/>
   </root>
-  <logger name="org.jboss" level="INFO"/>
-  <logger name="org.apache.polaris" level="DEBUG"/>
-  <logger name="org.apache.polaris.persistence.nosql.metastore" level="TRACE"/>
+  <logger name="org.jboss" level="ERROR"/>
+  <logger name="org.apache.polaris" level="ERROR"/>
+  <logger name="org.apache.polaris.persistence.nosql.metastore" level="ERROR"/>
 </configuration>


### PR DESCRIPTION
A few loggers were at INFO, DEBUG or even TRACE. Changed all of these to ERROR to reduce verbosity.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
