### PR TITLE
Return 404 when semantic models disappear during deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,9 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 
+- Deleting a semantic model now returns HTTP 404 instead of HTTP 500 when the model or its
+  catalog path disappears after resolution and before the deletion is persisted.
+
 - Iceberg REST: renaming a table or view with a missing `source` or `destination` now returns `400 Bad Request` instead of `500 Internal Server Error`.
 - Python CLI `catalogs create --type external` now validates `--storage-type` and `--default-base-location` up front, matching the behavior for internal catalogs and the flags' documented "(Required)" status. Previously, omitting either produced an opaque pydantic `ValidationError` at request-build time.
 - Iceberg REST: server-side JSON processing failures (HTTP 500) now return the standard Iceberg

--- a/extensions/semantic-models/src/main/java/org/apache/polaris/service/catalog/semanticmodel/SemanticModelCatalog.java
+++ b/extensions/semantic-models/src/main/java/org/apache/polaris/service/catalog/semanticmodel/SemanticModelCatalog.java
@@ -249,10 +249,16 @@ public class SemanticModelCatalog {
             Map.of(),
             false);
     if (!result.isSuccess()) {
-      throw new IllegalStateException(
-          String.format(
-              "Failed to drop semantic model %s error status: %s with extraInfo: %s",
-              identifier, result.getReturnStatus(), result.getExtraInformation()));
+      switch (result.getReturnStatus()) {
+        case ENTITY_NOT_FOUND, CATALOG_PATH_CANNOT_BE_RESOLVED ->
+            throw new NoSuchSemanticModelException(
+                String.format("Semantic model does not exist: %s", identifier.getName()));
+        default ->
+            throw new IllegalStateException(
+                String.format(
+                    "Failed to drop semantic model %s error status: %s with extraInfo: %s",
+                    identifier, result.getReturnStatus(), result.getExtraInformation()));
+      }
     }
   }
 

--- a/extensions/semantic-models/src/test/java/org/apache/polaris/service/catalog/semanticmodel/SemanticModelCatalogTest.java
+++ b/extensions/semantic-models/src/test/java/org/apache/polaris/service/catalog/semanticmodel/SemanticModelCatalogTest.java
@@ -63,6 +63,8 @@ import org.apache.polaris.service.catalog.semanticmodel.types.SemanticModelDocum
 import org.apache.polaris.service.catalog.semanticmodel.types.SemanticModelIdentifier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.invocation.InvocationOnMock;
 
 /**
@@ -248,6 +250,18 @@ class SemanticModelCatalogTest {
 
   @Test
   void dropRejectsMissingModel() {
+    assertThatThrownBy(() -> catalog.dropSemanticModel(IDENTIFIER))
+        .isInstanceOf(NoSuchSemanticModelException.class);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = BaseResult.ReturnStatus.class,
+      names = {"ENTITY_NOT_FOUND", "CATALOG_PATH_CANNOT_BE_RESOLVED"})
+  void dropRejectsModelRemovedAfterResolution(BaseResult.ReturnStatus status) {
+    stubExistingModel(1);
+    when(metaStoreManager.dropEntityIfExists(any(), any(), any(), any(), eq(false)))
+        .thenReturn(new DropEntityResult(status, null));
     assertThatThrownBy(() -> catalog.dropSemanticModel(IDENTIFIER))
         .isInstanceOf(NoSuchSemanticModelException.class);
   }


### PR DESCRIPTION
Deleting a semantic model currently returns HTTP 500 if the model or its catalog path disappears after resolution and before the deletion is persisted. Return `NoSuchSemanticModelException` (HTTP 404) for `ENTITY_NOT_FOUND` and `CATALOG_PATH_CANNOT_BE_RESOLVED`, consistent with deleting a model that is already missing at lookup time. Other persistence failures retain their existing handling.

Related to #4522

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Related to #4522
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic: the status mapping is direct and needs no additional comments.
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed): no additional guide changes; the API specification already documents HTTP 404 for a missing model.
