### PR TITLE
fix: return 400 instead of 500 for malformed pageToken on list endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,10 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 - Deleting a semantic model now returns HTTP 404 instead of HTTP 500 when the model or its
   catalog path disappears after resolution and before the deletion is persisted.
 - Return HTTP 404 instead of 500 when a policy or its catalog path disappears after resolution and before deletion.
-
+- Iceberg REST: a malformed `pageToken` on the namespace, table and view list endpoints now returns
+  `400 Bad Request` (`Invalid page token`) instead of `500 Internal Server Error`. Tokens that are
+  valid Base64 but not a serialized page token (garbage, truncated, or produced by an incompatible
+  Polaris version) previously escaped as Jackson decoding exceptions.
 - Iceberg REST: renaming a table or view with a missing `source` or `destination` now returns `400 Bad Request` instead of `500 Internal Server Error`.
 - Python CLI `catalogs create --type external` now validates `--storage-type` and `--default-base-location` up front, matching the behavior for internal catalogs and the flags' documented "(Required)" status. Previously, omitting either produced an opaque pydantic `ValidationError` at request-build time.
 - Iceberg REST: server-side JSON processing failures (HTTP 500) now return the standard Iceberg

--- a/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
+++ b/integration-tests/src/main/java/org/apache/polaris/service/it/test/PolarisRestCatalogIntegrationBase.java
@@ -2863,6 +2863,27 @@ public abstract class PolarisRestCatalogIntegrationBase extends CatalogTests<RES
   }
 
   @Test
+  public void testMalformedPageTokenIsBadRequest() {
+    // Valid url-safe base64 that is not a serialized page token. Client input, so the server
+    // must answer 400, not 500.
+    for (String badToken : List.of("AAAA", "aGVsbG8gd29ybGQ=", "%%%not-base64%%%")) {
+      try (Response response =
+          catalogApi
+              .request(
+                  "v1/{cat}/namespaces",
+                  Map.of("cat", currentCatalogName),
+                  Map.of("pageToken", badToken, "pageSize", "5"))
+              .get()) {
+        assertThat(response)
+            .as("pageToken=" + badToken)
+            .returns(Response.Status.BAD_REQUEST.getStatusCode(), Response::getStatus)
+            .extracting(r -> r.readEntity(ErrorResponse.class))
+            .returns("Invalid page token", ErrorResponse::message);
+      }
+    }
+  }
+
+  @Test
   public void testPaginatedListTables() {
     String prefix = "testPaginatedListTables";
     Namespace namespace = Namespace.of(prefix);

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageTokenUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageTokenUtil.java
@@ -34,6 +34,7 @@ import java.util.OptionalInt;
 import java.util.ServiceLoader;
 import java.util.function.BooleanSupplier;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.DatabindContext;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.ObjectMapper;
@@ -111,6 +112,11 @@ final class PageTokenUtil {
 
   private PageTokenUtil() {}
 
+  @VisibleForTesting
+  static ObjectMapper smileMapperForTests() {
+    return SMILE_MAPPER;
+  }
+
   /**
    * Decodes a {@link PageToken} from API request parameters for the page-size and a serialized page
    * token.
@@ -122,8 +128,7 @@ final class PageTokenUtil {
     if (requestedPageToken != null
         && !requestedPageToken.isEmpty()
         && shouldDecodeToken.getAsBoolean()) {
-      var bytes = Base64.getUrlDecoder().decode(requestedPageToken);
-      var pageToken = SMILE_MAPPER.readValue(bytes, PageToken.class);
+      var pageToken = deserializePageToken(requestedPageToken);
       if (requestedPageSize != null) {
         int pageSizeInt = requestedPageSize;
         checkArgument(pageSizeInt >= 0, "Invalid page size");
@@ -138,6 +143,23 @@ final class PageTokenUtil {
       return fromLimit(pageSizeInt);
     } else {
       return READ_EVERYTHING;
+    }
+  }
+
+  /**
+   * Decodes a client-supplied page token. Page tokens are opaque to clients, so any decoding
+   * failure is client input that cannot be interpreted and must surface as an {@link
+   * IllegalArgumentException} (mapped to HTTP 400), never as a server error.
+   */
+  private static PageToken deserializePageToken(String requestedPageToken) {
+    try {
+      var bytes = Base64.getUrlDecoder().decode(requestedPageToken);
+      return SMILE_MAPPER.readValue(bytes, PageToken.class);
+    } catch (IllegalArgumentException | IllegalStateException | JacksonException e) {
+      // IllegalArgumentException: not base64. IllegalStateException: unknown token type id (see
+      // TokenTypeIdResolver). JacksonException: not a serialized PageToken (garbage, truncated, or
+      // produced by an incompatible Polaris version).
+      throw new IllegalArgumentException("Invalid page token", e);
     }
   }
 

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageTokenUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageTokenUtil.java
@@ -34,7 +34,6 @@ import java.util.OptionalInt;
 import java.util.ServiceLoader;
 import java.util.function.BooleanSupplier;
 import org.jspecify.annotations.Nullable;
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.DatabindContext;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.ObjectMapper;
@@ -112,11 +111,6 @@ final class PageTokenUtil {
 
   private PageTokenUtil() {}
 
-  @VisibleForTesting
-  static ObjectMapper smileMapperForTests() {
-    return SMILE_MAPPER;
-  }
-
   /**
    * Decodes a {@link PageToken} from API request parameters for the page-size and a serialized page
    * token.
@@ -155,10 +149,12 @@ final class PageTokenUtil {
     try {
       var bytes = Base64.getUrlDecoder().decode(requestedPageToken);
       return SMILE_MAPPER.readValue(bytes, PageToken.class);
-    } catch (IllegalArgumentException | IllegalStateException | JacksonException e) {
-      // IllegalArgumentException: not base64. IllegalStateException: unknown token type id (see
-      // TokenTypeIdResolver). JacksonException: not a serialized PageToken (garbage, truncated, or
-      // produced by an incompatible Polaris version).
+    } catch (RuntimeException e) {
+      // Deliberately broad: the input is untrusted bytes fed to a binary parser. Besides the
+      // expected failures (IllegalArgumentException for non-base64, JacksonException for a payload
+      // that is not a serialized PageToken, IllegalStateException for an unknown token type id),
+      // corrupted SMILE can surface as e.g. ArrayIndexOutOfBoundsException from the parser. All of
+      // them mean the same thing: the client sent a token we cannot interpret.
       throw new IllegalArgumentException("Invalid page token", e);
     }
   }

--- a/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageTokenUtil.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/persistence/pagination/PageTokenUtil.java
@@ -146,9 +146,10 @@ final class PageTokenUtil {
    * IllegalArgumentException} (mapped to HTTP 400), never as a server error.
    */
   private static PageToken deserializePageToken(String requestedPageToken) {
+    PageToken pageToken;
     try {
       var bytes = Base64.getUrlDecoder().decode(requestedPageToken);
-      return SMILE_MAPPER.readValue(bytes, PageToken.class);
+      pageToken = SMILE_MAPPER.readValue(bytes, PageToken.class);
     } catch (RuntimeException e) {
       // Deliberately broad: the input is untrusted bytes fed to a binary parser. Besides the
       // expected failures (IllegalArgumentException for non-base64, JacksonException for a payload
@@ -157,6 +158,10 @@ final class PageTokenUtil {
       // them mean the same thing: the client sent a token we cannot interpret.
       throw new IllegalArgumentException("Invalid page token", e);
     }
+    // A SMILE-encoded null deserializes "successfully" to null; reject it here rather than letting
+    // callers fail on it later.
+    checkArgument(pageToken != null, "Invalid page token");
+    return pageToken;
   }
 
   /**

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/pagination/MalformedPageTokenTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/pagination/MalformedPageTokenTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.persistence.pagination;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A client-supplied {@code pageToken} that cannot be decoded must surface as an {@link
+ * IllegalArgumentException}, which the REST layer maps to HTTP 400. Any other exception type
+ * (Jackson decoding failures, {@link IllegalStateException} from the token-type registry) escapes
+ * the exception mappers and turns client input into an HTTP 500.
+ */
+class MalformedPageTokenTest {
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource
+  void malformedTokenIsRejectedAsBadRequest(String description, String serializedToken) {
+    assertThatThrownBy(() -> PageToken.build(serializedToken, null, () -> true))
+        .as(description)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid page token");
+  }
+
+  static Stream<Arguments> malformedTokenIsRejectedAsBadRequest() {
+    return Stream.of(
+        arguments("not base64", "%%%not-base64%%%"),
+        arguments("valid base64, not SMILE", "AAAA"),
+        arguments(
+            "valid base64, plain text",
+            encode("hello world".getBytes(java.nio.charset.StandardCharsets.UTF_8))),
+        arguments(
+            "SMILE with unknown token type id",
+            smile(Map.of("p", 5, "v", Map.of("t", "no-such-type")))),
+        arguments("SMILE with wrong shape (array)", smile(new int[] {1, 2, 3})),
+        arguments("truncated valid token", truncatedValidToken()));
+  }
+
+  private static String encode(byte[] bytes) {
+    return Base64.getUrlEncoder().encodeToString(bytes);
+  }
+
+  private static String smile(Object value) {
+    return encode(PageTokenUtil.smileMapperForTests().writeValueAsBytes(value));
+  }
+
+  private static String truncatedValidToken() {
+    PageToken valid =
+        ImmutablePageToken.builder()
+            .pageSize(10)
+            .value(ImmutableDummyTestToken.builder().s("some-string-value").i(42).build())
+            .build();
+    byte[] bytes = Base64.getUrlDecoder().decode(PageTokenUtil.serializePageToken(valid));
+    return encode(Arrays.copyOf(bytes, bytes.length / 2));
+  }
+}

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/pagination/MalformedPageTokenTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/pagination/MalformedPageTokenTest.java
@@ -18,24 +18,37 @@
  */
 package org.apache.polaris.core.persistence.pagination;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.smile.SmileMapper;
 
 /**
  * A client-supplied {@code pageToken} that cannot be decoded must surface as an {@link
  * IllegalArgumentException}, which the REST layer maps to HTTP 400. Any other exception type
- * (Jackson decoding failures, {@link IllegalStateException} from the token-type registry) escapes
- * the exception mappers and turns client input into an HTTP 500.
+ * (Jackson decoding failures, {@link IllegalStateException} from the token-type registry, parser
+ * errors on corrupted binary input) escapes the exception mappers and turns client input into an
+ * HTTP 500.
  */
 class MalformedPageTokenTest {
+
+  /** Plain SMILE mapper to craft arbitrary payloads that are not {@link PageToken}s. */
+  private static final ObjectMapper RAW_SMILE = SmileMapper.builder().build();
 
   @ParameterizedTest(name = "{0}")
   @MethodSource
@@ -50,14 +63,117 @@ class MalformedPageTokenTest {
     return Stream.of(
         arguments("not base64", "%%%not-base64%%%"),
         arguments("valid base64, not SMILE", "AAAA"),
-        arguments(
-            "valid base64, plain text",
-            encode("hello world".getBytes(java.nio.charset.StandardCharsets.UTF_8))),
+        arguments("valid base64, plain text", encode("hello world".getBytes(UTF_8))),
         arguments(
             "SMILE with unknown token type id",
             smile(Map.of("p", 5, "v", Map.of("t", "no-such-type")))),
         arguments("SMILE with wrong shape (array)", smile(new int[] {1, 2, 3})),
-        arguments("truncated valid token", truncatedValidToken()));
+        arguments("truncated valid token", encode(truncate(validTokenBytes()))),
+        // Found by fuzzing a valid token: the SMILE parser fails with
+        // ArrayIndexOutOfBoundsException rather than a Jackson exception.
+        arguments(
+            "corrupted SMILE that trips the parser itself",
+            "OikKAfqAcNTKdvqAdEBlgGkoAWs8aKr7-w=="));
+  }
+
+  /**
+   * Byte-level corruption: flip every single bit of a valid token, one at a time, and overwrite
+   * every byte with 0x00 and 0xFF. A corrupted token is allowed to still decode (some flips land in
+   * payload bytes and yield a different but well-formed token), but it must never fail with
+   * anything other than {@link IllegalArgumentException}.
+   */
+  @Test
+  void corruptedTokenNeverEscapesAsServerError() {
+    byte[] valid = validTokenBytes();
+
+    Stream<byte[]> bitFlips =
+        IntStream.range(0, valid.length * 8)
+            .mapToObj(
+                bit -> {
+                  byte[] corrupted = valid.clone();
+                  corrupted[bit / 8] ^= (byte) (1 << (bit % 8));
+                  return corrupted;
+                });
+    Stream<byte[]> byteOverwrites =
+        IntStream.range(0, valid.length)
+            .boxed()
+            .flatMap(
+                i ->
+                    Stream.of((byte) 0x00, (byte) 0xFF)
+                        .map(
+                            b -> {
+                              byte[] corrupted = valid.clone();
+                              corrupted[i] = b;
+                              return corrupted;
+                            }));
+
+    Stream.concat(bitFlips, byteOverwrites)
+        .map(MalformedPageTokenTest::encode)
+        .forEach(MalformedPageTokenTest::assertDecodesOrIsBadRequest);
+  }
+
+  /**
+   * Random corruption with a fixed seed: overwrite, truncate, insert and flip bytes of valid tokens
+   * of different shapes. Deterministic, so a failure reproduces.
+   */
+  @Test
+  void randomlyCorruptedTokenNeverEscapesAsServerError() {
+    List<byte[]> seeds =
+        List.of(
+            validTokenBytes(),
+            tokenBytes(
+                ImmutablePageToken.builder()
+                    .pageSize(10)
+                    .value(EntityIdToken.fromEntityId(123456789L))
+                    .build()),
+            tokenBytes(
+                ImmutablePageToken.builder()
+                    .pageSize(1000)
+                    .value(
+                        ImmutableDummyTestToken.builder()
+                            .s("a".repeat(300))
+                            .i(Integer.MAX_VALUE)
+                            .build())
+                    .build()));
+    Random random = new Random(42);
+    for (int iteration = 0; iteration < 20_000; iteration++) {
+      byte[] valid = seeds.get(iteration % seeds.size());
+      byte[] corrupted;
+      switch (random.nextInt(4)) {
+        case 0 -> {
+          corrupted = valid.clone();
+          for (int k = 0, n = 1 + random.nextInt(3); k < n; k++) {
+            corrupted[random.nextInt(corrupted.length)] = (byte) random.nextInt(256);
+          }
+        }
+        case 1 -> corrupted = Arrays.copyOf(valid, random.nextInt(valid.length));
+        case 2 -> {
+          int at = random.nextInt(valid.length);
+          corrupted = new byte[valid.length + 1];
+          System.arraycopy(valid, 0, corrupted, 0, at);
+          corrupted[at] = (byte) random.nextInt(256);
+          System.arraycopy(valid, at, corrupted, at + 1, valid.length - at);
+        }
+        default -> {
+          corrupted = valid.clone();
+          int at = random.nextInt(corrupted.length);
+          corrupted[at] ^= (byte) (1 << random.nextInt(8));
+          corrupted[(at + 1) % corrupted.length] = (byte) 0xFF;
+        }
+      }
+      assertDecodesOrIsBadRequest(encode(corrupted));
+    }
+  }
+
+  private static void assertDecodesOrIsBadRequest(String token) {
+    try {
+      PageToken decoded = PageToken.build(token, null, () -> true);
+      assertThat(decoded).as("token %s", token).isNotNull();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).as("token %s", token).hasMessageContaining("Invalid page token");
+    } catch (RuntimeException unexpected) {
+      fail("token %s escaped as %s".formatted(token, unexpected), unexpected);
+    }
   }
 
   private static String encode(byte[] bytes) {
@@ -65,16 +181,22 @@ class MalformedPageTokenTest {
   }
 
   private static String smile(Object value) {
-    return encode(PageTokenUtil.smileMapperForTests().writeValueAsBytes(value));
+    return encode(RAW_SMILE.writeValueAsBytes(value));
   }
 
-  private static String truncatedValidToken() {
-    PageToken valid =
+  private static byte[] truncate(byte[] bytes) {
+    return Arrays.copyOf(bytes, bytes.length / 2);
+  }
+
+  private static byte[] validTokenBytes() {
+    return tokenBytes(
         ImmutablePageToken.builder()
             .pageSize(10)
             .value(ImmutableDummyTestToken.builder().s("some-string-value").i(42).build())
-            .build();
-    byte[] bytes = Base64.getUrlDecoder().decode(PageTokenUtil.serializePageToken(valid));
-    return encode(Arrays.copyOf(bytes, bytes.length / 2));
+            .build());
+  }
+
+  private static byte[] tokenBytes(PageToken token) {
+    return Base64.getUrlDecoder().decode(PageTokenUtil.serializePageToken(token));
   }
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/persistence/pagination/MalformedPageTokenTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/persistence/pagination/MalformedPageTokenTest.java
@@ -35,6 +35,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.dataformat.smile.SmileMapper;
 
@@ -72,8 +74,24 @@ class MalformedPageTokenTest {
         // Found by fuzzing a valid token: the SMILE parser fails with
         // ArrayIndexOutOfBoundsException rather than a Jackson exception.
         arguments(
-            "corrupted SMILE that trips the parser itself",
-            "OikKAfqAcNTKdvqAdEBlgGkoAWs8aKr7-w=="));
+            "corrupted SMILE that trips the parser itself", "OikKAfqAcNTKdvqAdEBlgGkoAWs8aKr7-w=="),
+        // Deserializes "successfully" to null, so the failure would otherwise surface later as a
+        // NullPointerException.
+        arguments("SMILE-encoded null", smile(null)));
+  }
+
+  /**
+   * The page size is applied to the decoded token after deserialization; a token that decodes to
+   * null must be rejected before that, with or without a page size.
+   */
+  @ParameterizedTest(name = "pageSize={0}")
+  @NullSource
+  @ValueSource(ints = {0, 5})
+  void nullTokenIsRejectedWithAndWithoutPageSize(Integer pageSize) {
+    String nullToken = smile(null);
+    assertThatThrownBy(() -> PageToken.build(nullToken, pageSize, () -> true))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid page token");
   }
 
   /**


### PR DESCRIPTION
`PageTokenUtil.decodePageRequest` decoded the client-supplied `pageToken` (Base64 + SMILE) without error handling. A token that is valid Base64 but not a serialized page token (garbage, truncated, or produced by an incompatible Polaris version) escaped as a Jackson 3 `JacksonException` or, for an unknown token type id, as `IllegalStateException`. Neither is covered by the REST exception mappers, so client input turned into a 500 with an ERROR-level stack trace.

Wrap the decoding step and rethrow any failure as
`IllegalArgumentException("Invalid page token")`, which the existing `IcebergExceptionMapper` maps to 400. The original exception is kept as the cause for debug logging.

Adds a parameterized unit test covering the malformed-token shapes and an integration test asserting the HTTP 400 on `listNamespaces`.

Fixes #5465

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
