### PR TITLE
Thread ResolvedIntent through findMissingPrivileges

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/auth/PolarisAuthorizerImpl.java
@@ -133,6 +133,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.polaris.core.StructuredLogKeys;
+import org.apache.polaris.core.auth.AuthorizationIntentResolver.ResolvedIntent;
 import org.apache.polaris.core.auth.RbacOperationSemantics.ResolvedPathRooting;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.entity.PolarisBaseEntity;
@@ -775,14 +776,13 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
     RbacOperationSemantics semantics = RbacOperationSemantics.forOperation(intent.getOperation());
     boolean prependRootContainer = semantics.rooting() == ResolvedPathRooting.ROOT;
     try {
-      AuthorizationIntentResolver.ResolvedIntent resolvedIntent =
+      ResolvedIntent resolvedIntent =
           AuthorizationIntentResolver.resolve(resolutionManifest, intent, prependRootContainer);
       authorizeRbacOrThrow(
           polarisPrincipal,
           resolutionManifest.getAllActivatedCatalogRoleAndPrincipalRoles(),
           intent.getOperation(),
-          resolvedIntent.targets(),
-          resolvedIntent.secondaries());
+          resolvedIntent);
       return AuthorizationDecision.allow();
     } catch (ForbiddenException e) {
       LOGGER.debug(
@@ -817,8 +817,7 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
       @NonNull PolarisPrincipal polarisPrincipal,
       @NonNull Set<PolarisBaseEntity> activatedEntities,
       @NonNull PolarisAuthorizableOperation authzOp,
-      @Nullable List<PolarisResolvedPathWrapper> targets,
-      @Nullable List<PolarisResolvedPathWrapper> secondaries) {
+      @NonNull ResolvedIntent resolvedIntent) {
     AuthorizationPreConditions.checkCredentialRotationRequired(
         polarisPrincipal, authzOp, realmConfig);
     boolean isRoot = getRootPrincipalName().equals(polarisPrincipal.getName());
@@ -832,7 +831,7 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
           .log("Root principal allowed to reset credentials");
     } else {
       List<MissingPrivilege> missing =
-          findMissingPrivileges(polarisPrincipal, activatedEntities, authzOp, targets, secondaries);
+          findMissingPrivileges(polarisPrincipal, activatedEntities, authzOp, resolvedIntent);
       if (!missing.isEmpty()) {
         String missingDetails = formatMissingPrivileges(missing);
         LOGGER.info(
@@ -875,7 +874,8 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
       @NonNull PolarisAuthorizableOperation authzOp,
       @Nullable List<PolarisResolvedPathWrapper> targets,
       @Nullable List<PolarisResolvedPathWrapper> secondaries) {
-    return findMissingPrivileges(polarisPrincipal, activatedEntities, authzOp, targets, secondaries)
+    return findMissingPrivileges(
+            polarisPrincipal, activatedEntities, authzOp, new ResolvedIntent(targets, secondaries))
         .isEmpty();
   }
 
@@ -895,8 +895,9 @@ public class PolarisAuthorizerImpl implements PolarisAuthorizer {
       @NonNull PolarisPrincipal polarisPrincipal,
       @NonNull Set<PolarisBaseEntity> activatedEntities,
       @NonNull PolarisAuthorizableOperation authzOp,
-      @Nullable List<PolarisResolvedPathWrapper> targets,
-      @Nullable List<PolarisResolvedPathWrapper> secondaries) {
+      @NonNull ResolvedIntent resolvedIntent) {
+    List<PolarisResolvedPathWrapper> targets = resolvedIntent.targets();
+    List<PolarisResolvedPathWrapper> secondaries = resolvedIntent.secondaries();
     Set<Long> entityIdSet =
         activatedEntities.stream().map(PolarisEntityCore::getId).collect(Collectors.toSet());
     RbacOperationSemantics semantics = RbacOperationSemantics.forOperation(authzOp);

--- a/polaris-core/src/test/java/org/apache/polaris/core/auth/PolarisAuthorizerImplTest.java
+++ b/polaris-core/src/test/java/org/apache/polaris/core/auth/PolarisAuthorizerImplTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.polaris.core.auth.AuthorizationIntentResolver.ResolvedIntent;
 import org.apache.polaris.core.config.FeatureConfiguration;
 import org.apache.polaris.core.config.RealmConfig;
 import org.apache.polaris.core.entity.PolarisEntity;
@@ -111,8 +112,7 @@ public class PolarisAuthorizerImplTest {
             any(PolarisPrincipal.class),
             ArgumentMatchers.any(),
             eq(PolarisAuthorizableOperation.ADD_ROOT_GRANT_TO_PRINCIPAL_ROLE),
-            ArgumentMatchers.any(),
-            ArgumentMatchers.<List<PolarisResolvedPathWrapper>>any());
+            any(ResolvedIntent.class));
 
     AuthorizationRequest request =
         new AuthorizationRequest(
@@ -131,8 +131,7 @@ public class PolarisAuthorizerImplTest {
             eq(principal),
             eq(Set.of()),
             eq(PolarisAuthorizableOperation.ADD_ROOT_GRANT_TO_PRINCIPAL_ROLE),
-            eq(List.of(rootWrapper)),
-            eq(List.of(principalRoleWrapper)));
+            eq(new ResolvedIntent(List.of(rootWrapper), List.of(principalRoleWrapper))));
   }
 
   @Test
@@ -153,8 +152,7 @@ public class PolarisAuthorizerImplTest {
             any(PolarisPrincipal.class),
             ArgumentMatchers.any(),
             eq(PolarisAuthorizableOperation.LIST_CATALOGS),
-            ArgumentMatchers.any(),
-            ArgumentMatchers.<List<PolarisResolvedPathWrapper>>any());
+            any(ResolvedIntent.class));
 
     AuthorizationRequest request =
         new AuthorizationRequest(
@@ -169,8 +167,7 @@ public class PolarisAuthorizerImplTest {
             eq(principal),
             eq(Set.of()),
             eq(PolarisAuthorizableOperation.LIST_CATALOGS),
-            eq(List.of(rootWrapper)),
-            eq(null));
+            eq(new ResolvedIntent(List.of(rootWrapper), null)));
   }
 
   @Test
@@ -193,8 +190,7 @@ public class PolarisAuthorizerImplTest {
             any(PolarisPrincipal.class),
             ArgumentMatchers.any(),
             eq(PolarisAuthorizableOperation.LIST_NAMESPACES),
-            ArgumentMatchers.any(),
-            ArgumentMatchers.<List<PolarisResolvedPathWrapper>>any());
+            any(ResolvedIntent.class));
 
     AuthorizationRequest request =
         new AuthorizationRequest(
@@ -216,8 +212,7 @@ public class PolarisAuthorizerImplTest {
             eq(principal),
             eq(Set.of()),
             eq(PolarisAuthorizableOperation.LIST_NAMESPACES),
-            eq(List.of(namespaceWrapper)),
-            eq(null));
+            eq(new ResolvedIntent(List.of(namespaceWrapper), null)));
   }
 
   @Test
@@ -238,8 +233,7 @@ public class PolarisAuthorizerImplTest {
             any(PolarisPrincipal.class),
             ArgumentMatchers.any(),
             eq(PolarisAuthorizableOperation.GET_CATALOG),
-            ArgumentMatchers.any(),
-            ArgumentMatchers.<List<PolarisResolvedPathWrapper>>any());
+            any(ResolvedIntent.class));
 
     AuthorizationDecision decision =
         authorizer.authorize(
@@ -262,15 +256,13 @@ public class PolarisAuthorizerImplTest {
             eq(principal),
             eq(Set.of()),
             eq(PolarisAuthorizableOperation.GET_CATALOG),
-            eq(List.of(firstCatalogWrapper)),
-            eq(null));
+            eq(new ResolvedIntent(List.of(firstCatalogWrapper), null)));
     verify(authorizer, times(1))
         .findMissingPrivileges(
             eq(principal),
             eq(Set.of()),
             eq(PolarisAuthorizableOperation.GET_CATALOG),
-            eq(List.of(secondCatalogWrapper)),
-            eq(null));
+            eq(new ResolvedIntent(List.of(secondCatalogWrapper), null)));
   }
 
   @Test
@@ -291,8 +283,7 @@ public class PolarisAuthorizerImplTest {
             any(PolarisPrincipal.class),
             ArgumentMatchers.any(),
             any(PolarisAuthorizableOperation.class),
-            ArgumentMatchers.any(),
-            ArgumentMatchers.<List<PolarisResolvedPathWrapper>>any());
+            any(ResolvedIntent.class));
 
     PolarisSecurable tableTarget =
         PolarisSecurable.of(
@@ -317,15 +308,13 @@ public class PolarisAuthorizerImplTest {
             eq(principal),
             eq(Set.of()),
             eq(PolarisAuthorizableOperation.REMOVE_TABLE_PROPERTIES),
-            eq(List.of(tableWrapper)),
-            eq(null));
+            eq(new ResolvedIntent(List.of(tableWrapper), null)));
     verify(authorizer, times(1))
         .findMissingPrivileges(
             eq(principal),
             eq(Set.of()),
             eq(PolarisAuthorizableOperation.SET_TABLE_SNAPSHOT_REF),
-            eq(List.of(tableWrapper)),
-            eq(null));
+            eq(new ResolvedIntent(List.of(tableWrapper), null)));
   }
 
   @Test
@@ -511,8 +500,7 @@ public class PolarisAuthorizerImplTest {
             PolarisPrincipal.of("alice", Map.of(), Set.of("reader")),
             Set.of(),
             PolarisAuthorizableOperation.CREATE_TABLE_DIRECT,
-            List.of(namespace),
-            null);
+            new ResolvedIntent(List.of(namespace), null));
 
     assertThat(missing).isEmpty();
   }


### PR DESCRIPTION
## Summary

Follow-up to #5486, addressing @flyrain's review suggestion: thread the `ResolvedIntent` object down into `findMissingPrivileges()` instead of destructuring it into separate `targets` / `secondaries` arguments, so the resolved structure can evolve in the future without churning the intermediate signatures.

Tracked in #5491. That issue lists a second, larger follow-up (having each `AuthorizationIntent` expose its own securables to remove the resolver's per-type dispatch); this PR intentionally does **only** the `findMissingPrivileges` threading and leaves the other item for a separate PR.

## Changes

- `PolarisAuthorizerImpl.authorizeRbacOrThrow` and `findMissingPrivileges` now take a single `AuthorizationIntentResolver.ResolvedIntent` instead of separate `@Nullable List<PolarisResolvedPathWrapper> targets, secondaries`.
- `authorizeIntent` passes the `ResolvedIntent` straight through instead of destructuring it at the call site.
- `findMissingPrivileges` reads `targets` / `secondaries` from the object at the top; the rest of its logic is unchanged.
- The public `isAuthorized(...)` overloads keep their existing signatures and construct a `ResolvedIntent` internally, so there is no public API change.

## Behavior

No behavioral change. The same resolved targets/secondaries are evaluated; only the parameter shape changed. Nullability is preserved — the carrier is `@NonNull`, while its `targets` / `secondaries` remain `@Nullable` and are still guarded by the existing `Preconditions.checkState` in `findMissingPrivileges`.

## Testing

- `PolarisAuthorizerImplTest` updated to the new signature (stubs, verifies, and one direct call); the `isAuthorized` stubs are unchanged.
- `./gradlew :polaris-core:check` passes, along with the Ranger unit tests + `intTest`, the OPA tests, and the runtime-service catalog handler authz suites (`IcebergCatalogHandlerAuthzTest`, `IcebergCatalogHandlerFineGrainedDisabledTest`, `PolicyCatalogHandlerAuthzTest`, `PolarisGenericTableCatalogHandlerAuthzTest`).

## Checklist

- [x] 🛡️ Not a security issue
- [x] 🔗 Related to #5491
- [x] 🧪 Updated existing tests; no behavior change
- [x] 💡 No new Javadoc needed (internal refactoring)
- [x] 🧾 No CHANGELOG update needed
- [x] 📚 No documentation update needed
