### PR TITLE
Fix namespace property updates that set a location always failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,12 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   directly under an allowed location, at `s3://b1/ns`, and rejected it as a custom location even
   though the request asked for none. The namespace location is now compared against the
   catalog's `default-base-location`, which is what it is derived from.
+- Updating a namespace's properties no longer fails with HTTP 400 when the request restates the
+  namespace's own default location. With custom namespace locations disabled, the update validated
+  the namespace's *pre-update* entity against the namespace *itself* as its own parent, so the
+  expected default was computed as `<namespace location>/<namespace name>` and never matched. Any
+  `updateNamespaceProperties` carrying the base-location property was rejected, and the expected
+  location named in the error was wrong even when the rejection itself was correct.
 - Internal JWTs are bound to principal secret generation via `polaris-cv` (no secret material in the
   token). Credential-generation is enforced on token exchange; bearer verify is signature and claims
   only. Secrets-load failures during exchange return service unavailable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,12 +158,11 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
   directly under an allowed location, at `s3://b1/ns`, and rejected it as a custom location even
   though the request asked for none. The namespace location is now compared against the
   catalog's `default-base-location`, which is what it is derived from.
-- Updating a namespace's properties no longer fails with HTTP 400 when the request restates the
-  namespace's own default location. With custom namespace locations disabled, the update validated
-  the namespace's *pre-update* entity against the namespace *itself* as its own parent, so the
-  expected default was computed as `<namespace location>/<namespace name>` and never matched. Any
-  `updateNamespaceProperties` carrying the base-location property was rejected, and the expected
-  location named in the error was wrong even when the rejection itself was correct.
+- Setting a namespace's `location` property no longer fails with HTTP 400. With custom namespace
+  locations disabled, which is the default, every `updateNamespaceProperties` request carrying a
+  `location` was rejected, including one that simply repeated the location the namespace already
+  had. The error also named an expected location one level too deep: a namespace at `s3://b1/ns`
+  was told it should be at `s3://b1/ns/ns`.
 - Internal JWTs are bound to principal secret generation via `polaris-cv` (no secret material in the
   token). Credential-generation is enforced on token exchange; bearer verify is signature and claims
   only. Secrets-load failures during exchange return service unavailable.

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/LocalIcebergCatalog.java
@@ -910,7 +910,9 @@ public class LocalIcebergCatalog extends BaseMetastoreViewCatalog
     if (!realmConfig.getConfig(
         BehaviorChangeConfiguration.ALLOW_NAMESPACE_CUSTOM_LOCATION, catalogEntity)) {
       if (properties.containsKey(PolarisEntityConstants.ENTITY_BASE_LOCATION)) {
-        validateNamespaceUsesDefaultLocation(NamespaceEntity.of(entity), resolvedEntities);
+        validateNamespaceUsesDefaultLocation(
+            NamespaceEntity.of(updatedEntity),
+            new PolarisResolvedPathWrapper(resolvedEntities.getResolvedParentPath()));
       }
     }
 

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/iceberg/IcebergAllowedLocationTest.java
@@ -791,6 +791,43 @@ public class IcebergAllowedLocationTest {
     }
   }
 
+  /**
+   * With custom namespace locations disabled, restating a namespace's existing default location was
+   * rejected because the update validated the pre-update entity against the namespace itself as its
+   * own parent.
+   */
+  @Test
+  void testNamespacePropertyUpdateAcceptsTheDefaultLocation(@TempDir Path tmpDir) {
+    TestServices services =
+        TestServices.builder()
+            .config(
+                Map.of(
+                    "ALLOW_INSECURE_STORAGE_TYPES",
+                    "true",
+                    "SUPPORTED_CATALOG_STORAGE_TYPES",
+                    List.of("FILE")))
+            .build();
+
+    Path warehouse = tmpDir.resolve("warehouse");
+    String catalogLocation = warehouse.toAbsolutePath().toUri().toString();
+    createCatalog(services, Map.of(), catalogLocation, List.of(catalogLocation));
+
+    // createCatalog derives default-base-location as <catalogLocation>/<catalog>, so the
+    // namespace's default location is one level below that.
+    String defaultLocation =
+        warehouse.resolve(catalog).resolve(namespace).toAbsolutePath().toUri().toString();
+    createNamespace(services, defaultLocation);
+
+    // Restating the location the namespace already has is not a custom location.
+    updateNamespaceProperties(services, Map.of("location", defaultLocation));
+
+    // A different location is still rejected.
+    String otherLocation = warehouse.resolve("elsewhere").toAbsolutePath().toUri().toString();
+    assertThatThrownBy(() -> updateNamespaceProperties(services, Map.of("location", otherLocation)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("has a custom location");
+  }
+
   private void createCatalog(
       TestServices services,
       Map<String, String> catalogConfig,


### PR DESCRIPTION
With `ALLOW_NAMESPACE_CUSTOM_LOCATION` at its default of false, every `updateNamespaceProperties` request carrying the base-location property is rejected with `HTTP 400` — including one that restates the location the namespace already has, which is by definition not a custom location.

The error names a location that cannot exist:
```
Namespace ns has a custom location, which is not enabled.
Expected location: [file:///.../test-catalog/ns/ns/]
Got location:      [file:///.../test-catalog/ns/]
```
 `ns/ns/` is the namespace nested inside itself.
The check expects the namespace to check plus a resolved path whose leaf is that namespace's parent. The call in `setProperties` supplied neither:

 - resolvedEntities is the namespace's own resolved path, so `getResolvedLeafEntity()` returns the namespace itself. The expected default is then computed as `<namespace location>/<namespace name>`, which can never equal the namespace's location — hence the doubled path and the unconditional rejection.
 
- entity is the pre-update entity, so the location validated is the old one rather than the one the request asks for.
- Both call sites were introduced together in #2422 ("Disable custom namespace locations"), and the create path in that same commit passes the parent correctly:
```
// createNamespace — correct
validateNamespaceUsesDefaultLocation(entity, resolvedParent);
// setProperties — neither argument is right
validateNamespaceUsesDefaultLocation(NamespaceEntity.of(entity), resolvedEntities);
```
 Both arguments have to change together. Correcting only the parent would leave the check reading the pre-update location, which always equals the default, so a genuinely custom location in the request would never be examined — the endpoint would silently stop enforcing the flag. The test asserts both directions.


## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
