### PR TITLE
Switch OPA and Ranger authorizers to resolveSelections

### DIFF
--- a/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
+++ b/extensions/auth/opa/src/main/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizer.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
+import org.apache.polaris.core.persistence.resolver.Resolvable;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.ClassicHttpRequest;
@@ -124,15 +126,24 @@ class OpaPolarisAuthorizer implements PolarisAuthorizer {
   }
 
   /**
-   * Resolves authorization inputs using {@code resolveAll()} for backward compatibility.
+   * Resolves authorization inputs using {@code resolveSelections()} to resolve only the securables
+   * required for OPA authorization.
    *
-   * <p>This scope is intentionally broad for now and will be narrowed in a future refactoring to
-   * resolve only the selections required by OPA authorization.
+   * <p>Unlike {@code resolveAll()}, this avoids resolving the caller principal and principal roles,
+   * which are not needed by OPA-based authorization and removes the need for synthetic principal
+   * entities for external principals.
    */
   @Override
   public void resolveAuthorizationInputs(
       @NonNull AuthorizationState authzState, @NonNull AuthorizationRequest request) {
-    authzState.getResolutionManifest().resolveAll();
+    PolarisResolutionManifest manifest = authzState.getResolutionManifest();
+    manifest.resolveSelections(
+        manifest.getCatalogName() != null
+            ? Set.of(
+                Resolvable.REFERENCE_CATALOG,
+                Resolvable.REQUESTED_PATHS,
+                Resolvable.REQUESTED_TOP_LEVEL_ENTITIES)
+            : Set.of(Resolvable.REQUESTED_TOP_LEVEL_ENTITIES));
   }
 
   @Override

--- a/extensions/auth/opa/src/test/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerTest.java
+++ b/extensions/auth/opa/src/test/java/org/apache/polaris/extension/auth/opa/OpaPolarisAuthorizerTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -66,6 +67,7 @@ import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
+import org.apache.polaris.core.persistence.resolver.Resolvable;
 import org.apache.polaris.extension.auth.opa.token.BearerTokenProvider;
 import org.apache.polaris.extension.auth.opa.token.StaticBearerTokenProvider;
 import org.junit.jupiter.api.Test;
@@ -607,9 +609,32 @@ public class OpaPolarisAuthorizerTest {
   }
 
   @Test
-  void resolveAuthorizationInputsResolvesAll() {
-    // resolveAll() is intentionally used for compatibility and is expected
-    // to be narrowed in a future refactoring.
+  void resolveAuthorizationInputsResolvesRequiredSelections() {
+    OpaPolarisAuthorizer authorizer =
+        new OpaPolarisAuthorizer(
+            URI.create("http://opa.example.com:8181/v1/data/polaris/allow"),
+            mock(CloseableHttpClient.class),
+            JsonMapper.builder().build(),
+            null,
+            null,
+            "test-realm");
+    PolarisResolutionManifest resolutionManifest = mock(PolarisResolutionManifest.class);
+    when(resolutionManifest.getCatalogName()).thenReturn("catalog-1");
+    AuthorizationState authzState = new AuthorizationState(resolutionManifest);
+    PolarisPrincipal principal = PolarisPrincipal.of("alice", Map.of(), Set.of("role-1"));
+
+    authorizer.resolveAuthorizationInputs(authzState, requestWithCatalogTarget(principal));
+
+    verify(resolutionManifest)
+        .resolveSelections(
+            Set.of(
+                Resolvable.REFERENCE_CATALOG,
+                Resolvable.REQUESTED_PATHS,
+                Resolvable.REQUESTED_TOP_LEVEL_ENTITIES));
+  }
+
+  @Test
+  void resolveAuthorizationInputsNullCatalogResolvesOnlyTopLevelEntities() {
     OpaPolarisAuthorizer authorizer =
         new OpaPolarisAuthorizer(
             URI.create("http://opa.example.com:8181/v1/data/polaris/allow"),
@@ -624,7 +649,8 @@ public class OpaPolarisAuthorizerTest {
 
     authorizer.resolveAuthorizationInputs(authzState, requestWithCatalogTarget(principal));
 
-    verify(resolutionManifest).resolveAll();
+    verify(resolutionManifest)
+        .resolveSelections(Set.of(Resolvable.REQUESTED_TOP_LEVEL_ENTITIES));
   }
 
   @Test

--- a/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
+++ b/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
+import org.apache.polaris.core.persistence.resolver.Resolvable;
 import org.apache.polaris.core.auth.AuthorizationDecision;
 import org.apache.polaris.core.auth.AuthorizationPreConditions;
 import org.apache.polaris.core.auth.AuthorizationRequest;
@@ -76,15 +78,24 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
   }
 
   /**
-   * Resolves authorization inputs using {@code resolveAll()} for backward compatibility.
+   * Resolves authorization inputs using {@code resolveSelections()} to resolve only the securables
+   * required for Ranger authorization.
    *
-   * <p>This scope is intentionally broad for now and will be narrowed in a future refactoring to
-   * resolve only the selections required by Ranger authorization.
+   * <p>Unlike {@code resolveAll()}, this avoids resolving the caller principal and principal roles,
+   * which are not needed by Ranger-based authorization and removes the need for synthetic principal
+   * entities for external principals.
    */
   @Override
   public void resolveAuthorizationInputs(
       @NonNull AuthorizationState authzState, @NonNull AuthorizationRequest request) {
-    authzState.getResolutionManifest().resolveAll();
+    PolarisResolutionManifest manifest = authzState.getResolutionManifest();
+    manifest.resolveSelections(
+        manifest.getCatalogName() != null
+            ? Set.of(
+                Resolvable.REFERENCE_CATALOG,
+                Resolvable.REQUESTED_PATHS,
+                Resolvable.REQUESTED_TOP_LEVEL_ENTITIES)
+            : Set.of(Resolvable.REQUESTED_TOP_LEVEL_ENTITIES));
   }
 
   @Override

--- a/extensions/auth/ranger/src/test/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizerTest.java
+++ b/extensions/auth/ranger/src/test/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizerTest.java
@@ -26,6 +26,9 @@ import static org.apache.polaris.extension.auth.ranger.RangerTestUtils.createRea
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -36,14 +39,22 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.polaris.core.auth.AuthorizationRequest;
+import org.apache.polaris.core.auth.AuthorizationState;
+import org.apache.polaris.core.auth.PathSegment;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
+import org.apache.polaris.core.auth.PolarisSecurable;
+import org.apache.polaris.core.auth.SingleTargetAuthorizationIntent;
 import org.apache.polaris.core.entity.PolarisEntity;
 import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
+import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
+import org.apache.polaris.core.persistence.resolver.Resolvable;
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DatabindException;
@@ -102,6 +113,50 @@ public class RangerPolarisAuthorizerTest {
   @Test
   public void testAuthzUnsupported() throws Exception {
     runTests(authorizer, "/authz_tests/tests_authz_unsupported.json");
+  }
+
+  @Test
+  public void testResolveAuthorizationInputsResolvesRequiredSelections() {
+    PolarisResolutionManifest resolutionManifest = mock(PolarisResolutionManifest.class);
+    when(resolutionManifest.getCatalogName()).thenReturn("catalog-1");
+    AuthorizationState authzState = new AuthorizationState(resolutionManifest);
+    PolarisPrincipal principal = PolarisPrincipal.of("alice", Map.of(), Set.of("role-1"));
+    AuthorizationRequest request =
+        new AuthorizationRequest(
+            principal,
+            List.of(
+                new SingleTargetAuthorizationIntent(
+                    PolarisAuthorizableOperation.GET_CATALOG,
+                    PolarisSecurable.of(
+                        new PathSegment(PolarisEntityType.CATALOG, "catalog-1")))));
+
+    authorizer.resolveAuthorizationInputs(authzState, request);
+
+    verify(resolutionManifest)
+        .resolveSelections(
+            Set.of(
+                Resolvable.REFERENCE_CATALOG,
+                Resolvable.REQUESTED_PATHS,
+                Resolvable.REQUESTED_TOP_LEVEL_ENTITIES));
+  }
+
+  @Test
+  public void testResolveAuthorizationInputsNullCatalogResolvesOnlyTopLevelEntities() {
+    PolarisResolutionManifest resolutionManifest = mock(PolarisResolutionManifest.class);
+    AuthorizationState authzState = new AuthorizationState(resolutionManifest);
+    PolarisPrincipal principal = PolarisPrincipal.of("alice", Map.of(), Set.of("role-1"));
+    AuthorizationRequest request =
+        new AuthorizationRequest(
+            principal,
+            List.of(
+                new SingleTargetAuthorizationIntent(
+                    PolarisAuthorizableOperation.GET_CATALOG,
+                    PolarisSecurable.of(
+                        new PathSegment(PolarisEntityType.CATALOG, "catalog-1")))));
+
+    authorizer.resolveAuthorizationInputs(authzState, request);
+
+    verify(resolutionManifest).resolveSelections(Set.of(Resolvable.REQUESTED_TOP_LEVEL_ENTITIES));
   }
 
   private void runTests(PolarisAuthorizer authorizer, String testFilename) throws Exception {

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/resolver/PolarisResolutionManifest.java
@@ -57,6 +57,12 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
   private final Resolver primaryResolver;
   private final PolarisDiagnostics diagnostics;
 
+  /** Returns the name of the reference catalog, or {@code null} for admin-level operations. */
+  @Nullable
+  public String getCatalogName() {
+    return catalogName;
+  }
+
   private final Map<ResolvedPathKey, Integer> pathLookup = new HashMap<>();
   private final List<ResolverPath> addedPaths = new ArrayList<>();
   private final Multimap<String, PolarisEntityType> addedTopLevelNames = HashMultimap.create();


### PR DESCRIPTION
Fixes #5439

## Summary

Switch external authorizers (OPA, Ranger) from `resolveAll()` to `resolveSelections()` with `REFERENCE_CATALOG`, `REQUESTED_PATHS`, and `REQUESTED_TOP_LEVEL_ENTITIES`.

This avoids resolving the caller principal and principal roles, which external authorizers do not need and which may not exist in the metastore for external principals.

## Background

PR #5119 introduces external principals and a temporary hack in the Resolver: synthetic principals and principal roles. This hack is needed because the current external authorizers call `resolveAll()`, which tries to resolve the caller principal from the metastore — but external principals do not exist in the metastore.

## Changes

- **`OpaPolarisAuthorizer.resolveAuthorizationInputs()`**: Changed from `resolveAll()` to `resolveSelections()` with `REFERENCE_CATALOG`, `REQUESTED_PATHS`, `REQUESTED_TOP_LEVEL_ENTITIES`.
- **`RangerPolarisAuthorizer.resolveAuthorizationInputs()`**: Same change.

## Why this works

External authorizers (OPA, Ranger) do not use resolved caller principal/principal roles in their authorization logic. They derive actor information from the `AuthorizationRequest.principal()` directly. By skipping `CALLER_PRINCIPAL` and `CALLER_PRINCIPAL_ROLES` resolution, we avoid the need for synthetic principal entities in the Resolver.

## Checklist

- [x] I have read the Polaris contribution guidelines
- [x] My code follows the code style of this project
- [x] No new dependencies are introduced
- [x] This change does not affect internal authorizer behavior (PolarisAuthorizerImpl still uses resolveAll())