### PR TITLE
Accept optional whitespace around commas when parsing If-None-Match

### DIFF
--- a/runtime/service/src/main/java/org/apache/polaris/service/http/IfNoneMatch.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/http/IfNoneMatch.java
@@ -32,9 +32,11 @@ public record IfNoneMatch(boolean isWildcard, @NonNull List<String> eTags) {
   // Matches but does not capture any content of an ETag
   private static final String ETAG_REGEX = "(?:W/)?\"(?:[^\"]*)\"";
 
-  // Builds comma separated list of ETags and disallows trailing comma
+  // Builds comma separated list of ETags and disallows trailing comma. Per RFC 7230 section 7 the
+  // list separator is a comma surrounded by optional whitespace (OWS = *( SP / HTAB )), so the
+  // elements may be separated by a bare comma or by a comma padded with spaces/tabs.
   private static final String IF_NONE_MATCH_REGEX =
-      String.format("(?:%s, )*%s", ETAG_REGEX, ETAG_REGEX);
+      String.format("(?:%s[ \t]*,[ \t]*)*%s", ETAG_REGEX, ETAG_REGEX);
 
   // Wraps pattern in capture group to capture entire ETag
   private static final Pattern ETAG_PATTERN = Pattern.compile(String.format("(%s)", ETAG_REGEX));

--- a/runtime/service/src/test/java/org/apache/polaris/service/http/IfNoneMatchTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/http/IfNoneMatchTest.java
@@ -63,6 +63,30 @@ public class IfNoneMatchTest {
   }
 
   @Test
+  public void validMultipleETagsWithoutSpaceAfterComma() {
+    // RFC 7230 section 7 allows a bare comma (no surrounding whitespace) between list elements.
+    String etagValue1 = "W/\"etag1\"";
+    String etagValue2 = "W/\"etag2\"";
+
+    IfNoneMatch ifNoneMatch = IfNoneMatch.fromHeader(etagValue1 + "," + etagValue2);
+
+    Assertions.assertEquals(List.of(etagValue1, etagValue2), ifNoneMatch.eTags());
+  }
+
+  @Test
+  public void validMultipleETagsWithWhitespaceAroundComma() {
+    // RFC 7230 section 7 permits optional whitespace (spaces or tabs) on either side of the comma.
+    String etagValue1 = "W/\"etag1\"";
+    String etagValue2 = "W/\"etag2\"";
+    String etagValue3 = "W/\"etag3\"";
+
+    IfNoneMatch ifNoneMatch =
+        IfNoneMatch.fromHeader(etagValue1 + " , " + etagValue2 + "\t,\t" + etagValue3);
+
+    Assertions.assertEquals(List.of(etagValue1, etagValue2, etagValue3), ifNoneMatch.eTags());
+  }
+
+  @Test
   public void validWildcardIfNoneMatch() {
     IfNoneMatch ifNoneMatch = IfNoneMatch.fromHeader("*");
     Assertions.assertTrue(ifNoneMatch.isWildcard());

--- a/runtime/service/src/test/java/org/apache/polaris/service/http/IfNoneMatchTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/http/IfNoneMatchTest.java
@@ -22,8 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for If-None-Match header processing and ETag interaction scenarios. This includes both HTTP
@@ -62,28 +66,36 @@ public class IfNoneMatchTest {
     Assertions.assertEquals(etagValue3, etag3);
   }
 
-  @Test
-  public void validMultipleETagsWithoutSpaceAfterComma() {
-    // RFC 7230 section 7 allows a bare comma (no surrounding whitespace) between list elements.
-    String etagValue1 = "W/\"etag1\"";
-    String etagValue2 = "W/\"etag2\"";
-
-    IfNoneMatch ifNoneMatch = IfNoneMatch.fromHeader(etagValue1 + "," + etagValue2);
-
-    Assertions.assertEquals(List.of(etagValue1, etagValue2), ifNoneMatch.eTags());
+  /**
+   * The RFC 9110 section 5.6.1 list separator is a comma with optional whitespace (OWS = *( SP /
+   * HTAB )) on either side, independently. Every permutation below - bare, before-only, after-only,
+   * multiple, and mixed spaces/tabs - must parse to the same two ETags.
+   */
+  static Stream<Arguments> optionalWhitespaceSeparators() {
+    return Stream.of(
+        Arguments.of("bare comma", ","),
+        Arguments.of("space before only", " ,"),
+        Arguments.of("space after only", ", "),
+        Arguments.of("tab before only", "\t,"),
+        Arguments.of("tab after only", ",\t"),
+        Arguments.of("single space both sides", " , "),
+        Arguments.of("single tab both sides", "\t,\t"),
+        Arguments.of("multiple spaces both sides", "   ,   "),
+        Arguments.of("multiple tabs both sides", "\t\t,\t\t"),
+        Arguments.of("mixed spaces and tabs", " \t , \t "),
+        Arguments.of("mixed multiple, before only", " \t \t,"));
   }
 
-  @Test
-  public void validMultipleETagsWithWhitespaceAroundComma() {
-    // RFC 7230 section 7 permits optional whitespace (spaces or tabs) on either side of the comma.
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("optionalWhitespaceSeparators")
+  public void validMultipleETagsWithOptionalWhitespaceAroundComma(
+      String description, String separator) {
     String etagValue1 = "W/\"etag1\"";
     String etagValue2 = "W/\"etag2\"";
-    String etagValue3 = "W/\"etag3\"";
 
-    IfNoneMatch ifNoneMatch =
-        IfNoneMatch.fromHeader(etagValue1 + " , " + etagValue2 + "\t,\t" + etagValue3);
+    IfNoneMatch ifNoneMatch = IfNoneMatch.fromHeader(etagValue1 + separator + etagValue2);
 
-    Assertions.assertEquals(List.of(etagValue1, etagValue2, etagValue3), ifNoneMatch.eTags());
+    Assertions.assertEquals(List.of(etagValue1, etagValue2), ifNoneMatch.eTags());
   }
 
   @Test


### PR DESCRIPTION
The `If-None-Match` parser hard-codes the list separator as a comma followed by exactly one space (`", "`). Per [RFC 9110, Section 5.6.1](https://www.rfc-editor.org/rfc/rfc9110#section-5.6.1) (the `#rule` list extension, formerly [RFC 7230, Section 7](https://www.rfc-editor.org/rfc/rfc7230#section-7)), list elements are separated by a comma with optional surrounding whitespace (`OWS = *( SP / HTAB )`). Valid headers such as `W/"a",W/"b"` or `W/"a" , W/"b"` are therefore rejected with 400.

This relaxes the separator to allow zero or more spaces or tabs on either side of the comma. ETag matching semantics are unchanged; only list parsing is affected. See [RFC 9110, Section 13.1.2](https://www.rfc-editor.org/rfc/rfc9110#section-13.1.2) for `If-None-Match`.