### PR TITLE
Fix Python client dropping external catalog subtype fields during deserialization (#5409)

### DIFF
--- a/client/python/tests/test_connection_config_deserialization.py
+++ b/client/python/tests/test_connection_config_deserialization.py
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from apache_polaris.sdk.management import (
+    ConnectionConfigInfo,
+    IcebergRestConnectionConfigInfo,
+    HadoopConnectionConfigInfo,
+    HiveConnectionConfigInfo,
+)
+
+
+def test_iceberg_rest_connection_config_deserialization():
+    data = {
+        "connectionType": "ICEBERG_REST",
+        "uri": "https://example.com/api/catalog",
+        "remoteCatalogName": "my_remote_catalog",
+        "properties": {"key": "val"},
+    }
+    config = ConnectionConfigInfo.from_dict(data)
+    assert isinstance(config, IcebergRestConnectionConfigInfo)
+    assert config.connection_type == "ICEBERG_REST"
+    assert config.uri == "https://example.com/api/catalog"
+    assert config.remote_catalog_name == "my_remote_catalog"
+    assert config.properties == {"key": "val"}
+
+
+def test_hadoop_connection_config_deserialization():
+    data = {
+        "connectionType": "HADOOP",
+        "uri": "hdfs://namenode:8020/warehouse",
+        "warehouse": "/user/hive/warehouse",
+    }
+    config = ConnectionConfigInfo.from_dict(data)
+    assert isinstance(config, HadoopConnectionConfigInfo)
+    assert config.connection_type == "HADOOP"
+    assert config.uri == "hdfs://namenode:8020/warehouse"
+    assert config.warehouse == "/user/hive/warehouse"
+
+
+def test_hive_connection_config_deserialization():
+    data = {
+        "connectionType": "HIVE",
+        "uri": "thrift://metastore:9083",
+        "warehouse": "s3://my-bucket/hive/warehouse",
+    }
+    config = ConnectionConfigInfo.from_dict(data)
+    assert isinstance(config, HiveConnectionConfigInfo)
+    assert config.connection_type == "HIVE"
+    assert config.uri == "thrift://metastore:9083"
+    assert config.warehouse == "s3://my-bucket/hive/warehouse"

--- a/spec/polaris-management-service.yml
+++ b/spec/polaris-management-service.yml
@@ -947,32 +947,35 @@ components:
       description: Configuration necessary for connecting to an Iceberg REST Catalog
       allOf:
         - $ref: '#/components/schemas/ConnectionConfigInfo'
-      properties:
-        remoteCatalogName:
-          type: string
-          description: The name of a remote catalog instance within the remote catalog service; in some older systems
-            this is specified as the 'warehouse' when multiple logical catalogs are served under the same base
-            uri, and often translates into a 'prefix' added to all REST resource paths
+        - type: object
+          properties:
+            remoteCatalogName:
+              type: string
+              description: The name of a remote catalog instance within the remote catalog service; in some older systems
+                this is specified as the 'warehouse' when multiple logical catalogs are served under the same base
+                uri, and often translates into a 'prefix' added to all REST resource paths
 
     HadoopConnectionConfigInfo:
       type: object
       description: Configuration necessary for connecting to a Hadoop Catalog
       allOf:
         - $ref: '#/components/schemas/ConnectionConfigInfo'
-      properties:
-        warehouse:
-          type: string
-          description: The file path to where this catalog should store tables
+        - type: object
+          properties:
+            warehouse:
+              type: string
+              description: The file path to where this catalog should store tables
     
     HiveConnectionConfigInfo:
       type: object
       description: Configuration necessary for connecting to a Hive Catalog
       allOf:
         - $ref: '#/components/schemas/ConnectionConfigInfo'
-      properties:
-        warehouse:
-          type: string
-          description: The warehouse location for the hive catalog.
+        - type: object
+          properties:
+            warehouse:
+              type: string
+              description: The warehouse location for the hive catalog.
     
     BigQueryMetastoreConnectionConfigInfo:
       type: object


### PR DESCRIPTION
### Rationale for this change

Fixes #5409.

When deserializing `ConnectionConfigInfo` subclasses in the Python client SDK (`IcebergRestConnectionConfigInfo`, `HadoopConnectionConfigInfo`, `HiveConnectionConfigInfo`), OpenAPI Generator's Python discriminator mapper drops subtype-specific properties (`remoteCatalogName`, `warehouse`) if they are declared as sibling properties alongside `allOf` instead of inside an object schema within `allOf`.

### What changes are included in this PR?

1. Modified `spec/polaris-management-service.yml` to nest subtype properties inside a second `- type: object` block under `allOf` for `IcebergRestConnectionConfigInfo`, `HadoopConnectionConfigInfo`, and `HiveConnectionConfigInfo` (matching existing `AwsStorageConfigInfo` pattern).
2. Regenerated management client SDK models so `remote_catalog_name` and `warehouse` are generated as top-level fields on the respective models.
3. Added unit tests in `client/python/tests/test_connection_config_deserialization.py` verifying deserialization of external catalog subtype fields.

### Are these changes tested?

Yes. Added unit test in `client/python/tests/test_connection_config_deserialization.py` and verified all 202 Python unit tests pass cleanly (`uv run pytest tests/`).