### PR TITLE
Return 404 when generic tables disappear during deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ request adding CHANGELOG notes for breaking (!) changes and possibly other secti
 
 ### Fixes
 
+- Return HTTP 404 instead of 204 when a generic table or its catalog path disappears after resolution and before deletion.
+
 - Return HTTP 404 instead of 500 when a policy or its catalog path disappears after resolution and before deletion.
 
 - Iceberg REST: renaming a table or view with a missing `source` or `destination` now returns `400 Bad Request` instead of `500 Internal Server Error`.

--- a/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/PolarisGenericTableCatalog.java
+++ b/runtime/service/src/main/java/org/apache/polaris/service/catalog/generic/PolarisGenericTableCatalog.java
@@ -19,6 +19,8 @@
 package org.apache.polaris.service.catalog.generic;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.CATALOG_PATH_CANNOT_BE_RESOLVED;
+import static org.apache.polaris.core.persistence.dao.entity.BaseResult.ReturnStatus.ENTITY_NOT_FOUND;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.alreadyExistsExceptionForTableLikeEntity;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.noSuchNamespaceException;
 import static org.apache.polaris.service.catalog.common.ExceptionUtils.notFoundExceptionForTableLikeEntity;
@@ -172,6 +174,12 @@ public class PolarisGenericTableCatalog implements GenericTableCatalog {
             leafEntity,
             Map.of(),
             false);
+
+    if (dropEntityResult.getReturnStatus() == ENTITY_NOT_FOUND
+        || dropEntityResult.getReturnStatus() == CATALOG_PATH_CANNOT_BE_RESOLVED) {
+      throw notFoundExceptionForTableLikeEntity(
+          tableIdentifier, PolarisEntitySubType.GENERIC_TABLE);
+    }
 
     return dropEntityResult.isSuccess();
   }

--- a/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
+++ b/runtime/service/src/test/java/org/apache/polaris/service/catalog/generic/AbstractPolarisGenericTableCatalogTest.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.types.Types;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
@@ -53,6 +54,8 @@ import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.entity.table.GenericTableEntity;
 import org.apache.polaris.core.identity.provider.ServiceIdentityProvider;
 import org.apache.polaris.core.persistence.PolarisMetaStoreManager;
+import org.apache.polaris.core.persistence.dao.entity.BaseResult;
+import org.apache.polaris.core.persistence.dao.entity.DropEntityResult;
 import org.apache.polaris.core.persistence.resolver.ResolutionManifestFactory;
 import org.apache.polaris.core.persistence.resolver.ResolverFactory;
 import org.apache.polaris.core.secrets.UserSecretsManager;
@@ -79,6 +82,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
@@ -466,6 +470,42 @@ public abstract class AbstractPolarisGenericTableCatalogTest {
 
     Assertions.assertThat(genericTableCatalog.listGenericTables(namespace).size()).isEqualTo(10);
     Assertions.assertThat(icebergCatalog.listTables(namespace).size()).isEqualTo(10);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = BaseResult.ReturnStatus.class,
+      names = {"ENTITY_NOT_FOUND", "CATALOG_PATH_CANNOT_BE_RESOLVED"})
+  public void testDropGenericTableDisappearsAfterResolution(BaseResult.ReturnStatus status) {
+    icebergCatalog.createNamespace(NS);
+    genericTableCatalog.createGenericTable(TABLE, "format", null, "doc", Map.of());
+
+    // Resolve the existing table normally, then simulate a concurrent deletion at persistence.
+    PolarisMetaStoreManager concurrentlyDeleted = Mockito.spy(metaStoreManager);
+    Mockito.doReturn(new DropEntityResult(status, "simulated"))
+        .when(concurrentlyDeleted)
+        .dropEntityIfExists(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(false));
+    PolarisGenericTableCatalog catalog =
+        new PolarisGenericTableCatalog(
+            concurrentlyDeleted,
+            polarisContext,
+            new PolarisPassthroughResolutionView(
+                resolutionManifestFactory, authenticatedRoot, CATALOG_NAME));
+
+    Assertions.assertThatThrownBy(() -> catalog.dropGenericTable(TABLE))
+        .isInstanceOf(NoSuchTableException.class)
+        .hasMessage("Generic table does not exist: %s", TABLE);
+  }
+
+  @Test
+  public void testDropGenericTable() {
+    icebergCatalog.createNamespace(NS);
+    genericTableCatalog.createGenericTable(TABLE, "format", null, "doc", Map.of());
+
+    Assertions.assertThat(genericTableCatalog.dropGenericTable(TABLE)).isTrue();
+    Assertions.assertThatThrownBy(() -> genericTableCatalog.loadGenericTable(TABLE))
+        .isInstanceOf(NoSuchTableException.class);
   }
 
   @Test


### PR DESCRIPTION
Generic-table deletion currently returns HTTP 204 if the table or its catalog path disappears after successful resolution and before deletion is persisted: the catalog returns `false`, which the REST adapter ignores. Map `ENTITY_NOT_FOUND` and `CATALOG_PATH_CANNOT_BE_RESOLVED` to the existing generic-table not-found exception (HTTP 404), consistent with an initially missing table and Iceberg table/view deletion behavior.

Related to #5499 and #5500, which address equivalent semantic-model and policy deletion races. Other persistence statuses retain their existing behavior.

Regression tests resolve an existing generic table normally, then simulate each missing-object status at persistence. A successful-deletion test checks that normal deletion still succeeds. These tests run in the existing relational and NoSQL configurations.

## Checklist
- [x] 🛡️ Don't disclose security issues! (contact security@apache.org)
- [x] 🔗 Clearly explained why the changes are needed, or linked related issues: Related to #5499 and #5500
- [x] 🧪 Added/updated tests with good coverage, or manually tested (and explained how)
- [x] 💡 Added comments for complex logic: explains the simulated deletion window in the regression test.
- [x] 🧾 Updated `CHANGELOG.md` (if needed)
- [x] 📚 Updated documentation in `site/content/in-dev/unreleased` (if needed): no guide changes needed; the generic-table API already documents 404 for missing tables.

AI assistance was used to prepare the implementation and tests.
