### PR TITLE
Rat: update exclusions for Hugo, AI, Spark and IntelliJ

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,7 @@ tasks.named<RatTask>("rat").configure {
   // AI agents
   excludes.add(".claude/**")
   excludes.add(".agents/**")
+  excludes.add(".conductor/**")
 
   // Misc build artifacts
   excludes.add(".java-version")
@@ -117,6 +118,7 @@ tasks.named<RatTask>("rat").configure {
   excludes.add("site/.user-settings")
   excludes.add("site/node_modules/**")
   excludes.add("site/layouts/robots.txt")
+  excludes.add("site/hugo.direct.sum")
   // Ignore generated stuff, when the Hugo is run w/o Docker
   excludes.add("site/public/**")
   excludes.add("site/resources/_gen/**")
@@ -143,15 +145,18 @@ tasks.named<RatTask>("rat").configure {
   excludes.add("regtests/**/py.typed")
   excludes.add("regtests/**/*.ref")
   excludes.add("regtests/.env")
-  excludes.add("regtests/derby.log")
-  excludes.add("regtests/metastore_db/**")
   excludes.add("regtests/output/**")
   excludes.add("plugins/**/*.ref")
+
+  // Spark
+  excludes.add("**/derby.log")
+  excludes.add("**/metastore_db/**")
 
   // IntelliJ
   excludes.add(".idea")
   excludes.add("site/it/.idea")
   excludes.add("**/*.iml")
+  excludes.add("**/*.ipr")
   excludes.add("**/*.iws")
 
   // Rat can't scan binary images


### PR DESCRIPTION
This change updates the Rat plugin exclusions as follows:

- Hugo site: added `site/hugo.direct.sum` (generated when running the site locally)
- AI: exclude `.conductor` folder (Conductor produces TOML files that become Rat false positives).
- Spark: exclude `derby.log`, `**/metastore_db` anywhere (they appear frequently when running the quickstart guides, or with adhoc Spark runs).
- IntelliJ: also exclude `.ipr` files

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
