### PR TITLE
Log the correct operation name when storePrincipalSecrets fails

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -985,12 +985,12 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
         throw new AlreadyExistsException(e.getMessage(), e);
       }
       LOGGER.error(
-          "Failed to reset PrincipalSecrets  for clientId: {}, due to {}",
+          "Failed to storePrincipalSecrets for clientId: {}, due to {}",
           resolvedClientId,
           e.getMessage(),
           e);
       throw new RuntimeException(
-          String.format("Failed to reset PrincipalSecrets for clientId: %s", resolvedClientId), e);
+          String.format("Failed to storePrincipalSecrets for clientId: %s", resolvedClientId), e);
     }
 
     // return those
@@ -1046,7 +1046,7 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
               params));
     } catch (SQLException e) {
       LOGGER.error(
-          "Failed to rotatePrincipalSecrets  for clientId: {}, due to {}",
+          "Failed to rotatePrincipalSecrets for clientId: {}, due to {}",
           clientId,
           e.getMessage(),
           e);


### PR DESCRIPTION
The failure path in `storePrincipalSecrets` logs and throws "Failed to reset PrincipalSecrets ..." — a copy-paste leftover from the reset/rotate helpers. The method is neither reset nor rotate, so operators grepping logs or alerting on the operation name miss store failures, and the text also carried a stray double space.

This corrects the operation name to `storePrincipalSecrets` in both the log line and the thrown exception message, and collapses the double space. The sibling `rotatePrincipalSecrets` message had the same double space, fixed here too for consistency.

Message-only change: no logic, API, or schema impact.