### PR TITLE
Deduplicate intent-to-resolved-path resolution across authorizers

### DIFF
--- a/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
+++ b/extensions/auth/ranger/src/main/java/org/apache/polaris/extension/auth/ranger/RangerPolarisAuthorizer.java
@@ -25,28 +25,18 @@ import java.util.Set;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.polaris.core.auth.AuthorizationDecision;
 import org.apache.polaris.core.auth.AuthorizationIntent;
+import org.apache.polaris.core.auth.AuthorizationIntentResolver;
 import org.apache.polaris.core.auth.AuthorizationPreConditions;
 import org.apache.polaris.core.auth.AuthorizationRequest;
 import org.apache.polaris.core.auth.AuthorizationState;
-import org.apache.polaris.core.auth.PathSegment;
 import org.apache.polaris.core.auth.PolarisAuthorizableOperation;
 import org.apache.polaris.core.auth.PolarisAuthorizer;
 import org.apache.polaris.core.auth.PolarisPrincipal;
-import org.apache.polaris.core.auth.PolarisSecurable;
-import org.apache.polaris.core.auth.PolicyAttachmentAuthorizationIntent;
-import org.apache.polaris.core.auth.PrivilegeGrantAuthorizationIntent;
-import org.apache.polaris.core.auth.RenameAuthorizationIntent;
-import org.apache.polaris.core.auth.RoleAssignmentAuthorizationIntent;
-import org.apache.polaris.core.auth.RootPrivilegeGrantAuthorizationIntent;
-import org.apache.polaris.core.auth.SingleTargetAuthorizationIntent;
-import org.apache.polaris.core.auth.TargetlessAuthorizationIntent;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.context.RealmContext;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
-import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
-import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
 import org.apache.polaris.extension.auth.ranger.utils.RangerUtils;
 import org.apache.ranger.authz.api.RangerAuthzException;
 import org.apache.ranger.authz.embedded.RangerEmbeddedAuthorizer;
@@ -129,105 +119,18 @@ public class RangerPolarisAuthorizer implements PolarisAuthorizer {
         semantics.rooting() == RangerPolarisOperationSemantics.ResolvedPathRooting.ROOT;
 
     try {
-      List<PolarisResolvedPathWrapper> resolvedTargets;
-      List<PolarisResolvedPathWrapper> resolvedSecondaries;
-      if (intent instanceof TargetlessAuthorizationIntent) {
-        resolvedTargets =
-            prependRootContainer
-                ? List.of(resolutionManifest.getResolvedRootContainerEntityAsPath())
-                : null;
-        resolvedSecondaries = null;
-      } else if (intent instanceof SingleTargetAuthorizationIntent singleTargetIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, singleTargetIntent.target(), prependRootContainer));
-        resolvedSecondaries = null;
-      } else if (intent instanceof RenameAuthorizationIntent renameIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, renameIntent.from(), prependRootContainer));
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(resolutionManifest, renameIntent.to(), prependRootContainer));
-      } else if (intent instanceof PolicyAttachmentAuthorizationIntent policyAttachmentIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, policyAttachmentIntent.policy(), prependRootContainer));
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, policyAttachmentIntent.attachedTo(), prependRootContainer));
-      } else if (intent instanceof PrivilegeGrantAuthorizationIntent privilegeGrantIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, privilegeGrantIntent.grantTarget(), prependRootContainer));
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, privilegeGrantIntent.grantee(), prependRootContainer));
-      } else if (intent instanceof RootPrivilegeGrantAuthorizationIntent rootPrivilegeGrantIntent) {
-        resolvedTargets = List.of(resolutionManifest.getResolvedRootContainerEntityAsPath());
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, rootPrivilegeGrantIntent.grantee(), prependRootContainer));
-      } else if (intent instanceof RoleAssignmentAuthorizationIntent roleAssignmentIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, roleAssignmentIntent.role(), prependRootContainer));
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, roleAssignmentIntent.assignee(), prependRootContainer));
-      } else {
-        throw new IllegalStateException("Unsupported authorization intent: " + intent.getClass());
-      }
-
+      AuthorizationIntentResolver.ResolvedIntent resolvedIntent =
+          AuthorizationIntentResolver.resolve(resolutionManifest, intent, prependRootContainer);
       authorizeRangerOrThrow(
           polarisPrincipal,
           resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
           intent.getOperation(),
-          resolvedTargets,
-          resolvedSecondaries);
+          resolvedIntent.targets(),
+          resolvedIntent.secondaries());
       return AuthorizationDecision.allow();
     } catch (ForbiddenException e) {
       return AuthorizationDecision.deny(e.getMessage());
     }
-  }
-
-  private PolarisResolvedPathWrapper getResolvedSecurable(
-      PolarisResolutionManifest resolutionManifest,
-      PolarisSecurable securable,
-      boolean prependRootContainer) {
-    PolarisResolvedPathWrapper resolvedSecurable =
-        securable.getLeaf().entityType() == PolarisEntityType.CATALOG
-            ? resolutionManifest.getResolvedReferenceCatalogEntity(prependRootContainer)
-            : securable.getLeaf().entityType().isTopLevel()
-                ? resolutionManifest.getResolvedTopLevelEntity(
-                    securable.getLeaf().name(), securable.getLeaf().entityType())
-                : resolutionManifest.getResolvedPath(
-                    ResolvedPathKey.of(
-                        getPathNamesWithinCatalog(securable), securable.getLeaf().entityType()),
-                    prependRootContainer);
-    Preconditions.checkState(
-        resolvedSecurable != null,
-        "Resolved path for securable is null for entityType=%s leaf=%s parents=%s",
-        securable.getLeaf().entityType(),
-        securable.getLeaf(),
-        securable.getParents());
-    return resolvedSecurable;
-  }
-
-  private List<String> getPathNamesWithinCatalog(PolarisSecurable securable) {
-    return securable.getPathSegments().stream()
-        .filter(segment -> segment.entityType() != PolarisEntityType.CATALOG)
-        .map(PathSegment::name)
-        .toList();
   }
 
   private void authorizeRangerOrThrow(

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthorizationIntentResolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthorizationIntentResolver.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.auth;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
+import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
+import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Resolves an {@link AuthorizationIntent}'s securable references into the {@link
+ * PolarisResolvedPathWrapper} targets and secondaries expected by the resolved-path authorization
+ * APIs.
+ *
+ * <p>The decision-native {@code PolarisAuthorizer.authorize(AuthorizationState,
+ * AuthorizationRequest)} path lets each authorizer implementation re-derive the securables it needs
+ * from an {@link AuthorizationRequest}'s intents. The mechanical mapping from an intent to its
+ * resolved target/secondary paths is identical across authorizers, so it is centralized here to
+ * avoid duplicating it in every {@link PolarisAuthorizer} implementation (the built-in {@link
+ * PolarisAuthorizerImpl} and pluggable extensions such as the Apache Ranger authorizer).
+ *
+ * <p>Whether an operation's path is rooted at the root container is authorizer-specific (each
+ * authorizer owns its operation-semantics table), so callers pass the already-computed {@code
+ * prependRootContainer} flag rather than having this resolver decide it.
+ */
+public final class AuthorizationIntentResolver {
+
+  private AuthorizationIntentResolver() {}
+
+  /**
+   * The resolved target and secondary paths for a single {@link AuthorizationIntent}. Either list
+   * may be {@code null} when the intent has no target or no secondary to resolve.
+   */
+  public record ResolvedIntent(
+      @Nullable List<PolarisResolvedPathWrapper> targets,
+      @Nullable List<PolarisResolvedPathWrapper> secondaries) {}
+
+  /**
+   * Resolves the securable references carried by {@code intent} against {@code resolutionManifest}
+   * into the target and secondary resolved paths expected by the resolved-path authorization APIs.
+   *
+   * @param resolutionManifest the populated resolution manifest for the current authorization flow
+   * @param intent the authorization intent whose securables should be resolved
+   * @param prependRootContainer whether the operation roots its resolved path(s) at the root
+   *     container, as determined by the caller's operation semantics
+   * @return the resolved targets and secondaries for the intent
+   */
+  public static ResolvedIntent resolve(
+      PolarisResolutionManifest resolutionManifest,
+      AuthorizationIntent intent,
+      boolean prependRootContainer) {
+    List<PolarisResolvedPathWrapper> resolvedTargets;
+    List<PolarisResolvedPathWrapper> resolvedSecondaries;
+    if (intent instanceof TargetlessAuthorizationIntent) {
+      resolvedTargets =
+          prependRootContainer
+              ? List.of(resolutionManifest.getResolvedRootContainerEntityAsPath())
+              : null;
+      resolvedSecondaries = null;
+    } else if (intent instanceof SingleTargetAuthorizationIntent singleTargetIntent) {
+      resolvedTargets =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, singleTargetIntent.target(), prependRootContainer));
+      resolvedSecondaries = null;
+    } else if (intent instanceof RenameAuthorizationIntent renameIntent) {
+      resolvedTargets =
+          List.of(
+              getResolvedSecurable(resolutionManifest, renameIntent.from(), prependRootContainer));
+      resolvedSecondaries =
+          List.of(
+              getResolvedSecurable(resolutionManifest, renameIntent.to(), prependRootContainer));
+    } else if (intent instanceof PolicyAttachmentAuthorizationIntent policyAttachmentIntent) {
+      resolvedTargets =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, policyAttachmentIntent.policy(), prependRootContainer));
+      resolvedSecondaries =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, policyAttachmentIntent.attachedTo(), prependRootContainer));
+    } else if (intent instanceof RoleAssignmentAuthorizationIntent roleAssignmentIntent) {
+      resolvedTargets =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, roleAssignmentIntent.role(), prependRootContainer));
+      resolvedSecondaries =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, roleAssignmentIntent.assignee(), prependRootContainer));
+    } else if (intent instanceof PrivilegeGrantAuthorizationIntent privilegeGrantIntent) {
+      resolvedTargets =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, privilegeGrantIntent.grantTarget(), prependRootContainer));
+      resolvedSecondaries =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, privilegeGrantIntent.grantee(), prependRootContainer));
+    } else if (intent instanceof RootPrivilegeGrantAuthorizationIntent rootPrivilegeGrantIntent) {
+      resolvedTargets = List.of(resolutionManifest.getResolvedRootContainerEntityAsPath());
+      resolvedSecondaries =
+          List.of(
+              getResolvedSecurable(
+                  resolutionManifest, rootPrivilegeGrantIntent.grantee(), prependRootContainer));
+    } else {
+      throw new IllegalStateException("Unsupported authorization intent: " + intent.getClass());
+    }
+    return new ResolvedIntent(resolvedTargets, resolvedSecondaries);
+  }
+
+  private static PolarisResolvedPathWrapper getResolvedSecurable(
+      PolarisResolutionManifest resolutionManifest,
+      PolarisSecurable securable,
+      boolean prependRootContainer) {
+    PolarisEntityType leafType = securable.getLeaf().entityType();
+    PolarisResolvedPathWrapper resolvedSecurable;
+    if (leafType == PolarisEntityType.CATALOG) {
+      resolvedSecurable =
+          resolutionManifest.getResolvedReferenceCatalogEntity(prependRootContainer);
+    } else if (leafType.isTopLevel()) {
+      resolvedSecurable =
+          resolutionManifest.getResolvedTopLevelEntity(securable.getLeaf().name(), leafType);
+    } else {
+      resolvedSecurable =
+          resolutionManifest.getResolvedPath(
+              ResolvedPathKey.of(getPathNamesWithinCatalog(securable), leafType),
+              prependRootContainer);
+    }
+    Preconditions.checkState(
+        resolvedSecurable != null,
+        "Resolved path for securable is null for entityType=%s leaf=%s parents=%s",
+        leafType,
+        securable.getLeaf(),
+        securable.getParents());
+    return resolvedSecurable;
+  }
+
+  private static List<String> getPathNamesWithinCatalog(PolarisSecurable securable) {
+    // Resolver path keys are scoped within the reference catalog, so the explicit catalog
+    // path segment is omitted from the PolarisSecurable path before lookup.
+    return securable.getPathSegments().stream()
+        .filter(segment -> segment.entityType() != PolarisEntityType.CATALOG)
+        .map(PathSegment::name)
+        .toList();
+  }
+}

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthorizationIntentResolver.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/AuthorizationIntentResolver.java
@@ -69,19 +69,17 @@ public final class AuthorizationIntentResolver {
       AuthorizationIntent intent,
       boolean prependRootContainer) {
     List<PolarisResolvedPathWrapper> resolvedTargets;
-    List<PolarisResolvedPathWrapper> resolvedSecondaries;
+    List<PolarisResolvedPathWrapper> resolvedSecondaries = null;
     if (intent instanceof TargetlessAuthorizationIntent) {
       resolvedTargets =
           prependRootContainer
               ? List.of(resolutionManifest.getResolvedRootContainerEntityAsPath())
               : null;
-      resolvedSecondaries = null;
     } else if (intent instanceof SingleTargetAuthorizationIntent singleTargetIntent) {
       resolvedTargets =
           List.of(
               getResolvedSecurable(
                   resolutionManifest, singleTargetIntent.target(), prependRootContainer));
-      resolvedSecondaries = null;
     } else if (intent instanceof RenameAuthorizationIntent renameIntent) {
       resolvedTargets =
           List.of(

--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
@@ -137,13 +137,11 @@ import org.apache.polaris.core.auth.RbacOperationSemantics.ResolvedPathRooting;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
 import org.apache.polaris.core.entity.PolarisEntityCore;
-import org.apache.polaris.core.entity.PolarisEntityType;
 import org.apache.polaris.core.entity.PolarisGrantRecord;
 import org.apache.polaris.core.entity.PolarisPrivilege;
 import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
 import org.apache.polaris.core.persistence.ResolvedPolarisEntity;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
-import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -777,70 +775,14 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
     RbacOperationSemantics semantics = RbacOperationSemantics.forOperation(intent.getOperation());
     boolean prependRootContainer = semantics.rooting() == ResolvedPathRooting.ROOT;
     try {
-      List<PolarisResolvedPathWrapper> resolvedTargets;
-      List<PolarisResolvedPathWrapper> resolvedSecondaries;
-      if (intent instanceof TargetlessAuthorizationIntent) {
-        resolvedTargets =
-            prependRootContainer
-                ? List.of(resolutionManifest.getResolvedRootContainerEntityAsPath())
-                : null;
-        resolvedSecondaries = null;
-      } else if (intent instanceof SingleTargetAuthorizationIntent singleTargetIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, singleTargetIntent.target(), prependRootContainer));
-        resolvedSecondaries = null;
-      } else if (intent instanceof RenameAuthorizationIntent renameIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, renameIntent.from(), prependRootContainer));
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(resolutionManifest, renameIntent.to(), prependRootContainer));
-      } else if (intent instanceof PolicyAttachmentAuthorizationIntent policyAttachmentIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, policyAttachmentIntent.policy(), prependRootContainer));
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, policyAttachmentIntent.attachedTo(), prependRootContainer));
-      } else if (intent instanceof RoleAssignmentAuthorizationIntent roleAssignmentIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, roleAssignmentIntent.role(), prependRootContainer));
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, roleAssignmentIntent.assignee(), prependRootContainer));
-      } else if (intent instanceof PrivilegeGrantAuthorizationIntent privilegeGrantIntent) {
-        resolvedTargets =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, privilegeGrantIntent.grantTarget(), prependRootContainer));
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, privilegeGrantIntent.grantee(), prependRootContainer));
-      } else if (intent instanceof RootPrivilegeGrantAuthorizationIntent rootPrivilegeGrantIntent) {
-        resolvedTargets = List.of(resolutionManifest.getResolvedRootContainerEntityAsPath());
-        resolvedSecondaries =
-            List.of(
-                getResolvedSecurable(
-                    resolutionManifest, rootPrivilegeGrantIntent.grantee(), prependRootContainer));
-      } else {
-        throw new IllegalStateException("Unsupported authorization intent: " + intent.getClass());
-      }
+      AuthorizationIntentResolver.ResolvedIntent resolvedIntent =
+          AuthorizationIntentResolver.resolve(resolutionManifest, intent, prependRootContainer);
       authorizeRbacOrThrow(
           polarisPrincipal,
           resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
           intent.getOperation(),
-          resolvedTargets,
-          resolvedSecondaries);
+          resolvedIntent.targets(),
+          resolvedIntent.secondaries());
       return AuthorizationDecision.allow();
     } catch (ForbiddenException e) {
       LOGGER.debug(
@@ -850,38 +792,6 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
           e);
       return AuthorizationDecision.deny(e.getMessage());
     }
-  }
-
-  private PolarisResolvedPathWrapper getResolvedSecurable(
-      PolarisResolutionManifest resolutionManifest,
-      PolarisSecurable securable,
-      boolean prependRootContainer) {
-    PolarisResolvedPathWrapper resolvedSecurable =
-        securable.getLeaf().entityType() == PolarisEntityType.CATALOG
-            ? resolutionManifest.getResolvedReferenceCatalogEntity(prependRootContainer)
-            : securable.getLeaf().entityType().isTopLevel()
-                ? resolutionManifest.getResolvedTopLevelEntity(
-                    securable.getLeaf().name(), securable.getLeaf().entityType())
-                : resolutionManifest.getResolvedPath(
-                    ResolvedPathKey.of(
-                        getPathNamesWithinCatalog(securable), securable.getLeaf().entityType()),
-                    prependRootContainer);
-    Preconditions.checkState(
-        resolvedSecurable != null,
-        "Resolved path for securable is null for entityType=%s leaf=%s parents=%s",
-        securable.getLeaf().entityType(),
-        securable.getLeaf(),
-        securable.getParents());
-    return resolvedSecurable;
-  }
-
-  private List<String> getPathNamesWithinCatalog(PolarisSecurable securable) {
-    // Resolver path keys are scoped within the reference catalog, so the explicit catalog
-    // path segment is omitted from the PolarisSecurable path before lookup.
-    return securable.getPathSegments().stream()
-        .filter(segment -> segment.entityType() != PolarisEntityType.CATALOG)
-        .map(PathSegment::name)
-        .toList();
   }
 
   /**

--- a/polaris-core/src/test/java/org/apache/polaris/core/auth/AuthorizationIntentResolverTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/auth/AuthorizationIntentResolverTest.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.polaris.core.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.polaris.core.auth.AuthorizationIntentResolver.ResolvedIntent;
+import org.apache.polaris.core.entity.PolarisEntityType;
+import org.apache.polaris.core.persistence.PolarisResolvedPathWrapper;
+import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
+import org.apache.polaris.core.persistence.resolver.ResolvedPathKey;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link AuthorizationIntentResolver}, verifying that each {@link
+ * AuthorizationIntent} type is translated into the expected target/secondary resolved paths and
+ * that each securable-resolution branch (reference catalog, top-level entity, path) is exercised.
+ */
+public class AuthorizationIntentResolverTest {
+
+  private static final PolarisAuthorizableOperation OP = PolarisAuthorizableOperation.LIST_CATALOGS;
+
+  private static PolarisSecurable catalogSecurable() {
+    return PolarisSecurable.of(new PathSegment(PolarisEntityType.CATALOG, "catalog"));
+  }
+
+  private static PolarisSecurable namespaceSecurable() {
+    // Leaf is a NAMESPACE (not top-level) reached through a catalog -> resolved via a path key.
+    return PolarisSecurable.of(
+        new PathSegment(PolarisEntityType.CATALOG, "catalog"),
+        new PathSegment(PolarisEntityType.NAMESPACE, "ns"));
+  }
+
+  private static PolarisSecurable principalRoleSecurable(String name) {
+    // Leaf is a top-level PRINCIPAL_ROLE -> resolved via getResolvedTopLevelEntity.
+    return PolarisSecurable.of(new PathSegment(PolarisEntityType.PRINCIPAL_ROLE, name));
+  }
+
+  @Test
+  void resolve_targetless_prependRootContainer_targetsRootContainerAndNoSecondaries() {
+    PolarisResolutionManifest manifest = mock(PolarisResolutionManifest.class);
+    PolarisResolvedPathWrapper root = mock(PolarisResolvedPathWrapper.class);
+    when(manifest.getResolvedRootContainerEntityAsPath()).thenReturn(root);
+
+    ResolvedIntent resolved =
+        AuthorizationIntentResolver.resolve(manifest, new TargetlessAuthorizationIntent(OP), true);
+
+    assertThat(resolved.targets()).containsExactly(root);
+    assertThat(resolved.secondaries()).isNull();
+  }
+
+  @Test
+  void resolve_targetless_noPrependRootContainer_targetsAndSecondariesNull() {
+    PolarisResolutionManifest manifest = mock(PolarisResolutionManifest.class);
+
+    ResolvedIntent resolved =
+        AuthorizationIntentResolver.resolve(manifest, new TargetlessAuthorizationIntent(OP), false);
+
+    assertThat(resolved.targets()).isNull();
+    assertThat(resolved.secondaries()).isNull();
+  }
+
+  @Test
+  void resolve_singleTarget_catalogLeaf_resolvedViaReferenceCatalog() {
+    PolarisResolutionManifest manifest = mock(PolarisResolutionManifest.class);
+    PolarisResolvedPathWrapper catalog = mock(PolarisResolvedPathWrapper.class);
+    when(manifest.getResolvedReferenceCatalogEntity(true)).thenReturn(catalog);
+
+    ResolvedIntent resolved =
+        AuthorizationIntentResolver.resolve(
+            manifest, new SingleTargetAuthorizationIntent(OP, catalogSecurable()), true);
+
+    assertThat(resolved.targets()).containsExactly(catalog);
+    assertThat(resolved.secondaries()).isNull();
+  }
+
+  @Test
+  void resolve_singleTarget_topLevelLeaf_resolvedViaTopLevelEntity() {
+    PolarisResolutionManifest manifest = mock(PolarisResolutionManifest.class);
+    PolarisResolvedPathWrapper role = mock(PolarisResolvedPathWrapper.class);
+    when(manifest.getResolvedTopLevelEntity("admin", PolarisEntityType.PRINCIPAL_ROLE))
+        .thenReturn(role);
+
+    ResolvedIntent resolved =
+        AuthorizationIntentResolver.resolve(
+            manifest,
+            new SingleTargetAuthorizationIntent(OP, principalRoleSecurable("admin")),
+            true);
+
+    assertThat(resolved.targets()).containsExactly(role);
+    assertThat(resolved.secondaries()).isNull();
+  }
+
+  @Test
+  void resolve_singleTarget_pathLeaf_resolvedViaResolvedPathWithCatalogSegmentStripped() {
+    PolarisResolutionManifest manifest = mock(PolarisResolutionManifest.class);
+    PolarisResolvedPathWrapper namespace = mock(PolarisResolvedPathWrapper.class);
+    // The CATALOG segment is stripped, so the lookup key is just ["ns"].
+    when(manifest.getResolvedPath(
+            ResolvedPathKey.of(List.of("ns"), PolarisEntityType.NAMESPACE), true))
+        .thenReturn(namespace);
+
+    ResolvedIntent resolved =
+        AuthorizationIntentResolver.resolve(
+            manifest, new SingleTargetAuthorizationIntent(OP, namespaceSecurable()), true);
+
+    assertThat(resolved.targets()).containsExactly(namespace);
+    assertThat(resolved.secondaries()).isNull();
+  }
+
+  @Test
+  void resolve_rename_resolvesFromAsTargetAndToAsSecondary() {
+    PolarisResolutionManifest manifest = mock(PolarisResolutionManifest.class);
+    PolarisResolvedPathWrapper from = mock(PolarisResolvedPathWrapper.class);
+    PolarisResolvedPathWrapper to = mock(PolarisResolvedPathWrapper.class);
+    when(manifest.getResolvedTopLevelEntity("from", PolarisEntityType.PRINCIPAL_ROLE))
+        .thenReturn(from);
+    when(manifest.getResolvedTopLevelEntity("to", PolarisEntityType.PRINCIPAL_ROLE)).thenReturn(to);
+
+    ResolvedIntent resolved =
+        AuthorizationIntentResolver.resolve(
+            manifest,
+            new RenameAuthorizationIntent(
+                OP, principalRoleSecurable("from"), principalRoleSecurable("to")),
+            true);
+
+    assertThat(resolved.targets()).containsExactly(from);
+    assertThat(resolved.secondaries()).containsExactly(to);
+  }
+
+  @Test
+  void resolve_policyAttachment_resolvesPolicyAndAttachedTo() {
+    PolarisResolutionManifest manifest = mock(PolarisResolutionManifest.class);
+    PolarisResolvedPathWrapper policy = mock(PolarisResolvedPathWrapper.class);
+    PolarisResolvedPathWrapper attachedTo = mock(PolarisResolvedPathWrapper.class);
+    when(manifest.getResolvedTopLevelEntity("policy", PolarisEntityType.PRINCIPAL_ROLE))
+        .thenReturn(policy);
+    when(manifest.getResolvedTopLevelEntity("attachedTo", PolarisEntityType.PRINCIPAL_ROLE))
+        .thenReturn(attachedTo);
+
+    ResolvedIntent resolved =
+        AuthorizationIntentResolver.resolve(
+            manifest,
+            new PolicyAttachmentAuthorizationIntent(
+                OP, principalRoleSecurable("policy"), principalRoleSecurable("attachedTo")),
+            true);
+
+    assertThat(resolved.targets()).containsExactly(policy);
+    assertThat(resolved.secondaries()).containsExactly(attachedTo);
+  }
+
+  @Test
+  void resolve_roleAssignment_resolvesRoleAndAssignee() {
+    PolarisResolutionManifest manifest = mock(PolarisResolutionManifest.class);
+    PolarisResolvedPathWrapper role = mock(PolarisResolvedPathWrapper.class);
+    PolarisResolvedPathWrapper assignee = mock(PolarisResolvedPathWrapper.class);
+    when(manifest.getResolvedTopLevelEntity("role", PolarisEntityType.PRINCIPAL_ROLE))
+        .thenReturn(role);
+    when(manifest.getResolvedTopLevelEntity("assignee", PolarisEntityType.PRINCIPAL_ROLE))
+        .thenReturn(assignee);
+
+    ResolvedIntent resolved =
+        AuthorizationIntentResolver.resolve(
+            manifest,
+            new RoleAssignmentAuthorizationIntent(
+                OP, principalRoleSecurable("role"), principalRoleSecurable("assignee")),
+            true);
+
+    assertThat(resolved.targets()).containsExactly(role);
+    assertThat(resolved.secondaries()).containsExactly(assignee);
+  }
+
+  @Test
+  void resolve_privilegeGrant_resolvesGrantTargetAndGrantee() {
+    PolarisResolutionManifest manifest = mock(PolarisResolutionManifest.class);
+    PolarisResolvedPathWrapper grantTarget = mock(PolarisResolvedPathWrapper.class);
+    PolarisResolvedPathWrapper grantee = mock(PolarisResolvedPathWrapper.class);
+    when(manifest.getResolvedReferenceCatalogEntity(true)).thenReturn(grantTarget);
+    when(manifest.getResolvedTopLevelEntity("grantee", PolarisEntityType.PRINCIPAL_ROLE))
+        .thenReturn(grantee);
+
+    ResolvedIntent resolved =
+        AuthorizationIntentResolver.resolve(
+            manifest,
+            new PrivilegeGrantAuthorizationIntent(
+                OP, catalogSecurable(), principalRoleSecurable("grantee")),
+            true);
+
+    assertThat(resolved.targets()).containsExactly(grantTarget);
+    assertThat(resolved.secondaries()).containsExactly(grantee);
+  }
+
+  @Test
+  void resolve_rootPrivilegeGrant_targetsRootContainerAndResolvesGrantee() {
+    PolarisResolutionManifest manifest = mock(PolarisResolutionManifest.class);
+    PolarisResolvedPathWrapper root = mock(PolarisResolvedPathWrapper.class);
+    PolarisResolvedPathWrapper grantee = mock(PolarisResolvedPathWrapper.class);
+    when(manifest.getResolvedRootContainerEntityAsPath()).thenReturn(root);
+    when(manifest.getResolvedTopLevelEntity("grantee", PolarisEntityType.PRINCIPAL_ROLE))
+        .thenReturn(grantee);
+
+    ResolvedIntent resolved =
+        AuthorizationIntentResolver.resolve(
+            manifest,
+            new RootPrivilegeGrantAuthorizationIntent(OP, principalRoleSecurable("grantee")),
+            true);
+
+    assertThat(resolved.targets()).containsExactly(root);
+    assertThat(resolved.secondaries()).containsExactly(grantee);
+  }
+
+  @Test
+  void resolve_unresolvableSecurable_throwsIllegalState() {
+    PolarisResolutionManifest manifest = mock(PolarisResolutionManifest.class);
+    // Manifest returns null (default) for the reference catalog lookup -> checkState should trip.
+
+    assertThatThrownBy(
+            () ->
+                AuthorizationIntentResolver.resolve(
+                    manifest, new SingleTargetAuthorizationIntent(OP, catalogSecurable()), true))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Resolved path for securable is null");
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #5194 (which routed the `CatalogHandler` / `PolarisAdminService` call sites through `authorize(AuthorizationState, AuthorizationRequest)`), as discussed on #5170.

After #5194, each `PolarisAuthorizer` implementation re-derives the securables it needs from an `AuthorizationRequest`'s intents. The mechanical mapping from an `AuthorizationIntent` to its resolved target/secondary paths was duplicated **verbatim** in two authorizers:

- `PolarisAuthorizerImpl` (built-in RBAC, `polaris-core`)
- `RangerPolarisAuthorizer` (Apache Ranger extension)

Both contained the same per-intent-type dispatch over the seven sealed `AuthorizationIntent` types plus identical private `getResolvedSecurable(...)` and `getPathNamesWithinCatalog(...)` helpers. This is correctness-sensitive and drift-prone — for example, the `CATALOG` branch in `getResolvedSecurable` had to be added to both copies. A future change to the resolution rules or a new intent type risks being applied to one authorizer and missed in the other.

This PR extracts that translation into a single `AuthorizationIntentResolver` in `org.apache.polaris.core.auth`, so both authorizers (and any future resolved-path authorizer) share one implementation.

## Changes

- **New** `AuthorizationIntentResolver` (`polaris-core`): `resolve(manifest, intent, prependRootContainer)` returns a `ResolvedIntent(targets, secondaries)`. It holds the per-intent dispatch, `getResolvedSecurable` (reference-catalog / top-level / path), and `getPathNamesWithinCatalog`.
- `PolarisAuthorizerImpl` and `RangerPolarisAuthorizer`: `authorizeIntent` now calls the shared resolver; the duplicated private helpers are removed. Each authorizer keeps its own operation-semantics / rooting decision (passing its own `prependRootContainer`), its terminal decision call (`authorizeRbacOrThrow` / `authorizeRangerOrThrow`), and its exception handling.
- Whether an operation roots its path at the root container is authorizer-specific, so that flag is passed in rather than decided by the resolver.
- `OpaPolarisAuthorizer` is unchanged — it maps intents to its own `ResourceEntity` model and does not perform resolution-manifest path resolution.

## Behavior

No behavioral change. The extracted logic is identical to what each authorizer previously ran, and the resolver executes inside the same `try` that translates a `ForbiddenException` into a decision.

## Testing

- New `AuthorizationIntentResolverTest` covering all seven intent types, the three securable-resolution branches (reference catalog / top-level / path), the rooted vs. non-rooted targetless cases, and the unresolvable-securable `IllegalStateException`.
- Existing suites pass unchanged: `PolarisAuthorizerImplTest`, the runtime-service catalog handler authz tests (`IcebergCatalogHandlerAuthzTest`, `IcebergCatalogHandlerFineGrainedDisabledTest`, `PolicyCatalogHandlerAuthzTest`, `PolarisGenericTableCatalogHandlerAuthzTest`), the Ranger unit tests + `intTest`, and the OPA tests.
- `./gradlew :polaris-core:check` passes (Spotless + Checkstyle + tests).

## Note

`polaris-core` compiles with `--release 17`, so the resolver uses an `if` / `else if` chain rather than a Java 21 pattern `switch`. A natural follow-up (noted in #5485) is to let each `AuthorizationIntent` expose its own securables, which would remove the dispatch entirely and provide compile-time exhaustiveness for future intent types.

## Checklist

- [x] 🛡️ Not a security issue
- [x] 🔗 Fixes #5485
- [x] 🧪 Added `AuthorizationIntentResolverTest`; existing authz suites pass
- [x] 💡 Added Javadoc for the new resolver
- [x] 🧾 No CHANGELOG update needed (internal refactoring)
- [x] 📚 No documentation update needed
