### PR TITLE
Build: avoid empty directories in JARs

### DIFF
--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -222,16 +222,12 @@ tasks.withType<Jar>().configureEach {
 
   if (!project.file("src/main/no-license-notice-marker").exists()) {
     if (!project.file("src/main/resources/META-INF/LICENSE").exists()) {
-      from(rootProject.rootDir) {
-        include("gradle/jar-licenses/LICENSE").eachFile { path = "META-INF/$sourceName" }
-      }
+      from(rootProject.file("gradle/jar-licenses/LICENSE")) { into("META-INF") }
     } else if (name == "javadocJar") {
       from("src/main/resources") { include("META-INF/LICENSE") }
     }
     if (!project.file("src/main/resources/META-INF/NOTICE").exists()) {
-      from(rootProject.rootDir) {
-        include("gradle/jar-licenses/NOTICE").eachFile { path = "META-INF/$sourceName" }
-      }
+      from(rootProject.file("gradle/jar-licenses/NOTICE")) { into("META-INF") }
     } else if (name == "javadocJar") {
       from("src/main/resources") { include("META-INF/NOTICE") }
     }

--- a/plugins/spark/v3.5/spark/build.gradle.kts
+++ b/plugins/spark/v3.5/spark/build.gradle.kts
@@ -269,9 +269,8 @@ tasks.named("build") { dependsOn(createPolarisSparkJar) }
 // bundle jar is intentionally left untouched here).
 listOf("jar", "sourcesJar", "javadocJar").forEach { jarTask ->
   tasks.named<Jar>(jarTask) {
-    from(layout.settingsDirectory) {
-      include("gradle/jar-licenses/LICENSE", "gradle/jar-licenses/NOTICE")
-      eachFile { path = "META-INF/$sourceName" }
+    into("META-INF") {
+      from(layout.settingsDirectory.dir("gradle/jar-licenses")) { include("LICENSE", "NOTICE") }
     }
   }
 }

--- a/plugins/spark/v4.0/spark/build.gradle.kts
+++ b/plugins/spark/v4.0/spark/build.gradle.kts
@@ -272,9 +272,8 @@ tasks.named("build") { dependsOn(createPolarisSparkJar) }
 // bundle jar is intentionally left untouched here).
 listOf("jar", "sourcesJar", "javadocJar").forEach { jarTask ->
   tasks.named<Jar>(jarTask) {
-    from(layout.settingsDirectory) {
-      include("gradle/jar-licenses/LICENSE", "gradle/jar-licenses/NOTICE")
-      eachFile { path = "META-INF/$sourceName" }
+    into("META-INF") {
+      from(layout.settingsDirectory.dir("gradle/jar-licenses")) { include("LICENSE", "NOTICE") }
     }
   }
 }


### PR DESCRIPTION
## Summary

Avoid adding empty `gradle/` and `gradle/jar-licenses/` directories to JARs when copying `LICENSE` and `NOTICE` into `META-INF`.

## Problem

The existing copy configuration starts at the repository root. Gradle retains the source directories as empty JAR entries:

```text
META-INF/LICENSE
META-INF/NOTICE
gradle/
gradle/jar-licenses/
```

## Fix

Copy the legal files directly from `gradle/jar-licenses` into `META-INF` for shared Java JARs and the Spark 3.5 and 4.0 JARs. Spark bundle JAR handling is unchanged.

## Verification

- Confirmed main, sources, and Javadoc JARs contain exactly one `META-INF/LICENSE` and `META-INF/NOTICE`.
- Confirmed `gradle/` and `gradle/jar-licenses/` are absent after the fix.
- Confirmed custom module LICENSE handling is preserved.
- Confirmed Spark bundle JARs still contain their customized legal files.
- `./gradlew spotlessCheck` passes.

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [ ] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [ ] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
