### PR TITLE
Fix EntityNameLookupRecord.toString to use the correct class name

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/entity/EntityNameLookupRecord.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/entity/EntityNameLookupRecord.java
@@ -120,7 +120,7 @@ public class EntityNameLookupRecord implements Identifiable {
 
   @Override
   public String toString() {
-    return "PolarisEntitiesActiveRecord{"
+    return "EntityNameLookupRecord{"
         + "catalogId="
         + catalogId
         + ", id="


### PR DESCRIPTION
`EntityNameLookupRecord.toString()` still starts with `PolarisEntitiesActiveRecord{`, left over from an old rename. That type no longer exists, so logs and debugger output show a class name that can't be traced back to anything.

Corrected the prefix to `EntityNameLookupRecord{`. Nothing asserts the old string.