### PR TITLE
CLI: show current status for namespace during setup dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Python CLI `setup` now preserves `endpoint_internal` and `sts_endpoint` during apply and export for S3 configuration
 - Fixed a false-negative in the JDBC optimized location-overlap check (`OPTIMIZED_SIBLING_CHECK`). Ancestor locations stored in `location_without_scheme` without a trailing slash were not matched by the generated ancestor equality terms, allowing nested table/namespace locations to be created under existing prefixes. The query now emits both slash-terminated and non-slash-terminated prefix terms and uses a slash-terminated `LIKE` pattern for descendant matching.
 - Python CLI `setup` now preserves the Azure `hierarchical` storage flag during apply and export
+- Python CLI `setup apply --dry-run` now reports already-existing namespaces as skipped instead of proposed creations.
 - Fixed policy detach on the relational JDBC backend silently doing nothing when the mapping's `parameters` changed in between. The delete's `WHERE` clause included the non-key `parameters` column, so a re-attach landing between the detach's lookup and its delete made the delete match zero rows while detach still reported success, leaving the policy attached. The delete is now keyed on the mapping's identity columns, matching the table's primary key and the transactional backend's behavior.
 - Relational JDBC: the `idx_locations` index used by the optimized sibling check now matches the
   query that reads it. On Postgres and CockroachDB the index led with `parent_id`, while the overlap
@@ -152,6 +153,7 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Internal JWTs are bound to principal secret generation via `polaris-cv` (no secret material in the
   token). Credential-generation is enforced on token exchange; bearer verify is signature and claims
   only. Secrets-load failures during exchange return service unavailable.
+
 
 ### Commits
 

--- a/client/python/apache_polaris/cli/command/setup.py
+++ b/client/python/apache_polaris/cli/command/setup.py
@@ -1264,6 +1264,19 @@ class SetupCommand(Command):
         listed_parents: Set[tuple[str, ...]] = set()
 
         listed_parents.add(())
+        confirmed_existing_namespaces: Set[tuple[str, ...]] = set()
+        if dry_run:
+            try:
+                sub_ns = catalog_api.list_namespaces(prefix=catalog_name).namespaces
+                for ns in sub_ns:
+                    existing_namespaces.add(tuple(ns))
+                    confirmed_existing_namespaces.add(tuple(ns))
+            except NotFoundException:
+                pass
+            except Exception:
+                self._record_failure(
+                    f"Failed to list existing namespaces for catalog '{catalog_name}'"
+                )
         all_namespaces_to_create: Set[tuple[str, ...]] = set()
         namespace_data_map: Dict[tuple[str, ...], Dict[str, Any]] = {}
         for ns_item in namespaces_config:
@@ -1295,17 +1308,17 @@ class SetupCommand(Command):
             if len(namespace_key) > 1:
                 parent = namespace_key[:-1]
                 parent_ns = ".".join(parent)
-                if (
-                    not dry_run
-                    and parent in existing_namespaces
-                    and parent not in listed_parents
-                ):
+                known_parents = (
+                    confirmed_existing_namespaces if dry_run else existing_namespaces
+                )
+                if parent in known_parents and parent not in listed_parents:
                     try:
                         sub_ns = catalog_api.list_namespaces(
                             prefix=catalog_name, parent=UNIT_SEPARATOR.join(parent)
                         ).namespaces
                         for ns in sub_ns:
                             existing_namespaces.add(tuple(ns))
+                            confirmed_existing_namespaces.add(tuple(ns))
                             listed_parents.add(parent)
                     except Exception:
                         self._record_failure(

--- a/client/python/tests/test_setup_command.py
+++ b/client/python/tests/test_setup_command.py
@@ -19,6 +19,7 @@
 
 import io
 from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import call, patch, MagicMock, mock_open
 
 import yaml
@@ -185,6 +186,78 @@ class TestSetupCommand(CLITestBase):
         )
 
         self.assertEqual(command._failure_count, 1)
+
+    @patch("apache_polaris.cli.command.setup.IcebergCatalogAPI")
+    def test_setup_dry_run_namespace_detects_existing_namespaces(
+        self, mock_catalog_api_class: MagicMock
+    ) -> None:
+        def list_namespaces(
+            prefix: str, parent: Optional[str] = None
+        ) -> SimpleNamespace:
+            if parent is None:
+                return SimpleNamespace(namespaces=[["dev_namespace"]])
+            return SimpleNamespace(namespaces=[["dev_namespace", "inner_namespace"]])
+
+        mock_catalog_api_class.return_value.list_namespaces.side_effect = (
+            list_namespaces
+        )
+        mock_client = self.build_mock_client()
+        command = SetupCommand(
+            setup_subcommand=Subcommands.APPLY,
+            dry_run=True,
+        )
+        with self.assertLogs("apache_polaris.cli.command.setup", level="INFO") as logs:
+            command._create_namespaces(
+                mock_client,
+                "catalog",
+                [{"name": ["dev_namespace", "inner_namespace"]}],
+                dry_run=True,
+            )
+
+        output = "\n".join(logs.output)
+        self.assertIn(
+            "Skipping creation for already existing namespace 'dev_namespace'", output
+        )
+        self.assertIn(
+            "Skipping creation for already existing namespace "
+            "'dev_namespace.inner_namespace'",
+            output,
+        )
+        self.assertNotIn("Would create namespace", output)
+        mock_catalog_api_class.return_value.list_namespaces.assert_called()
+
+    @patch("apache_polaris.cli.command.setup.IcebergCatalogAPI")
+    def test_setup_dry_run_nested_namespace_without_existing_parent_succeeds(
+        self, mock_catalog_api_class: MagicMock
+    ) -> None:
+        def list_namespaces(
+            prefix: str, parent: Optional[str] = None
+        ) -> SimpleNamespace:
+            if parent is None:
+                return SimpleNamespace(namespaces=[])
+            raise NotFoundException()
+
+        list_namespaces_mock = mock_catalog_api_class.return_value.list_namespaces
+        list_namespaces_mock.side_effect = list_namespaces
+        mock_client = self.build_mock_client()
+        command = SetupCommand(
+            setup_subcommand=Subcommands.APPLY,
+            dry_run=True,
+        )
+        with self.assertLogs("apache_polaris.cli.command.setup", level="INFO") as logs:
+            command._create_namespaces(
+                mock_client,
+                "catalog",
+                [{"name": ["dev_namespace", "inner_namespace"]}],
+                dry_run=True,
+            )
+
+        self.assertEqual(command._failure_count, 0)
+        self.assertIn(
+            "Would create namespace dev_namespace.inner_namespace",
+            "\n".join(logs.output),
+        )
+        list_namespaces_mock.assert_called_once_with(prefix="catalog")
 
     @patch("apache_polaris.cli.command.setup.PolicyAPI")
     def test_setup_apply_recovers_policy_lookup_failure(

--- a/site/content/guides/assets/polaris/simple-setup-config.yaml
+++ b/site/content/guides/assets/polaris/simple-setup-config.yaml
@@ -45,4 +45,4 @@ catalogs:
           catalog:
             - CATALOG_MANAGE_CONTENT
     namespaces:
-      - dev_namespace
+     - name: [dev_namespace]

--- a/site/content/in-dev/unreleased/getting-started/setup-tools.md
+++ b/site/content/in-dev/unreleased/getting-started/setup-tools.md
@@ -82,7 +82,7 @@ catalogs:
           catalog:
             - CATALOG_MANAGE_CONTENT
     namespaces:
-      - dev_namespace
+      - name: [dev_namespace]
 ```
 
 ### Applying the Setup


### PR DESCRIPTION
<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

Earlier namespace exists check is always skipped during dry-run. This PR close this gap by checking if namespaces existed during dry-run mode as well now. Sample output:
```
2026-09-07 23:42:00,202 INFO --- Processing namespaces for catalog: quickstart_catalog ---
2026-09-07 23:42:00,223 INFO Skipping creation for already existing namespace 'a_namespace' in catalog 'quickstart_catalog'
2026-09-07 23:42:00,223 INFO Skipping creation for already existing namespace 'dev_namespace' in catalog 'quickstart_catalog'
2026-09-07 23:42:00,242 INFO Skipping creation for already existing namespace 'dev_namespace.inner_namespace' in catalog 'quickstart_catalog'
2026-09-07 23:42:00,242 INFO --- Finished processing namespaces for catalog: quickstart_catalog ---
2026-09-07 23:42:00,242 INFO --- Processing catalog roles for catalog: quickstart_catalog ---
```

Also, this PR apply fixes from https://github.com/apache/polaris/pull/5292 for sample setup config (the existed one is still valid but less preferred based on discussion from reference PR).

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
