### PR TITLE
 Reconcile ambiguous JDBC writes during Iceberg metadata commits 

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -279,7 +279,11 @@ public class DatasourceOperations {
                 throw e;
               }
             } finally {
-              connection.setAutoCommit(autoCommit);
+              try {
+                connection.setAutoCommit(autoCommit);
+              } catch (SQLException resetFailure) {
+                LOGGER.warn("Unable to restore auto-commit; closing connection", resetFailure);
+              }
             }
           }
         });
@@ -386,8 +390,9 @@ public class DatasourceOperations {
   }
 
   private boolean isRetryable(SQLException e) {
-    if (SERIALIZATION_FAILURE_SQL_CODE.equals(e.getSQLState())) {
-      return true;
+    String sqlState = e.getSQLState();
+    if (sqlState != null) {
+      return SERIALIZATION_FAILURE_SQL_CODE.equals(sqlState);
     }
 
     String message = e.getMessage();

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -42,6 +42,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
+import org.apache.polaris.core.persistence.AmbiguousWriteException;
 import org.apache.polaris.core.persistence.EntityAlreadyExistsException;
 import org.apache.polaris.core.persistence.RetryOnConcurrencyException;
 import org.apache.polaris.persistence.relational.jdbc.QueryGenerator.PreparedQuery;
@@ -70,6 +71,7 @@ public class DatasourceOperations {
 
   // POSTGRES RETRYABLE EXCEPTIONS
   private static final String SERIALIZATION_FAILURE_SQL_CODE = "40001";
+  private static final String CONNECTION_FAILURE_SQL_CODE = "08006";
 
   private final DataSource datasource;
   private final RelationalJdbcConfiguration relationalJdbcConfiguration;
@@ -241,6 +243,21 @@ public class DatasourceOperations {
    * @throws SQLException : Exception during Query Execution.
    */
   public int executeUpdate(QueryGenerator.PreparedQuery preparedQuery) throws SQLException {
+    return executeUpdate(preparedQuery, false);
+  }
+
+  /**
+   * Executes an auto-commit update without replaying a connection failure whose outcome is unknown.
+   * Callers must reconcile the durable state before retrying or reporting success.
+   */
+  public int executeUpdateWithAmbiguousWriteDetection(QueryGenerator.PreparedQuery preparedQuery)
+      throws SQLException {
+    return executeUpdate(preparedQuery, true);
+  }
+
+  private int executeUpdate(
+      QueryGenerator.PreparedQuery preparedQuery, boolean detectAmbiguousWrite)
+      throws SQLException {
     return withRetries(
         () -> {
           logQuery(preparedQuery);
@@ -253,7 +270,14 @@ public class DatasourceOperations {
             boolean autoCommit = connection.getAutoCommit();
             connection.setAutoCommit(true);
             try {
-              return statement.executeUpdate();
+              try {
+                return statement.executeUpdate();
+              } catch (SQLException e) {
+                if (detectAmbiguousWrite && isAmbiguousWriteFailure(e)) {
+                  throw new AmbiguousWriteException(e);
+                }
+                throw e;
+              }
             } finally {
               connection.setAutoCommit(autoCommit);
             }
@@ -362,15 +386,35 @@ public class DatasourceOperations {
   }
 
   private boolean isRetryable(SQLException e) {
-    String sqlState = e.getSQLState();
-
-    if (sqlState != null) {
-      return sqlState.equals(SERIALIZATION_FAILURE_SQL_CODE); // Serialization failure
+    if (SERIALIZATION_FAILURE_SQL_CODE.equals(e.getSQLState())) {
+      return true;
     }
 
-    // Additionally, one might check for specific error messages or other conditions
-    return e.getMessage().toLowerCase(Locale.ROOT).contains("connection refused")
-        || e.getMessage().toLowerCase(Locale.ROOT).contains("connection reset");
+    String message = e.getMessage();
+    if (message == null) {
+      return false;
+    }
+    String lowerMessage = message.toLowerCase(Locale.ROOT);
+    return lowerMessage.contains("connection refused")
+        || lowerMessage.contains("connection reset")
+        || lowerMessage.contains("acquisition timeout");
+  }
+
+  private boolean isAmbiguousWriteFailure(SQLException e) {
+    if (CONNECTION_FAILURE_SQL_CODE.equals(e.getSQLState())) {
+      return true;
+    }
+
+    String message = e.getMessage();
+    if (message == null) {
+      return false;
+    }
+    String lowerMessage = message.toLowerCase(Locale.ROOT);
+    return lowerMessage.contains("connection refused")
+        || lowerMessage.contains("connection reset")
+        || lowerMessage.contains("i/o error occurred while sending to the backend")
+        || lowerMessage.contains("broken pipe")
+        || lowerMessage.contains("connection has been closed");
   }
 
   // TODO: consider refactoring to use a retry library, inorder to have fair retries
@@ -391,6 +435,8 @@ public class DatasourceOperations {
     while (attempts < maxAttempts) {
       try {
         return operation.execute();
+      } catch (AmbiguousWriteException e) {
+        throw e;
       } catch (EntityAlreadyExistsException | RetryOnConcurrencyException e) {
         // Pass domain exceptions through unchanged. Do not unwrap their SQLException cause into
         // the retry path (that would rewrap them as a generic SQLException and lose the typed

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -391,10 +391,12 @@ public class DatasourceOperations {
 
   private boolean isRetryable(SQLException e) {
     String sqlState = e.getSQLState();
+
     if (sqlState != null) {
-      return SERIALIZATION_FAILURE_SQL_CODE.equals(sqlState);
+      return sqlState.equals(SERIALIZATION_FAILURE_SQL_CODE); // Serialization failure
     }
 
+    // Additionally, one might check for specific error messages or other conditions
     String message = e.getMessage();
     if (message == null) {
       return false;

--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/JdbcBasePersistenceImpl.java
@@ -134,6 +134,24 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
       @NonNull PolarisBaseEntity entity,
       boolean nameOrParentChanged,
       PolarisBaseEntity originalEntity) {
+    writeEntity(callCtx, entity, nameOrParentChanged, originalEntity, false);
+  }
+
+  @Override
+  public void writeEntityWithAmbiguousWriteDetection(
+      @NonNull PolarisCallContext callCtx,
+      @NonNull PolarisBaseEntity entity,
+      boolean nameOrParentChanged,
+      PolarisBaseEntity originalEntity) {
+    writeEntity(callCtx, entity, nameOrParentChanged, originalEntity, true);
+  }
+
+  private void writeEntity(
+      @NonNull PolarisCallContext callCtx,
+      @NonNull PolarisBaseEntity entity,
+      boolean nameOrParentChanged,
+      PolarisBaseEntity originalEntity,
+      boolean detectAmbiguousWrite) {
     try {
       persistEntity(
           callCtx,
@@ -141,7 +159,9 @@ public class JdbcBasePersistenceImpl implements BasePersistence, IntegrationPers
           originalEntity,
           null,
           (connection, preparedQuery) -> {
-            return datasourceOperations.executeUpdate(preparedQuery);
+            return detectAmbiguousWrite
+                ? datasourceOperations.executeUpdateWithAmbiguousWriteDetection(preparedQuery)
+                : datasourceOperations.executeUpdate(preparedQuery);
           });
     } catch (SQLException e) {
       throw new RuntimeException("Error persisting entity", e);

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
@@ -159,6 +159,18 @@ public class DatasourceOperationsTest {
   }
 
   @Test
+  void withRetries_doesNotRetryWhenSqlStateAndMessageAreAbsent() throws SQLException {
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(2));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(1_000L));
+    when(relationalJdbcConfiguration.initialDelayInMs()).thenReturn(Optional.of(0L));
+    when(mockOperation.execute()).thenThrow(new SQLException((String) null));
+
+    assertThrows(SQLException.class, () -> datasourceOperations.withRetries(mockOperation));
+
+    verify(mockOperation).execute();
+  }
+
+  @Test
   void executeUpdateWithAmbiguousWriteDetection_retriesSerializationFailure() throws Exception {
     when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(2));
     when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(1_000L));

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.polaris.persistence.relational.jdbc;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
 import org.apache.polaris.core.entity.EventEntity;
+import org.apache.polaris.core.persistence.AmbiguousWriteException;
 import org.apache.polaris.persistence.relational.jdbc.DatasourceOperations.Operation;
 import org.apache.polaris.persistence.relational.jdbc.models.ImmutableModelEvent;
 import org.apache.polaris.persistence.relational.jdbc.models.ModelEntity;
@@ -95,6 +97,59 @@ public class DatasourceOperationsTest {
     when(mockPreparedStatement.executeUpdate()).thenThrow(new SQLException("demo", "42P07"));
 
     assertThrows(SQLException.class, () -> datasourceOperations.executeUpdate(query));
+  }
+
+  @Test
+  void executeUpdateWithAmbiguousWriteDetection_doesNotRetryAmbiguousConnectionFailure()
+      throws Exception {
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(3));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(1_000L));
+    when(relationalJdbcConfiguration.initialDelayInMs()).thenReturn(Optional.of(0L));
+    QueryGenerator.PreparedQuery query =
+        new QueryGenerator.PreparedQuery("UPDATE entities SET entity_version = ?", List.of(2));
+    when(mockConnection.prepareStatement(query.sql())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeUpdate())
+        .thenThrow(new SQLException("An I/O error occurred while sending to the backend."));
+
+    assertThatThrownBy(() -> datasourceOperations.executeUpdateWithAmbiguousWriteDetection(query))
+        .isInstanceOf(AmbiguousWriteException.class);
+
+    verify(mockPreparedStatement).executeUpdate();
+  }
+
+  @Test
+  void executeUpdateWithAmbiguousWriteDetection_retriesSerializationFailure() throws Exception {
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(2));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(1_000L));
+    when(relationalJdbcConfiguration.initialDelayInMs()).thenReturn(Optional.of(0L));
+    QueryGenerator.PreparedQuery query =
+        new QueryGenerator.PreparedQuery("UPDATE entities SET entity_version = ?", List.of(2));
+    when(mockConnection.prepareStatement(query.sql())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeUpdate())
+        .thenThrow(new SQLException("serialization failure", "40001"))
+        .thenReturn(1);
+
+    assertEquals(1, datasourceOperations.executeUpdateWithAmbiguousWriteDetection(query));
+
+    verify(mockPreparedStatement, times(2)).executeUpdate();
+  }
+
+  @Test
+  void executeUpdateWithAmbiguousWriteDetection_retriesAcquisitionTimeout() throws Exception {
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(2));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(1_000L));
+    when(relationalJdbcConfiguration.initialDelayInMs()).thenReturn(Optional.of(0L));
+    when(mockDataSource.getConnection())
+        .thenThrow(new SQLException("Acquisition timeout while waiting for a connection"))
+        .thenReturn(mockConnection);
+    QueryGenerator.PreparedQuery query =
+        new QueryGenerator.PreparedQuery("UPDATE entities SET entity_version = ?", List.of(2));
+    when(mockConnection.prepareStatement(query.sql())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeUpdate()).thenReturn(1);
+
+    assertEquals(1, datasourceOperations.executeUpdateWithAmbiguousWriteDetection(query));
+
+    verify(mockPreparedStatement).executeUpdate();
   }
 
   @Test

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
@@ -23,8 +23,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -115,6 +117,45 @@ public class DatasourceOperationsTest {
         .isInstanceOf(AmbiguousWriteException.class);
 
     verify(mockPreparedStatement).executeUpdate();
+  }
+
+  @Test
+  void executeUpdateWithAmbiguousWriteDetection_preservesAmbiguousFailureWhenResetFails()
+      throws Exception {
+    QueryGenerator.PreparedQuery query =
+        new QueryGenerator.PreparedQuery("UPDATE entities SET entity_version = ?", List.of(2));
+    when(mockConnection.prepareStatement(query.sql())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeUpdate())
+        .thenThrow(new SQLException("An I/O error occurred while sending to the backend."));
+    doAnswer(
+            invocation -> {
+              if (!(Boolean) invocation.getArgument(0)) {
+                throw new SQLException("This connection has been closed.");
+              }
+              return null;
+            })
+        .when(mockConnection)
+        .setAutoCommit(anyBoolean());
+
+    AmbiguousWriteException exception =
+        assertThrows(
+            AmbiguousWriteException.class,
+            () -> datasourceOperations.executeUpdateWithAmbiguousWriteDetection(query));
+
+    assertEquals(
+        "Unable to determine whether the persistence write succeeded", exception.getMessage());
+  }
+
+  @Test
+  void withRetries_doesNotUseMessageFallbackWhenSqlStateIsPresent() throws SQLException {
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(2));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(1_000L));
+    when(relationalJdbcConfiguration.initialDelayInMs()).thenReturn(Optional.of(0L));
+    when(mockOperation.execute()).thenThrow(new SQLException("connection reset", "08006"));
+
+    assertThrows(SQLException.class, () -> datasourceOperations.withRetries(mockOperation));
+
+    verify(mockOperation).execute();
   }
 
   @Test

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AmbiguousWriteException.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AmbiguousWriteException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.persistence;
+
+/**
+ * Raised when a write may have reached the persistence backend but its result could not be
+ * confirmed.
+ *
+ * <p>Callers must reconcile the intended write before retrying or reporting a definite conflict.
+ */
+public class AmbiguousWriteException extends RuntimeException {
+  public AmbiguousWriteException(Throwable cause) {
+    super("Unable to determine whether the persistence write succeeded", cause);
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/AtomicOperationMetaStoreManager.java
@@ -154,12 +154,28 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       @NonNull PolarisBaseEntity entity,
       boolean nameOrParentChanged,
       @NonNull PolarisBaseEntity originalEntity) {
+    return persistEntityAfterChange(
+        callCtx, ms, entity, nameOrParentChanged, originalEntity, false);
+  }
+
+  private @NonNull PolarisBaseEntity persistEntityAfterChange(
+      @NonNull PolarisCallContext callCtx,
+      @NonNull BasePersistence ms,
+      @NonNull PolarisBaseEntity entity,
+      boolean nameOrParentChanged,
+      @NonNull PolarisBaseEntity originalEntity,
+      boolean detectAmbiguousWrite) {
     // Invoke shared logic for validation and updating expected fields.
     entity =
         prepareToPersistEntityAfterChange(callCtx, ms, entity, nameOrParentChanged, originalEntity);
 
     // persist it to the various slices
-    ms.writeEntity(callCtx, entity, nameOrParentChanged, originalEntity);
+    if (detectAmbiguousWrite) {
+      ms.writeEntityWithAmbiguousWriteDetection(
+          callCtx, entity, nameOrParentChanged, originalEntity);
+    } else {
+      ms.writeEntity(callCtx, entity, nameOrParentChanged, originalEntity);
+    }
 
     // return it
     return entity;
@@ -922,6 +938,22 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
       @NonNull PolarisCallContext callCtx,
       @Nullable List<PolarisEntityCore> catalogPath,
       @NonNull PolarisBaseEntity entity) {
+    return updateEntityPropertiesIfNotChanged(callCtx, catalogPath, entity, false);
+  }
+
+  @Override
+  public @NonNull EntityResult updateEntityPropertiesIfNotChangedWithAmbiguousWriteDetection(
+      @NonNull PolarisCallContext callCtx,
+      @Nullable List<PolarisEntityCore> catalogPath,
+      @NonNull PolarisBaseEntity entity) {
+    return updateEntityPropertiesIfNotChanged(callCtx, catalogPath, entity, true);
+  }
+
+  private @NonNull EntityResult updateEntityPropertiesIfNotChanged(
+      @NonNull PolarisCallContext callCtx,
+      @Nullable List<PolarisEntityCore> catalogPath,
+      @NonNull PolarisBaseEntity entity,
+      boolean detectAmbiguousWrite) {
     // get metastore we should be using
     BasePersistence ms = callCtx.getMetaStore();
 
@@ -931,7 +963,7 @@ public class AtomicOperationMetaStoreManager extends BaseMetaStoreManager {
     // updated time. Because the entity version is changed, we will update the change tracking table
     try {
       PolarisBaseEntity persistedEntity =
-          this.persistEntityAfterChange(callCtx, ms, entity, false, entity);
+          this.persistEntityAfterChange(callCtx, ms, entity, false, entity, detectAmbiguousWrite);
 
       // TODO: Revalidate parent-path *after* performing update to fulfill the semantic of returning
       // a NotFoundException if some element of the parent path was concurrently deleted.

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/BasePersistence.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/BasePersistence.java
@@ -94,6 +94,21 @@ public interface BasePersistence extends PolicyMappingPersistence {
       @Nullable PolarisBaseEntity originalEntity);
 
   /**
+   * Writes an entity without retrying a connection failure whose outcome may be ambiguous.
+   *
+   * <p>The default preserves the behavior of persistence implementations that execute this write
+   * transactionally. Backends that issue an auto-commit statement should override this method when
+   * the caller can reconcile the resulting entity state.
+   */
+  default void writeEntityWithAmbiguousWriteDetection(
+      @NonNull PolarisCallContext callCtx,
+      @NonNull PolarisBaseEntity entity,
+      boolean nameOrParentChanged,
+      @Nullable PolarisBaseEntity originalEntity) {
+    writeEntity(callCtx, entity, nameOrParentChanged, originalEntity);
+  }
+
+  /**
    * write a batch of entities to the persistence backend conditional on *every* member of
    * originalEntities matching the existing persistent state. After this commit, *every* member of
    * entities must be committed durably.

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/PolarisMetaStoreManager.java
@@ -273,6 +273,19 @@ public interface PolarisMetaStoreManager
       @NonNull PolarisBaseEntity entity);
 
   /**
+   * Updates an entity and reports an ambiguous auto-commit write instead of replaying it.
+   *
+   * <p>Callers must reconcile the persisted entity before treating an ambiguous result as success.
+   * The default is appropriate for transactional persistence implementations.
+   */
+  default @NonNull EntityResult updateEntityPropertiesIfNotChangedWithAmbiguousWriteDetection(
+      @NonNull PolarisCallContext callCtx,
+      @Nullable List<PolarisEntityCore> catalogPath,
+      @NonNull PolarisBaseEntity entity) {
+    return updateEntityPropertiesIfNotChanged(callCtx, catalogPath, entity);
+  }
+
+  /**
    * This works exactly like {@link #updateEntityPropertiesIfNotChanged(PolarisCallContext, List,
    * PolarisBaseEntity)} but allows to operate on multiple entities at once. Just loop through the
    * list, calling each entity update and return null if any of those fail.

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -2935,22 +2935,26 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
                   PolarisEntity.toCoreList(catalogPath),
                   icebergTableLikeEntity);
     } catch (AmbiguousWriteException e) {
-      EntityResult persisted =
-          getMetaStoreManager()
-              .loadEntity(
-                  getCurrentPolarisContext(),
-                  icebergTableLikeEntity.getCatalogId(),
-                  icebergTableLikeEntity.getId(),
-                  icebergTableLikeEntity.getType());
-      if (persisted.isSuccess()
-          && Objects.equal(
-              IcebergTableLikeEntity.of(persisted.getEntity()).getMetadataLocation(),
-              icebergTableLikeEntity.getMetadataLocation())) {
-        LOGGER.info(
-            "Recovered ambiguous table commit for {} with metadata location {}",
-            identifier,
-            icebergTableLikeEntity.getMetadataLocation());
-        return;
+      try {
+        EntityResult persisted =
+            getMetaStoreManager()
+                .loadEntity(
+                    getCurrentPolarisContext(),
+                    icebergTableLikeEntity.getCatalogId(),
+                    icebergTableLikeEntity.getId(),
+                    icebergTableLikeEntity.getType());
+        if (persisted.isSuccess()
+            && Objects.equal(
+                IcebergTableLikeEntity.of(persisted.getEntity()).getMetadataLocation(),
+                icebergTableLikeEntity.getMetadataLocation())) {
+          LOGGER.info(
+              "Recovered ambiguous table commit for {} with metadata location {}",
+              identifier,
+              icebergTableLikeEntity.getMetadataLocation());
+          return;
+        }
+      } catch (RuntimeException reconciliationFailure) {
+        e.addSuppressed(reconciliationFailure);
       }
       throw new CommitStateUnknownException(
           "Unable to determine whether table metadata location became current", e);

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -73,6 +73,7 @@ import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
@@ -119,6 +120,7 @@ import org.apache.polaris.core.entity.PolarisTaskConstants;
 import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
+import org.apache.polaris.core.persistence.AmbiguousWriteException;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
@@ -2924,12 +2926,35 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     }
 
     List<PolarisEntity> catalogPath = resolvedEntities.getRawParentPath();
-    EntityResult res =
-        getMetaStoreManager()
-            .updateEntityPropertiesIfNotChanged(
-                getCurrentPolarisContext(),
-                PolarisEntity.toCoreList(catalogPath),
-                icebergTableLikeEntity);
+    EntityResult res;
+    try {
+      res =
+          getMetaStoreManager()
+              .updateEntityPropertiesIfNotChangedWithAmbiguousWriteDetection(
+                  getCurrentPolarisContext(),
+                  PolarisEntity.toCoreList(catalogPath),
+                  icebergTableLikeEntity);
+    } catch (AmbiguousWriteException e) {
+      EntityResult persisted =
+          getMetaStoreManager()
+              .loadEntity(
+                  getCurrentPolarisContext(),
+                  icebergTableLikeEntity.getCatalogId(),
+                  icebergTableLikeEntity.getId(),
+                  icebergTableLikeEntity.getType());
+      if (persisted.isSuccess()
+          && Objects.equal(
+              IcebergTableLikeEntity.of(persisted.getEntity()).getMetadataLocation(),
+              icebergTableLikeEntity.getMetadataLocation())) {
+        LOGGER.info(
+            "Recovered ambiguous table commit for {} with metadata location {}",
+            identifier,
+            icebergTableLikeEntity.getMetadataLocation());
+        return;
+      }
+      throw new CommitStateUnknownException(
+          "Unable to determine whether table metadata location became current", e);
+    }
     if (!res.isSuccess()) {
       switch (res.getReturnStatus()) {
         case BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED:

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -2898,7 +2898,7 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
 
     doReturn(new EntityResult(BaseResult.ReturnStatus.TARGET_ENTITY_CONCURRENTLY_MODIFIED, null))
         .when(spyMetaStore)
-        .updateEntityPropertiesIfNotChanged(any(), any(), any());
+        .updateEntityPropertiesIfNotChangedWithAmbiguousWriteDetection(any(), any(), any());
 
     UpdateSchema update = table.updateSchema().addColumn("new_col", Types.LongType.get());
     Schema expected = update.apply();

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/AbstractLocalIcebergCatalogTest.java
@@ -26,6 +26,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isA;
@@ -48,6 +49,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -94,6 +96,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NotFoundException;
@@ -134,6 +137,7 @@ import org.apache.polaris.core.entity.table.IcebergTableLikeEntity;
 import org.apache.polaris.core.exceptions.CommitConflictException;
 import org.apache.polaris.core.exceptions.PolarisServiceUnavailableException;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
+import org.apache.polaris.core.persistence.AmbiguousWriteException;
 import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.TransactionWorkspaceMetaStoreManager;
@@ -2906,6 +2910,37 @@ public abstract class AbstractLocalIcebergCatalogTest extends CatalogTests<Local
     Assertions.assertThatThrownBy(() -> update.commit())
         .isInstanceOf(CommitConflictException.class)
         .hasMessageContaining("conflict_table");
+  }
+
+  @Test
+  public void testAmbiguousTableCommitReturnsUnknownWhenReconciliationFails() {
+    Assumptions.assumeTrue(
+        requiresNamespaceCreate(),
+        "Only applicable if namespaces must be created before adding children");
+    Assumptions.assumeTrue(
+        supportsNestedNamespaces(), "Only applicable if nested namespaces are supported");
+
+    PolarisMetaStoreManager spyMetaStore = spy(metaStoreManager);
+    LocalIcebergCatalog catalog = newIcebergCatalog(CATALOG_NAME, spyMetaStore);
+    catalog.initialize(
+        CATALOG_NAME,
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
+    Namespace namespace = Namespace.of("parent", "ambiguous_commit");
+    createNonExistingNamespaces(namespace);
+    Table table = catalog.buildTable(TableIdentifier.of(namespace, "table"), SCHEMA).create();
+
+    doThrow(new AmbiguousWriteException(new SQLException("connection reset")))
+        .when(spyMetaStore)
+        .updateEntityPropertiesIfNotChangedWithAmbiguousWriteDetection(any(), any(), any());
+    doThrow(new RuntimeException("database unavailable"))
+        .when(spyMetaStore)
+        .loadEntity(any(), anyLong(), anyLong(), any());
+
+    Assertions.assertThatThrownBy(
+            () -> table.updateSchema().addColumn("new_col", Types.LongType.get()).commit())
+        .isInstanceOf(CommitStateUnknownException.class)
+        .hasMessageContaining("Unable to determine whether table metadata location became current");
   }
 
   static Stream<Arguments> renameFailureStatuses() {

--- a/runtime/service/src/test/java/org/apache/polaris/service/it/RestCatalogFileIntegrationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/it/RestCatalogFileIntegrationTest.java
@@ -18,18 +18,35 @@
  */
 package org.apache.polaris.service.it;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.smallrye.common.annotation.Identifier;
 import jakarta.inject.Inject;
+import java.sql.SQLException;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.polaris.core.persistence.AmbiguousWriteException;
+import org.apache.polaris.core.persistence.MetaStoreManagerFactory;
+import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.service.Profiles;
 import org.apache.polaris.service.it.test.PolarisRestCatalogFileIntegrationTest;
 import org.apache.polaris.service.task.TaskErrorHandler;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 @TestProfile(Profiles.RestCatalogFileIntegrationProfile.class)
 public class RestCatalogFileIntegrationTest extends PolarisRestCatalogFileIntegrationTest {
+  @Inject MetaStoreManagerFactory metaStoreManagerFactory;
+
   @Inject
   @Identifier("task-error-handler")
   TaskErrorHandler taskErrorHandler;
@@ -37,5 +54,40 @@ public class RestCatalogFileIntegrationTest extends PolarisRestCatalogFileIntegr
   @AfterEach
   void checkTaskExceptions() {
     taskErrorHandler.assertNoTaskExceptions();
+  }
+
+  @Test
+  void appendRecoversWhenDatabaseWriteResultIsLost() {
+    Namespace namespace = Namespace.of("ambiguous_commit");
+    TableIdentifier tableIdentifier = TableIdentifier.of(namespace, "tbl");
+    catalog().createNamespace(namespace);
+    Table table = catalog().buildTable(tableIdentifier, SCHEMA).create();
+
+    PolarisMetaStoreManager metaStoreManager =
+        spy(metaStoreManagerFactory.getOrCreateMetaStoreManager(() -> "POLARIS"));
+    MetaStoreManagerFactory factorySpy = spy(metaStoreManagerFactory);
+    doReturn(metaStoreManager).when(factorySpy).getOrCreateMetaStoreManager(any());
+    QuarkusMock.installMockForType(factorySpy, MetaStoreManagerFactory.class);
+
+    doAnswer(
+            invocation -> {
+              invocation.callRealMethod();
+              throw new AmbiguousWriteException(
+                  new SQLException("I/O error occurred while sending to the backend"));
+            })
+        .when(metaStoreManager)
+        .updateEntityPropertiesIfNotChangedWithAmbiguousWriteDetection(any(), any(), any());
+
+    table.newAppend().appendFile(FILE_A).commit();
+
+    Table committedTable = catalog().loadTable(tableIdentifier);
+    var snapshot = committedTable.currentSnapshot();
+    assertThat(snapshot).isNotNull();
+    assertThat(committedTable.io().newInputFile(snapshot.manifestListLocation()).exists()).isTrue();
+    assertThat(snapshot.allManifests(committedTable.io()))
+        .allSatisfy(
+            manifest ->
+                assertThat(committedTable.io().newInputFile(manifest.path().toString()).exists())
+                    .isTrue());
   }
 }

--- a/runtime/service/src/test/java/org/apache/polaris/service/it/RestCatalogFileIntegrationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/it/RestCatalogFileIntegrationTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -79,6 +80,9 @@ public class RestCatalogFileIntegrationTest extends PolarisRestCatalogFileIntegr
         .updateEntityPropertiesIfNotChangedWithAmbiguousWriteDetection(any(), any(), any());
 
     table.newAppend().appendFile(FILE_A).commit();
+
+    verify(metaStoreManager)
+        .updateEntityPropertiesIfNotChangedWithAmbiguousWriteDetection(any(), any(), any());
 
     Table committedTable = catalog().loadTable(tableIdentifier);
     var snapshot = committedTable.currentSnapshot();


### PR DESCRIPTION
fixes: https://github.com/apache/polaris/issues/5459
## Summary

Handle uncertain outcomes from JDBC entity updates made during Iceberg metadata commits.

A JDBC `executeUpdate()` can complete on the database while the client loses the response. Previously, Polaris could surface that outcome as a definite commit conflict. Iceberg may then treat the commit as failed and clean up metadata/manifests that are already referenced by the successfully committed table metadata.

This change:

- identifies failures occurring during the JDBC update execution as potentially ambiguous rather than retrying them;
- reloads the persisted table entity after an ambiguous write;
- treats the commit as successful when the persisted metadata location matches the requested metadata location;
- returns Iceberg `CommitStateUnknownException` when the intended persisted state cannot be confirmed, preventing a false definite commit failure and unsafe cleanup;
- preserves existing retry behavior for connection acquisition, statement setup, serialization failures, and other failures known to occur before the write executes.

The ambiguity-aware behavior is selected only for Iceberg table-like metadata updates. Non-JDBC persistence implementations retain their existing behavior through default SPI methods.

## Why

The issue is not specific to a particular connection pooler or proxy. Any auto-commit JDBC deployment can lose the response after the database has applied an update. The key problem is distinguishing an update known not to have happened from one whose result is genuinely unknown.

## Tests

- ambiguous post-`executeUpdate()` failures are not retried;
- pre-execution connection-acquisition failures continue to retry;
- serialization failures continue to retry;
- successful reconciliation after a lost write response preserves readable committed metadata and manifests;
- normal optimistic-concurrency conflicts retain their existing behavior.