### PR TITLE
Return 404 when policies disappear during deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 
+- Return HTTP 404 instead of 500 when a policy or its catalog path disappears after resolution and before deletion.
+
 - Iceberg REST: renaming a table or view with a missing `source` or `destination` now returns `400 Bad Request` instead of `500 Internal Server Error`.
 - Python CLI `catalogs create --type external` now validates `--storage-type` and `--default-base-location` up front, matching the behavior for internal catalogs and the flags' documented "(Required)" status. Previously, omitting either produced an opaque pydantic `ValidationError` at request-build time.
 - Iceberg REST: server-side JSON processing failures (HTTP 500) now return the standard Iceberg

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/policy/PolicyCatalog.java
@@ -18,6 +18,8 @@
  */
 package org.apache.polaris.service.catalog.policy;
 
+import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED;
+import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.ENTITY_NOT_FOUND;
 import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.POLICY_HAS_MAPPINGS;
 import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.POLICY_MAPPING_OF_SAME_TYPE_ALREADY_EXISTS;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.noSuchNamespaceException;
@@ -268,6 +270,11 @@ public class PolicyCatalog {
             detachAll);
 
     if (!result.isSuccess()) {
+      if (result.getReturnStatus() == ENTITY_NOT_FOUND
+          || result.getReturnStatus() == CATALOG_PATH_CANNOT_BE_RESOLVED) {
+        throw new NoSuchPolicyException(
+            String.format("Policy does not exist: %s", policyIdentifier));
+      }
       if (result.getReturnStatus() == POLICY_HAS_MAPPINGS) {
         throw new PolicyInUseException("Policy %s is still attached to entities", policyIdentifier);
       }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/policy/AbstractPolicyCatalogTest.java
@@ -63,6 +63,7 @@ import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
 import org.apache.polaris.core.persistence.PolicyMappingAlreadyExistsException;
 import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.DropEntityResult;
 import org.apache.polaris.core.persistence.dao.entity.EntityResult;
 import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
@@ -97,6 +98,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
@@ -476,6 +479,37 @@ public abstract class AbstractPolicyCatalogTest {
     policyCatalog.dropPolicy(POLICY1, false);
     assertThatThrownBy(() -> policyCatalog.loadPolicy(POLICY1))
         .isInstanceOf(NoSuchPolicyException.class);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "ENTITY_NOT_FOUND, false",
+    "ENTITY_NOT_FOUND, true",
+    "CATALOG_PATH_CANNOT_BE_RESOLVED, false",
+    "CATALOG_PATH_CANNOT_BE_RESOLVED, true"
+  })
+  public void testDropPolicyDisappearsAfterResolution(
+      BaseResult.ReturnStatus status, boolean detachAll) {
+    icebergCatalog.createNamespace(NS);
+    policyCatalog.createPolicy(
+        POLICY1, PredefinedPolicyTypes.DATA_COMPACTION.getName(), "test", "{\"enable\": false}");
+
+    // Resolve the existing policy normally, then simulate a concurrent deletion at persistence.
+    PolarisMetaStoreManager concurrentlyDeleted = Mockito.spy(metaStoreManager);
+    Mockito.doReturn(new DropEntityResult(status, "simulated"))
+        .when(concurrentlyDeleted)
+        .dropEntityIfExists(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(detachAll));
+    PolicyCatalog catalog =
+        new PolicyCatalog(
+            concurrentlyDeleted,
+            polarisContext,
+            new PolarisPassthroughResolutionView(
+                resolutionManifestFactory, authenticatedRoot, CATALOG_NAME));
+
+    assertThatThrownBy(() -> catalog.dropPolicy(POLICY1, detachAll))
+        .isInstanceOf(NoSuchPolicyException.class)
+        .hasMessage("Policy does not exist: %s", POLICY1);
   }
 
   @Test


### PR DESCRIPTION
Deleting a policy currently returns HTTP 500 if the policy or its catalog path disappears after successful resolution and before the deletion is persisted. Map `ENTITY_NOT_FOUND` and `CATALOG_PATH_CANNOT_BE_RESOLVED` to `NoSuchPolicyException` (HTTP 404), consistent with a policy missing at initial lookup and the table/view deletion behavior. Policies still attached to entities retain their existing error handling, as do other persistence failures.

Related to #5499, which addresses the equivalent semantic-model deletion race. #5288 addresses policy update conflicts, not this deletion race.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Related to #5499
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic: explains the simulated deletion window in the regression test.
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed): no guide change needed; the Policy API already documents 404 for missing policies.

AI assistance was used to prepare the implementation and tests.
