### PR TITLE
 Fix Azure user delegation key clock-skew failures 

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -196,8 +196,11 @@ public class AzureCredentialsStorageIntegration
 
     AccessToken accessToken =
         getAccessToken(defaultAzureCredential, realmConfig, azureStorageConfig.getTenantId());
-    // Get user delegation key. Backdate its start time to avoid intermittent authorization
-    // failures when the Azure Storage or consuming client's clock trails Polaris's clock.
+    // Microsoft's general SAS guidance recommends setting the start time at least 15 minutes in
+    // the past to account for clock skew; its Java user-delegation SAS example uses five minutes.
+    // Use the five-minute buffer here to prevent intermittent authorization failures when Azure
+    // Storage or the consuming client clock trails Polaris's clock. The key is limited to Azure's
+    // seven-day validity window, with a one-minute safety margin on the end time.
     Instant clockSkewAdjustedStart = getClockSkewAdjustedStart(start);
     OffsetDateTime startTime =
         clockSkewAdjustedStart.truncatedTo(ChronoUnit.SECONDS).atOffset(ZoneOffset.UTC);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -78,8 +78,9 @@ public class AzureCredentialsStorageIntegration
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AzureCredentialsStorageIntegration.class);
 
-  // Microsoft recommends backdating SAS start times to account for clock skew between clients and
-  // Azure Storage. See https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview.
+  // Microsoft's Java user-delegation SAS example backdates the key start time to account for
+  // clock skew. See
+  // https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-user-delegation-sas-create-java.
   private static final long SAS_CLOCK_SKEW_BUFFER_SECONDS = Duration.ofMinutes(5).toSeconds();
 
   final DefaultAzureCredential defaultAzureCredential;
@@ -196,11 +197,11 @@ public class AzureCredentialsStorageIntegration
 
     AccessToken accessToken =
         getAccessToken(defaultAzureCredential, realmConfig, azureStorageConfig.getTenantId());
-    // Microsoft's general SAS guidance recommends setting the start time at least 15 minutes in
-    // the past to account for clock skew; its Java user-delegation SAS example uses five minutes.
-    // Use the five-minute buffer here to prevent intermittent authorization failures when Azure
-    // Storage or the consuming client clock trails Polaris's clock. The key is limited to Azure's
-    // seven-day validity window, with a one-minute safety margin on the end time.
+    // Backdate the user delegation key start time by five minutes, following Microsoft's Java
+    // user-delegation SAS example, to prevent authorization failures caused by clock skew.
+    // Microsoft's general SAS guidance recommends a 15-minute backdate for an explicit SAS start
+    // time; Polaris does not set a SAS start time, and this buffer applies only to the key. The
+    // key is limited to Azure's seven-day validity window, with a one-minute end-time margin.
     Instant clockSkewAdjustedStart = getClockSkewAdjustedStart(start);
     OffsetDateTime startTime =
         clockSkewAdjustedStart.truncatedTo(ChronoUnit.SECONDS).atOffset(ZoneOffset.UTC);

--- a/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegration.java
@@ -78,6 +78,10 @@ public class AzureCredentialsStorageIntegration
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AzureCredentialsStorageIntegration.class);
 
+  // Microsoft recommends backdating SAS start times to account for clock skew between clients and
+  // Azure Storage. See https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview.
+  private static final long SAS_CLOCK_SKEW_BUFFER_SECONDS = Duration.ofMinutes(5).toSeconds();
+
   final DefaultAzureCredential defaultAzureCredential;
 
   public AzureCredentialsStorageIntegration(
@@ -192,16 +196,16 @@ public class AzureCredentialsStorageIntegration
 
     AccessToken accessToken =
         getAccessToken(defaultAzureCredential, realmConfig, azureStorageConfig.getTenantId());
-    // Get user delegation key.
-    // Set the new generated user delegation key expiry to 7 days and minute 1 min
-    // Azure strictly requires the end time to be <= 7 days from the current time, -1 min to avoid
-    // clock skew between the client and server,
-    OffsetDateTime startTime = start.truncatedTo(ChronoUnit.SECONDS).atOffset(ZoneOffset.UTC);
+    // Get user delegation key. Backdate its start time to avoid intermittent authorization
+    // failures when the Azure Storage or consuming client's clock trails Polaris's clock.
+    Instant clockSkewAdjustedStart = getClockSkewAdjustedStart(start);
+    OffsetDateTime startTime =
+        clockSkewAdjustedStart.truncatedTo(ChronoUnit.SECONDS).atOffset(ZoneOffset.UTC);
     int intendedDurationSeconds = realmConfig.getConfig(STORAGE_CREDENTIAL_DURATION_SECONDS);
     OffsetDateTime intendedEndTime =
         start.plusSeconds(intendedDurationSeconds).atOffset(ZoneOffset.UTC);
     OffsetDateTime maxAllowedEndTime =
-        start.plus(Period.ofDays(7)).minusSeconds(60).atOffset(ZoneOffset.UTC);
+        clockSkewAdjustedStart.plus(Period.ofDays(7)).minusSeconds(60).atOffset(ZoneOffset.UTC);
     OffsetDateTime sanitizedEndTime =
         intendedEndTime.isBefore(maxAllowedEndTime) ? intendedEndTime : maxAllowedEndTime;
 
@@ -254,6 +258,11 @@ public class AzureCredentialsStorageIntegration
     }
 
     return toAccessConfig(sasToken, location, sanitizedEndTime.toInstant(), refreshEndpoint);
+  }
+
+  @VisibleForTesting
+  static Instant getClockSkewAdjustedStart(Instant start) {
+    return start.minusSeconds(SAS_CLOCK_SKEW_BUFFER_SECONDS);
   }
 
   @VisibleForTesting

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
@@ -19,15 +19,40 @@
 
 package org.apache.polaris.core.storage.azure;
 
+import static org.apache.polaris.core.config.FeatureConfiguration.AZURE_RETRY_COUNT;
+import static org.apache.polaris.core.config.FeatureConfiguration.AZURE_RETRY_DELAY_MILLIS;
+import static org.apache.polaris.core.config.FeatureConfiguration.AZURE_RETRY_JITTER_FACTOR;
+import static org.apache.polaris.core.config.FeatureConfiguration.AZURE_TIMEOUT_MILLIS;
+import static org.apache.polaris.core.config.FeatureConfiguration.STORAGE_CREDENTIAL_DURATION_SECONDS;
 import static org.apache.polaris.core.storage.azure.AzureCredentialsStorageIntegration.toAccessConfig;
 
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.identity.DefaultAzureCredential;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.UserDelegationKey;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
+import java.util.Set;
+import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageAccessProperty;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
 
 public class AzureCredentialsStorageIntegrationTest {
 
@@ -94,12 +119,102 @@ public class AzureCredentialsStorageIntegrationTest {
         .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "myaccount");
   }
 
-  @Test
-  void getClockSkewAdjustedStart_backdatesByFiveMinutes() {
-    Instant start = Instant.parse("2026-09-10T00:00:00Z");
+  @ParameterizedTest
+  @CsvSource({"3600,3900", "604800,604740"})
+  void computeUsesAdjustedKeyStartAndMatchingExpiry(
+      int configuredDurationSeconds, int expectedKeyDurationSeconds) {
+    VendedCredentials vendedCredentials = vendCredentials(configuredDurationSeconds);
 
-    Instant adjustedStart = AzureCredentialsStorageIntegration.getClockSkewAdjustedStart(start);
-
-    Assertions.assertThat(adjustedStart).isEqualTo(start.minus(5, ChronoUnit.MINUTES));
+    Assertions.assertThat(
+            vendedCredentials
+                .keyStart()
+                .toInstant()
+                .until(vendedCredentials.sasExpiry().toInstant(), ChronoUnit.SECONDS))
+        .isEqualTo(expectedKeyDurationSeconds);
+    Assertions.assertThat(vendedCredentials.keyEnd()).isEqualTo(vendedCredentials.sasExpiry());
+    Assertions.assertThat(vendedCredentials.accessConfig().expiresAt())
+        .contains(vendedCredentials.sasExpiry().toInstant());
   }
+
+  private static VendedCredentials vendCredentials(int configuredDurationSeconds) {
+    DefaultAzureCredential credential = Mockito.mock(DefaultAzureCredential.class);
+    Mockito.when(credential.getToken(Mockito.any(TokenRequestContext.class)))
+        .thenReturn(
+            Mono.just(
+                new AccessToken("access-token", OffsetDateTime.now().plus(Duration.ofHours(1)))));
+
+    BlobServiceClient blobServiceClient = Mockito.mock(BlobServiceClient.class);
+    UserDelegationKey userDelegationKey = Mockito.mock(UserDelegationKey.class);
+    Mockito.when(blobServiceClient.getUserDelegationKey(Mockito.any(), Mockito.any()))
+        .thenReturn(userDelegationKey);
+
+    BlobContainerClient blobContainerClient = Mockito.mock(BlobContainerClient.class);
+    Mockito.when(
+            blobContainerClient.generateUserDelegationSas(
+                Mockito.any(BlobServiceSasSignatureValues.class), Mockito.same(userDelegationKey)))
+        .thenReturn("sas-token");
+
+    RealmConfig realmConfig = realmConfigWithDuration(configuredDurationSeconds);
+    AzureStorageConfigurationInfo storageConfig =
+        AzureStorageConfigurationInfo.builder()
+            .addAllowedLocation("wasbs://container@account.blob.core.windows.net/path")
+            .tenantId("tenant-id")
+            .build();
+    AzureStorageCredentialCacheKey key =
+        AzureStorageCredentialCacheKey.of(
+            "realm",
+            storageConfig,
+            false,
+            Set.of("wasbs://container@account.blob.core.windows.net/path"),
+            Set.of(),
+            Optional.empty(),
+            credential,
+            realmConfig);
+
+    try (MockedConstruction<BlobServiceClientBuilder> ignored =
+            Mockito.mockConstruction(
+                BlobServiceClientBuilder.class,
+                Mockito.withSettings().defaultAnswer(Answers.RETURNS_SELF),
+                (builder, context) ->
+                    Mockito.when(builder.buildClient()).thenReturn(blobServiceClient));
+        MockedConstruction<BlobContainerClientBuilder> ignoredContainerBuilder =
+            Mockito.mockConstruction(
+                BlobContainerClientBuilder.class,
+                Mockito.withSettings().defaultAnswer(Answers.RETURNS_SELF),
+                (builder, context) ->
+                    Mockito.when(builder.buildClient()).thenReturn(blobContainerClient))) {
+      StorageAccessConfig accessConfig = AzureCredentialsStorageIntegration.compute(key);
+
+      ArgumentCaptor<OffsetDateTime> keyStartCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+      ArgumentCaptor<OffsetDateTime> keyEndCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+      Mockito.verify(blobServiceClient)
+          .getUserDelegationKey(keyStartCaptor.capture(), keyEndCaptor.capture());
+      ArgumentCaptor<BlobServiceSasSignatureValues> sasValuesCaptor =
+          ArgumentCaptor.forClass(BlobServiceSasSignatureValues.class);
+      Mockito.verify(blobContainerClient)
+          .generateUserDelegationSas(sasValuesCaptor.capture(), Mockito.same(userDelegationKey));
+      return new VendedCredentials(
+          keyStartCaptor.getValue(),
+          keyEndCaptor.getValue(),
+          sasValuesCaptor.getValue().getExpiryTime(),
+          accessConfig);
+    }
+  }
+
+  private static RealmConfig realmConfigWithDuration(int durationSeconds) {
+    RealmConfig realmConfig = Mockito.mock(RealmConfig.class);
+    Mockito.when(realmConfig.getConfig(AZURE_TIMEOUT_MILLIS)).thenReturn(1_000);
+    Mockito.when(realmConfig.getConfig(AZURE_RETRY_COUNT)).thenReturn(0);
+    Mockito.when(realmConfig.getConfig(AZURE_RETRY_DELAY_MILLIS)).thenReturn(1);
+    Mockito.when(realmConfig.getConfig(AZURE_RETRY_JITTER_FACTOR)).thenReturn(0.0);
+    Mockito.when(realmConfig.getConfig(STORAGE_CREDENTIAL_DURATION_SECONDS))
+        .thenReturn(durationSeconds);
+    return realmConfig;
+  }
+
+  private record VendedCredentials(
+      OffsetDateTime keyStart,
+      OffsetDateTime keyEnd,
+      OffsetDateTime sasExpiry,
+      StorageAccessConfig accessConfig) {}
 }

--- a/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/storage/azure/AzureCredentialsStorageIntegrationTest.java
@@ -22,6 +22,7 @@ package org.apache.polaris.core.storage.azure;
 import static org.apache.polaris.core.storage.azure.AzureCredentialsStorageIntegration.toAccessConfig;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import org.apache.polaris.core.storage.StorageAccessConfig;
 import org.apache.polaris.core.storage.StorageAccessProperty;
@@ -91,5 +92,14 @@ public class AzureCredentialsStorageIntegrationTest {
         .containsEntry(StorageAccessProperty.AZURE_SAS_TOKEN_BARE.getPropertyName(), "sasToken");
     Assertions.assertThat(blobResult.credentials())
         .containsEntry(StorageAccessProperty.AZURE_ACCOUNT_NAME.getPropertyName(), "myaccount");
+  }
+
+  @Test
+  void getClockSkewAdjustedStart_backdatesByFiveMinutes() {
+    Instant start = Instant.parse("2026-09-10T00:00:00Z");
+
+    Instant adjustedStart = AzureCredentialsStorageIntegration.getClockSkewAdjustedStart(start);
+
+    Assertions.assertThat(adjustedStart).isEqualTo(start.minus(5, ChronoUnit.MINUTES));
   }
 }


### PR DESCRIPTION
fixes #5484 
## Summary

- Backdate Azure user delegation key start times by five minutes.
- Preserve the configured credential expiry where possible.
- Keep the user delegation key within Azure Storage's seven-day validity limit,
  with a one-minute safety margin.
- Add a regression test for the clock-skew adjustment.

## Problem

Polaris first requests an Azure user delegation key and then uses it to sign a
user delegation SAS returned to the storage client.

The current implementation used Polaris's current wall-clock time as the
user delegation key start time. If Azure Storage or the consuming client clock
is slightly behind Polaris, the newly issued SAS can fail immediately with:

`Signature not valid in the specified key time frame`

## Fix

Backdate the user delegation key start time by five minutes before calling
`getUserDelegationKey(...)`. The key is then used normally to generate the
Blob or ADLS user delegation SAS.

Five minutes matches Microsoft's Java user-delegation SAS example. The
implementation also recalculates the maximum expiry from the adjusted start
time so the Azure seven-day limit is not exceeded.

## Microsoft documentation

- SAS clock-skew guidance:
  https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview

- Java user-delegation SAS example using
  `OffsetDateTime.now().minusMinutes(5)`:
  https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-user-delegation-sas-create-java

- Get User Delegation Key API:
  https://learn.microsoft.com/en-us/rest/api/storageservices/get-user-delegation-key
