### PR TITLE
Docs: redact the Spark credential config in catalog examples

### DIFF
--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-aws-s3-cloud-storage-specific.md
@@ -254,8 +254,13 @@ bin/spark-sql \
     --conf spark.sql.catalog.polaris.warehouse=warehouse_s3 \
     --conf spark.sql.catalog.polaris.scope=PRINCIPAL_ROLE:ALL \
     --conf spark.sql.catalog.polaris.credential=<client-id>:<client-secret> \
+    --conf spark.redaction.regex='(?i)secret|password|token|access[.]?key|credential' \
     --conf spark.sql.catalog.polaris.header.X-Iceberg-Access-Delegation=vended-credentials
 ```
+
+The `spark.redaction.regex` line redacts the `credential` secret from the Spark UI and logs, since
+Spark's default redaction pattern does not cover `credential`. Newer Spark releases redact this key
+by default; the line keeps it redacted on earlier versions.
 
 The `oauth2-server-uri` is recommended: without it the Iceberg REST client falls back to a
 hard-coded `/v1/oauth/tokens` path and logs a deprecation warning, since the automatic fallback

--- a/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-azure-blob-cloud-storage-specific.md
+++ b/site/content/in-dev/unreleased/configuration/configuring-polaris-for-production/configuring-azure-blob-cloud-storage-specific.md
@@ -147,9 +147,14 @@ bin/spark-sql \
     --conf spark.sql.catalog.polaris.warehouse=warehouse_azure \
     --conf spark.sql.catalog.polaris.scope=PRINCIPAL_ROLE:ALL \
     --conf spark.sql.catalog.polaris.credential=<client-id>:<client-secret> \
+    --conf spark.redaction.regex='(?i)secret|password|token|access[.]?key|credential' \
     --conf spark.sql.catalog.polaris.header.X-Iceberg-Access-Delegation=vended-credentials \
     --conf spark.sql.catalog.polaris.io-impl=org.apache.iceberg.azure.adlsv2.ADLSFileIO
 ```
+
+The `spark.redaction.regex` line redacts the `credential` secret from the Spark UI and logs, since
+Spark's default redaction pattern does not cover `credential`. Newer Spark releases redact this key
+by default; the line keeps it redacted on earlier versions.
 
 The `oauth2-server-uri` is recommended: without it the Iceberg REST client falls back to a
 hard-coded `/v1/oauth/tokens` path and logs a deprecation warning, since the automatic fallback

--- a/site/content/in-dev/unreleased/getting-started/using-polaris/_index.md
+++ b/site/content/in-dev/unreleased/getting-started/using-polaris/_index.md
@@ -156,10 +156,15 @@ bin/spark-sql \
 --conf spark.sql.catalog.polaris.catalog-impl=org.apache.iceberg.rest.RESTCatalog \
 --conf spark.sql.catalog.polaris.uri=http://localhost:8181/api/catalog \
 --conf spark.sql.catalog.polaris.credential=${USER_CLIENT_ID}:${USER_CLIENT_SECRET} \
+--conf spark.redaction.regex='(?i)secret|password|token|access[.]?key|credential' \
 --conf spark.sql.catalog.polaris.scope='PRINCIPAL_ROLE:ALL' \
 --conf spark.sql.catalog.polaris.token-refresh-enabled=true \
 --conf spark.sql.catalog.polaris.client.region=us-west-2
 ```
+
+The `spark.redaction.regex` line redacts the `credential` secret from the Spark UI and logs, since
+Spark's default redaction pattern does not cover `credential`. Newer Spark releases redact this key
+by default; the line keeps it redacted on earlier versions.
 
 Similar to the CLI commands above, this configures Spark to use the Polaris running at `localhost:8181`. If your Polaris server is running elsewhere, be sure to update the configuration appropriately.
 

--- a/site/content/in-dev/unreleased/polaris-spark-client.md
+++ b/site/content/in-dev/unreleased/polaris-spark-client.md
@@ -67,9 +67,15 @@ bin/spark-shell \
 --conf spark.sql.catalog.<spark-catalog-name>=org.apache.polaris.spark.SparkCatalog \
 --conf spark.sql.catalog.<spark-catalog-name>.uri=<polaris-service-uri> \
 --conf spark.sql.catalog.<spark-catalog-name>.credential='<client-id>:<client-secret>' \
+--conf spark.redaction.regex='(?i)secret|password|token|access[.]?key|credential' \
 --conf spark.sql.catalog.<spark-catalog-name>.scope='PRINCIPAL_ROLE:ALL' \
 --conf spark.sql.catalog.<spark-catalog-name>.token-refresh-enabled=true
 ```
+
+The `spark.redaction.regex` line redacts the `credential` secret from the Spark UI and logs, since
+Spark's default redaction pattern does not cover `credential`. Newer Spark releases redact this key
+by default; the line keeps it redacted on earlier versions.
+
 Assume the released Polaris Spark client you want to use is `org.apache.polaris:polaris-spark-3.5_2.12:1.0.0`,
 replace the `polaris-spark-client-package` field with the release.
 
@@ -94,6 +100,7 @@ spark = SparkSession.builder
   .config("spark.sql.catalog.<spark-catalog-name>.uri", <polaris-service-uri>)
   .config("spark.sql.catalog.<spark-catalog-name>.token-refresh-enabled", "true")
   .config("spark.sql.catalog.<spark-catalog-name>.credential", "<client-id>:<client_secret>")
+  .config("spark.redaction.regex", "(?i)secret|password|token|access[.]?key|credential")
   .config("spark.sql.catalog.<spark-catalog-name>.warehouse", <polaris_catalog_name>)
   .config("spark.sql.catalog.polaris.scope", 'PRINCIPAL_ROLE:ALL')
   .config("spark.sql.catalog.polaris.header.X-Iceberg-Access-Delegation", 'vended-credentials')


### PR DESCRIPTION
The Spark examples pass the OAuth2 client credentials via spark.sql.catalog.<catalog>.credential. Spark surfaces its full configuration in the Spark UI, event logs, and diagnostic output, and Spark's default spark.redaction.regex does not match credential, so the secret can be written in cleartext.

Add spark.redaction.regex='(?i)secret|password|token|credential' to each Spark example, with a short note explaining it, so users copying the configuration redact the credential by default. Newer Spark releases redact this key on their own; the config keeps it redacted on earlier versions.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
