### PR TITLE
Fix retry handling in `executeSelect()`

### DIFF
--- a/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
+++ b/persistence/relational-jdbc/src/main/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperations.java
@@ -30,7 +30,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -38,6 +37,7 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -155,9 +155,9 @@ public class DatasourceOperations {
    */
   public <T> List<T> executeSelect(
       @NonNull PreparedQuery query, @NonNull Converter<T> converterInstance) throws SQLException {
-    ArrayList<T> results = new ArrayList<>();
-    executeSelectOverStream(query, converterInstance, stream -> stream.forEach(results::add));
-    return results;
+    AtomicReference<List<T>> results = new AtomicReference<>();
+    executeSelectOverStream(query, converterInstance, stream -> results.set(stream.toList()));
+    return results.get();
   }
 
   /**
@@ -227,10 +227,10 @@ public class DatasourceOperations {
       @NonNull PreparedQuery query,
       @NonNull Converter<T> converterInstance)
       throws SQLException {
-    ArrayList<T> results = new ArrayList<>();
+    AtomicReference<List<T>> results = new AtomicReference<>();
     executeSelectOverStream(
-        connection, query, converterInstance, stream -> stream.forEach(results::add));
-    return results;
+        connection, query, converterInstance, stream -> results.set(stream.toList()));
+    return results.get();
   }
 
   /**

--- a/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
+++ b/persistence/relational-jdbc/src/test/java/org/apache/polaris/persistence/relational/jdbc/DatasourceOperationsTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -40,6 +41,7 @@ import java.util.Optional;
 import javax.sql.DataSource;
 import org.apache.polaris.core.entity.EventEntity;
 import org.apache.polaris.persistence.relational.jdbc.DatasourceOperations.Operation;
+import org.apache.polaris.persistence.relational.jdbc.models.Converter;
 import org.apache.polaris.persistence.relational.jdbc.models.ImmutableModelEvent;
 import org.apache.polaris.persistence.relational.jdbc.models.ModelEntity;
 import org.apache.polaris.persistence.relational.jdbc.models.ModelEvent;
@@ -57,11 +59,15 @@ public class DatasourceOperationsTest {
 
   @Mock private PreparedStatement mockPreparedStatement;
 
+  @Mock private ResultSet mockResultSet;
+
   @Mock private RelationalJdbcConfiguration relationalJdbcConfiguration;
 
   @Mock private DatabaseMetaData mockDatabaseMetaData;
 
   @Mock Operation<String> mockOperation;
+
+  @Mock Converter<String> mockConverter;
 
   private DatasourceOperations datasourceOperations;
 
@@ -142,6 +148,47 @@ public class DatasourceOperationsTest {
 
     assertThrows(
         SQLException.class, () -> datasourceOperations.executeSelect(query, new ModelEntity(1)));
+  }
+
+  @Test
+  void testExecuteSelectRetryReplacesPartialResults() throws Exception {
+    QueryGenerator.PreparedQuery query =
+        new QueryGenerator.PreparedQuery("SELECT * FROM users", List.of());
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(2));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(1000L));
+    when(relationalJdbcConfiguration.initialDelayInMs()).thenReturn(Optional.of(0L));
+    when(mockConnection.prepareStatement(query.sql())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next())
+        .thenReturn(true, true)
+        .thenThrow(new SQLException("Retryable error", "40001"))
+        .thenReturn(true, true, false);
+    when(mockConverter.fromResultSet(mockResultSet))
+        .thenReturn("first", "second", "third", "fourth");
+
+    assertEquals(
+        List.of("third", "fourth"), datasourceOperations.executeSelect(query, mockConverter));
+  }
+
+  @Test
+  void testExecuteSelectWithConnectionRetryReplacesPartialResults() throws Exception {
+    QueryGenerator.PreparedQuery query =
+        new QueryGenerator.PreparedQuery("SELECT * FROM users", List.of());
+    when(relationalJdbcConfiguration.maxRetries()).thenReturn(Optional.of(2));
+    when(relationalJdbcConfiguration.maxDurationInMs()).thenReturn(Optional.of(1000L));
+    when(relationalJdbcConfiguration.initialDelayInMs()).thenReturn(Optional.of(0L));
+    when(mockConnection.prepareStatement(query.sql())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next())
+        .thenReturn(true, true)
+        .thenThrow(new SQLException("Retryable error", "40001"))
+        .thenReturn(true, true, false);
+    when(mockConverter.fromResultSet(mockResultSet))
+        .thenReturn("first", "second", "third", "fourth");
+
+    assertEquals(
+        List.of("third", "fourth"),
+        datasourceOperations.executeSelect(mockConnection, query, mockConverter));
   }
 
   @Test


### PR DESCRIPTION
Do not accumulate result entries across retries.
Convert each result set stream into a fresh list of results.

Fixes #5498

<!--
📝 Describe what changes you're proposing, especially breaking or user-facing changes. 
📖 See https://github.com/apache/polaris/blob/main/CONTRIBUTING.md for more.
-->

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Fixes #
- [ ] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [ ] 💡 Added comments for complex logic
- [ ] 🧾 Updated `CHANGELOG.md` (if needed)
- [ ] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed)
